### PR TITLE
feat: port over several missing ADI devices

### DIFF
--- a/packages/vexide-devices/src/adi/analog.rs
+++ b/packages/vexide-devices/src/adi/analog.rs
@@ -10,7 +10,11 @@
 
 use vex_sdk::vexDeviceAdiValueGet;
 
-use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
+use super::{AdiDevice, AdiDeviceType, AdiPort, PortError};
+
+/// The maximum 12-bit analog value returned by the internal
+/// analog-to-digital converters on the brain.
+pub const ADC_MAX_VALUE: u16 = 4095;
 
 /// Generic analog input ADI device.
 #[derive(Debug, Eq, PartialEq)]
@@ -20,7 +24,7 @@ pub struct AdiAnalogIn {
 
 impl AdiAnalogIn {
     /// Create a analog input from an ADI port.
-    pub fn new(mut port: AdiPort) -> Result<Self, AdiError> {
+    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
         port.configure(AdiDeviceType::AnalogIn)?;
 
         Ok(Self { port })
@@ -32,7 +36,7 @@ impl AdiAnalogIn {
     ///
     /// The value returned is undefined if the analog pin has been switched to a different mode.
     /// The meaning of the returned value varies depending on the sensor attached.
-    pub fn value(&self) -> Result<u16, AdiError> {
+    pub fn value(&self) -> Result<u16, PortError> {
         self.port.validate_expander()?;
 
         Ok(
@@ -52,8 +56,8 @@ impl AdiAnalogIn {
     ///
     /// The value returned is undefined if the analog pin has been switched to a different mode.
     /// The meaning of the returned value varies depending on the sensor attached.
-    pub fn voltage(&self) -> Result<f64, AdiError> {
-        Ok(self.value()? as f64 / 4095.0 * 5.0)
+    pub fn voltage(&self) -> Result<f64, PortError> {
+        Ok(self.value()? as f64 / (ADC_MAX_VALUE as f64) * 5.0)
     }
 }
 

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -2,7 +2,7 @@
 
 use vex_sdk::{vexDeviceAdiValueGet, vexDeviceAdiValueSet};
 
-use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
+use super::{AdiDevice, AdiDeviceType, AdiPort, PortError};
 
 /// Represents the logic level of a digital pin.
 ///
@@ -60,14 +60,14 @@ pub struct AdiDigitalIn {
 
 impl AdiDigitalIn {
     /// Create a digital input from an ADI port.
-    pub fn new(mut port: AdiPort) -> Result<Self, AdiError> {
+    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
         port.configure(AdiDeviceType::DigitalIn)?;
 
         Ok(Self { port })
     }
 
     /// Gets the current logic level of a digital input pin.
-    pub fn level(&self) -> Result<LogicLevel, AdiError> {
+    pub fn level(&self) -> Result<LogicLevel, PortError> {
         self.port.validate_expander()?;
 
         let value =
@@ -81,12 +81,12 @@ impl AdiDigitalIn {
     }
 
     /// Returns `true` if the digital input's logic level level is [`LogicLevel::High`].
-    pub fn is_high(&self) -> Result<bool, AdiError> {
+    pub fn is_high(&self) -> Result<bool, PortError> {
         Ok(self.level()?.is_high())
     }
 
     /// Returns `true` if the digital input's logic level level is [`LogicLevel::Low`].
-    pub fn is_low(&self) -> Result<bool, AdiError> {
+    pub fn is_low(&self) -> Result<bool, PortError> {
         Ok(self.level()?.is_high())
     }
 }
@@ -115,14 +115,14 @@ pub struct AdiDigitalOut {
 
 impl AdiDigitalOut {
     /// Create a digital output from an [`AdiPort`].
-    pub fn new(mut port: AdiPort) -> Result<Self, AdiError> {
+    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
         port.configure(AdiDeviceType::DigitalOut)?;
 
         Ok(Self { port })
     }
 
     /// Sets the digital logic level (high or low) of a pin.
-    pub fn set_level(&mut self, level: LogicLevel) -> Result<(), AdiError> {
+    pub fn set_level(&mut self, level: LogicLevel) -> Result<(), PortError> {
         unsafe {
             vexDeviceAdiValueSet(
                 self.port.device_handle(),
@@ -136,13 +136,13 @@ impl AdiDigitalOut {
 
     /// Set the digital logic level to [`LogicLevel::High`]. Analagous to
     /// [`Self::set_level(LogicLevel::High)`].
-    pub fn set_high(&mut self) -> Result<(), AdiError> {
+    pub fn set_high(&mut self) -> Result<(), PortError> {
         self.set_level(LogicLevel::High)
     }
 
     /// Set the digital logic level to [`LogicLevel::Low`]. Analagous to
     /// [`Self::set_level(LogicLevel::Low)`].
-    pub fn set_low(&mut self) -> Result<(), AdiError> {
+    pub fn set_low(&mut self) -> Result<(), PortError> {
         self.set_level(LogicLevel::Low)
     }
 }

--- a/packages/vexide-devices/src/adi/linetracker.rs
+++ b/packages/vexide-devices/src/adi/linetracker.rs
@@ -1,0 +1,79 @@
+//! ADI Line Tracker
+//!
+//! Line trackers read the difference between a black line and a white surface. They can
+//! be used to follow a marked path on the ground.
+//!
+//! # Overview
+//!
+//! A line tracker consists of an analog infrared light sensor and an infrared LED.
+//! It works by illuminating a surface with infrared light; the sensor then picks up
+//! the reflected infrared radiation and, based on its intensity, determines the
+//! reflectivity of the surface in question. White surfaces will reflect more light
+//! than dark surfaces, resulting in their appearing brighter to the sensor. This
+//! allows the sensor to detect a dark line on a white background, or a white line on
+//! a dark background.
+//!
+//! # Hardware
+//!
+//! The Line Tracking Sensor is an analog sensor, and it internally measures values in the
+//! range of 0 to 4095 from 0-5V. Darker objects reflect less light, and are indicated by
+//! higher numbers. Lighter objects reflect more light, and are indicated by lower numbers.
+//!
+//! For best results when using the Line Tracking Sensors, it is best to mount the sensors
+//! between 1/8 and 1/4 of an inch away from the surface it is measuring. It is also important
+//! to keep lighting in the room consistent, so sensors' readings remain accurate.
+
+use vex_sdk::vexDeviceAdiValueGet;
+
+use super::{analog, AdiDevice, AdiDeviceType, AdiPort, PortError};
+
+/// ADI Line Tracker
+#[derive(Debug, Eq, PartialEq)]
+pub struct AdiLineTracker {
+    port: AdiPort,
+}
+
+impl AdiLineTracker {
+    /// Create a line tracker from an ADI port.
+    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
+        port.configure(AdiDeviceType::LineTracker)?;
+
+        Ok(Self { port })
+    }
+
+    /// Get the reflectivity factor measured by the sensor.
+    ///
+    /// This is returned as a value ranging from [0.0, 1.0].
+    pub fn reflectivity(&self) -> Result<f64, PortError> {
+        Ok(self.raw_reflectivity()? as f64 / analog::ADC_MAX_VALUE as f64)
+    }
+
+    /// Get the raw reflectivity factor of the sensor.
+    ///
+    /// This is a raw 12-bit value from [0, 4095] representing the voltage level from
+    /// 0-5V measured by the V5 brain's ADC.
+    pub fn raw_reflectivity(&self) -> Result<u16, PortError> {
+        self.port.validate_expander()?;
+
+        Ok(
+            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
+                as u16,
+        )
+    }
+}
+
+impl AdiDevice for AdiLineTracker {
+    type PortIndexOutput = u8;
+
+    fn port_index(&self) -> Self::PortIndexOutput {
+        self.port.index()
+    }
+
+    fn expander_port_index(&self) -> Option<u8> {
+        self.port.expander_index()
+    }
+
+    fn device_type(&self) -> AdiDeviceType {
+        AdiDeviceType::LineTracker
+    }
+}

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -1,15 +1,19 @@
 //! ADI (Triport) devices on the Vex V5.
 
-use snafu::Snafu;
-
 use crate::PortError;
 
 pub mod analog;
 pub mod digital;
+pub mod linetracker;
+pub mod motor;
 pub mod pwm;
+pub mod solenoid;
 
 pub use analog::AdiAnalogIn;
 pub use digital::{AdiDigitalIn, AdiDigitalOut};
+pub use linetracker::AdiLineTracker;
+pub use motor::AdiMotor;
+pub use solenoid::AdiSolenoid;
 use vex_sdk::{
     vexDeviceAdiPortConfigGet, vexDeviceAdiPortConfigSet, vexDeviceGetByIndex,
     V5_AdiPortConfiguration, V5_DeviceT,
@@ -77,7 +81,7 @@ impl AdiPort {
         validate_port(self.internal_expander_index() as u8, SmartDeviceType::Adi)
     }
 
-    pub(crate) fn configure(&mut self, config: AdiDeviceType) -> Result<(), AdiError> {
+    pub(crate) fn configure(&mut self, config: AdiDeviceType) -> Result<(), PortError> {
         self.validate_expander()?;
 
         unsafe {
@@ -88,7 +92,7 @@ impl AdiPort {
     }
 
     /// Get the type of device this port is currently configured as.
-    pub fn configured_type(&self) -> Result<AdiDeviceType, AdiError> {
+    pub fn configured_type(&self) -> Result<AdiDeviceType, PortError> {
         self.validate_expander()?;
 
         Ok(
@@ -239,15 +243,4 @@ impl From<AdiDeviceType> for V5_AdiPortConfiguration {
             AdiDeviceType::Unknown(raw) => raw,
         }
     }
-}
-
-#[derive(Debug, Snafu)]
-/// Errors that can occur when working with ADI devices.
-pub enum AdiError {
-    #[snafu(display("{source}"), context(false))]
-    /// An error occurred while interacting with a port.
-    Port {
-        /// The source of the error
-        source: PortError,
-    },
 }

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -56,13 +56,13 @@ impl AdiMotor {
         self.port.validate_expander()?;
 
         Ok(
-			// TODO:
-			// Subtracting i8::MAX from this value comes from this line in the PROS kernel:
-			//
-			// https://github.com/purduesigbots/pros/blob/master/src/devices/vdml_ext_adi.c#L269
-			//
-			// Presumably this happens because the legacy motor device types return out of 256 (u8)
-			// in the getter, but have an i8 setter. This needs hardware testing, though.
+            // TODO:
+            // Subtracting i8::MAX from this value comes from this line in the PROS kernel:
+            //
+            // https://github.com/purduesigbots/pros/blob/master/src/devices/vdml_ext_adi.c#L269
+            //
+            // Presumably this happens because the legacy motor device types return out of 256 (u8)
+            // in the getter, but have an i8 setter. This needs hardware testing, though.
             (unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
                 - i8::MAX as i32) as i8,
         )

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -1,0 +1,87 @@
+//! ADI motor device.
+
+use vex_sdk::{vexDeviceAdiValueGet, vexDeviceAdiValueSet};
+
+use super::{AdiDevice, AdiDeviceType, AdiPort};
+use crate::PortError;
+
+#[derive(Debug, Eq, PartialEq)]
+/// Cortex era motor device.
+pub struct AdiMotor {
+    port: AdiPort,
+    slew: bool,
+}
+
+impl AdiMotor {
+    /// Create a new motor from an [`AdiPort`].
+    ///
+    /// Motors can be optionally configured to use slew rate control to prevent the internal
+    /// PTC from tripping on older cortex-era 393 motors.
+    pub fn new(mut port: AdiPort, slew: bool) -> Result<Self, PortError> {
+        port.configure(match slew {
+            false => AdiDeviceType::Motor,
+            true => AdiDeviceType::MotorSlew,
+        })?;
+
+        Ok(Self { port, slew })
+    }
+
+    /// Sets the PWM output of the given motor as an f64 from [-1.0, 1.0].
+    pub fn set_output(&mut self, value: f64) -> Result<(), PortError> {
+        self.set_raw_output((value * 127.0) as i8)
+    }
+
+    /// Sets the PWM output of the given motor as an i8 from [-127, 127].
+    pub fn set_raw_output(&mut self, pwm: i8) -> Result<(), PortError> {
+        self.port.validate_expander()?;
+
+        unsafe {
+            vexDeviceAdiValueSet(
+                self.port.device_handle(),
+                self.port.internal_index(),
+                pwm as i32,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns the last set PWM output of the motor on the given port as an f32 from [-1.0, 1.0].
+    pub fn output(&self) -> Result<f64, PortError> {
+        Ok(self.raw_output()? as f64 / i8::MAX as f64)
+    }
+
+    /// Returns the last set PWM output of the motor on the given port as an i8 from [-127, 127].
+    pub fn raw_output(&self) -> Result<i8, PortError> {
+        self.port.validate_expander()?;
+
+        Ok(
+            (unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
+                - i8::MAX as i32) as i8,
+        )
+    }
+
+    /// Stops the given motor.
+    pub fn stop(&mut self) -> Result<(), PortError> {
+        self.set_raw_output(0)
+    }
+}
+
+impl AdiDevice for AdiMotor {
+    type PortIndexOutput = u8;
+
+    fn port_index(&self) -> Self::PortIndexOutput {
+        self.port.index()
+    }
+
+    fn expander_port_index(&self) -> Option<u8> {
+        self.port.expander_index()
+    }
+
+    fn device_type(&self) -> AdiDeviceType {
+        match self.slew {
+            false => AdiDeviceType::Motor,
+            true => AdiDeviceType::MotorSlew,
+        }
+    }
+}

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -56,6 +56,13 @@ impl AdiMotor {
         self.port.validate_expander()?;
 
         Ok(
+			// TODO:
+			// Subtracting i8::MAX from this value comes from this line in the PROS kernel:
+			//
+			// https://github.com/purduesigbots/pros/blob/master/src/devices/vdml_ext_adi.c#L269
+			//
+			// Presumably this happens because the legacy motor device types return out of 256 (u8)
+			// in the getter, but have an i8 setter. This needs hardware testing, though.
             (unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
                 - i8::MAX as i32) as i8,
         )

--- a/packages/vexide-devices/src/adi/pwm.rs
+++ b/packages/vexide-devices/src/adi/pwm.rs
@@ -2,7 +2,7 @@
 
 use vex_sdk::vexDeviceAdiValueSet;
 
-use super::{AdiDevice, AdiDeviceType, AdiError, AdiPort};
+use super::{AdiDevice, AdiDeviceType, AdiPort, PortError};
 
 /// Generic PWM output ADI device.
 #[derive(Debug, Eq, PartialEq)]
@@ -12,7 +12,7 @@ pub struct AdiPwmOut {
 
 impl AdiPwmOut {
     /// Create a pwm output from an [`AdiPort`].
-    pub fn new(mut port: AdiPort) -> Result<Self, AdiError> {
+    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
         port.configure(AdiDeviceType::PwmOut)?;
 
         Ok(Self { port })
@@ -22,13 +22,15 @@ impl AdiPwmOut {
     ///
     /// This value is sent over 16ms periods with pulse widths ranging from roughly
     /// 0.94mS to 2.03mS.
-    pub fn set_output(&mut self, value: u8) -> Result<(), AdiError> {
+    pub fn set_output(&mut self, value: u8) -> Result<(), PortError> {
+        self.port.validate_expander()?;
+
         unsafe {
             vexDeviceAdiValueSet(
                 self.port.device_handle(),
                 self.port.internal_index(),
                 value as i32,
-            )
+            );
         }
 
         Ok(())

--- a/packages/vexide-devices/src/adi/solenoid.rs
+++ b/packages/vexide-devices/src/adi/solenoid.rs
@@ -1,0 +1,92 @@
+//! ADI Solenoid Pneumatic Control
+
+use vex_sdk::vexDeviceAdiValueSet;
+
+use super::{digital::LogicLevel, AdiDevice, AdiDeviceType, AdiPort};
+use crate::PortError;
+
+/// Digital pneumatic solenoid valve.
+#[derive(Debug, Eq, PartialEq)]
+pub struct AdiSolenoid {
+    port: AdiPort,
+    level: LogicLevel,
+}
+
+impl AdiSolenoid {
+    /// Create an AdiSolenoid.
+    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
+        port.configure(AdiDeviceType::DigitalOut)?;
+
+        Ok(Self {
+            port,
+            level: LogicLevel::Low,
+        })
+    }
+
+    /// Sets the digital logic level of the solenoid. [`LogicLevel::Low`] will close the solenoid,
+    /// and [`LogicLevel::High`] will open it.
+    pub fn set_level(&mut self, level: LogicLevel) -> Result<(), PortError> {
+        self.port.validate_expander()?;
+
+        unsafe {
+            vexDeviceAdiValueSet(
+                self.port.device_handle(),
+                self.port.internal_index(),
+                level.is_high() as i32,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Returns the current [`LogicLevel`] of the solenoid's digital output state.
+    pub const fn level(&self) -> LogicLevel {
+        self.level
+    }
+
+    /// Returns `true` if the solenoid is open.
+    pub const fn is_open(&self) -> LogicLevel {
+        self.level
+    }
+
+    /// Returns `true` if the solenoid is closed.
+    pub const fn is_closed(&self) -> LogicLevel {
+        self.level
+    }
+
+    /// Open the solenoid, allowing air pressure through the "open" valve.
+    pub fn open(&mut self) -> Result<(), PortError> {
+        self.set_level(LogicLevel::High)
+    }
+
+    /// Close the solenoid.
+    ///
+    /// - On single-acting solenoids (e.g. SY113-SMO-PM3-F), this will simply block air pressure
+    /// through the "open" valve.
+    /// - On double-acting solenoids (e.g. SYJ3120-SMO-M3-F), this will block air pressure through
+    /// the "open" valve and allow air pressure into the "close" valve.
+    pub fn close(&mut self) -> Result<(), PortError> {
+        self.set_level(LogicLevel::Low)
+    }
+
+    /// Toggle the solenoid's state between open and closed.
+    pub fn toggle(&mut self) -> Result<(), PortError> {
+        self.set_level(!self.level)
+    }
+}
+
+impl AdiDevice for AdiSolenoid {
+    type PortIndexOutput = u8;
+
+    fn port_index(&self) -> Self::PortIndexOutput {
+        self.port.index()
+    }
+
+    fn expander_port_index(&self) -> Option<u8> {
+        self.port.expander_index()
+    }
+
+    fn device_type(&self) -> AdiDeviceType {
+        AdiDeviceType::DigitalOut
+    }
+}


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Ports the following ADI device APIs from `pros-rs`:
- `AdiLineTracker`
- `AdiMotor`
- `AdiSolenoid`

## Additional Context
Also removes `AdiError` for now, opting to instead just use `PortError`, since other ADI errors aren't a thing anymore. In the future, i'll just do device-local errors for anything more specific rather than a general "ADI Error".
