### PR TITLE
feat: AdiUltrasonic (and other miscellaneous ADI fixes)

### DIFF
--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -24,7 +24,7 @@ authors = [
 async-task = { version = "4.5.0", default-features = false }
 vexide-core = { version = "0.1.0", path = "../vexide-core" }
 waker-fn = "1.1.1"
-vex-sdk = "0.10.1"
+vex-sdk = "0.11.0"
 critical-section = { version = "1.1.2", features = ["restore-state-bool"] }
 
 [lints]

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -21,7 +21,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vex-sdk = "0.10.1"
+vex-sdk = "0.11.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -22,7 +22,7 @@ authors = [
 
 [dependencies]
 vexide-core = { version = "0.1.0", path = "../vexide-core" }
-vex-sdk = "0.10.1"
+vex-sdk = "0.11.0"
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",
     "unstable-core-error",

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -16,7 +16,6 @@ pub use linetracker::AdiLineTracker;
 pub use motor::AdiMotor;
 pub use solenoid::AdiSolenoid;
 pub use ultrasonic::AdiUltrasonic;
-
 use vex_sdk::{
     vexDeviceAdiPortConfigGet, vexDeviceAdiPortConfigSet, vexDeviceGetByIndex,
     V5_AdiPortConfiguration, V5_DeviceT,
@@ -81,7 +80,10 @@ impl AdiPort {
     }
 
     pub(crate) fn validate_expander(&self) -> Result<(), PortError> {
-        validate_port(self.internal_expander_index() as u8 + 1, SmartDeviceType::Adi)
+        validate_port(
+            self.internal_expander_index() as u8 + 1,
+            SmartDeviceType::Adi,
+        )
     }
 
     pub(crate) fn configure(&mut self, config: AdiDeviceType) -> Result<(), PortError> {

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -8,12 +8,15 @@ pub mod linetracker;
 pub mod motor;
 pub mod pwm;
 pub mod solenoid;
+pub mod ultrasonic;
 
 pub use analog::AdiAnalogIn;
 pub use digital::{AdiDigitalIn, AdiDigitalOut};
 pub use linetracker::AdiLineTracker;
 pub use motor::AdiMotor;
 pub use solenoid::AdiSolenoid;
+pub use ultrasonic::AdiUltrasonic;
+
 use vex_sdk::{
     vexDeviceAdiPortConfigGet, vexDeviceAdiPortConfigSet, vexDeviceGetByIndex,
     V5_AdiPortConfiguration, V5_DeviceT,
@@ -70,7 +73,7 @@ impl AdiPort {
     }
 
     pub(crate) fn internal_expander_index(&self) -> u32 {
-        (self.expander_index.unwrap_or(Self::INTERNAL_ADI_PORT_INDEX) - 1) as u32
+        ((self.expander_index.unwrap_or(Self::INTERNAL_ADI_PORT_INDEX)) - 1) as u32
     }
 
     pub(crate) fn device_handle(&self) -> V5_DeviceT {
@@ -78,7 +81,7 @@ impl AdiPort {
     }
 
     pub(crate) fn validate_expander(&self) -> Result<(), PortError> {
-        validate_port(self.internal_expander_index() as u8, SmartDeviceType::Adi)
+        validate_port(self.internal_expander_index() as u8 + 1, SmartDeviceType::Adi)
     }
 
     pub(crate) fn configure(&mut self, config: AdiDeviceType) -> Result<(), PortError> {

--- a/packages/vexide-devices/src/adi/ultrasonic.rs
+++ b/packages/vexide-devices/src/adi/ultrasonic.rs
@@ -46,12 +46,17 @@ impl AdiUltrasonic {
     ///
     /// Round and/or fluffy objects can cause inaccurate values to be returned.
     pub fn distance(&self) -> Result<u16, UltrasonicError> {
-        Ok(unsafe {
+        self.port_ping.validate_expander()?;
+
+        match unsafe {
             vexDeviceAdiValueGet(
                 self.port_ping.device_handle(),
                 self.port_ping.internal_index(),
             )
-        } as u16)
+        } {
+            -1 => Err(UltrasonicError::NoReading),
+            val => Ok(val as u16),
+        }
     }
 }
 
@@ -74,6 +79,9 @@ impl AdiDevice for AdiUltrasonic {
 #[derive(Debug, Snafu)]
 /// Errors that can occur when interacting with an ultrasonic range finder.
 pub enum UltrasonicError {
+    /// The sensor is unable to return a valid reading.
+    NoReading,
+
     /// The index of the ping ("output") wire must be on an odd numbered port (A, C, E, G).
     BadPingPort,
 

--- a/packages/vexide-devices/src/adi/ultrasonic.rs
+++ b/packages/vexide-devices/src/adi/ultrasonic.rs
@@ -3,9 +3,8 @@
 use snafu::Snafu;
 use vex_sdk::vexDeviceAdiValueGet;
 
-use crate::PortError;
-
 use super::{AdiDevice, AdiDeviceType, AdiPort};
+use crate::PortError;
 
 /// ADI Range Finders.
 ///
@@ -32,8 +31,8 @@ impl AdiUltrasonic {
             return Err(UltrasonicError::BadPingPort);
         } else if port_echo.index() != (port_ping.index() - 1) {
             // Echo must be directly next to ping on the higher port index.
-			return Err(UltrasonicError::BadEchoPort);
-		}
+            return Err(UltrasonicError::BadEchoPort);
+        }
 
         port_ping.configure(AdiDeviceType::Ultrasonic)?;
 
@@ -47,10 +46,12 @@ impl AdiUltrasonic {
     ///
     /// Round and/or fluffy objects can cause inaccurate values to be returned.
     pub fn distance(&self) -> Result<u16, UltrasonicError> {
-        Ok(
-            unsafe { vexDeviceAdiValueGet(self.port_ping.device_handle(), self.port_ping.internal_index()) }
-                as u16,
-        )
+        Ok(unsafe {
+            vexDeviceAdiValueGet(
+                self.port_ping.device_handle(),
+                self.port_ping.internal_index(),
+            )
+        } as u16)
     }
 }
 
@@ -79,8 +80,8 @@ pub enum UltrasonicError {
     /// The echo ("input") wire must be plugged in directly above the ping wire.
     BadEchoPort,
 
-	/// The specified ping and echo ports belong to different ADI expanders.
-	ExpanderPortMismatch,
+    /// The specified ping and echo ports belong to different ADI expanders.
+    ExpanderPortMismatch,
 
     /// Generic port related error.
     #[snafu(display("{source}"), context(false))]

--- a/packages/vexide-devices/src/adi/ultrasonic.rs
+++ b/packages/vexide-devices/src/adi/ultrasonic.rs
@@ -1,0 +1,91 @@
+//! ADI ultrasonic sensor.
+
+use snafu::Snafu;
+use vex_sdk::vexDeviceAdiValueGet;
+
+use crate::PortError;
+
+use super::{AdiDevice, AdiDeviceType, AdiPort};
+
+/// ADI Range Finders.
+///
+/// Requires two ports one for pinging, and one for listening for the response.
+/// This ping port ("output") must be indexed directly below the echo ("input") port.
+#[derive(Debug, Eq, PartialEq)]
+pub struct AdiUltrasonic {
+    port_ping: AdiPort,
+    port_echo: AdiPort,
+}
+
+impl AdiUltrasonic {
+    /// Create a new ultrasonic sensor from a ping and echo [`AdiPort`].
+    pub fn new(ports: (AdiPort, AdiPort)) -> Result<Self, UltrasonicError> {
+        let mut port_ping = ports.0;
+        let port_echo = ports.1;
+
+        // Port error handling - two-wire devices are a little weird with this sort of thing.
+        if port_ping.internal_expander_index() != port_echo.internal_expander_index() {
+            // Ping and echo must be plugged into the same ADI expander.
+            return Err(UltrasonicError::ExpanderPortMismatch);
+        } else if port_ping.index() % 2 == 0 {
+            // Ping must be on an odd indexed port (A, C, E, G).
+            return Err(UltrasonicError::BadPingPort);
+        } else if port_echo.index() != (port_ping.index() - 1) {
+            // Echo must be directly next to ping on the higher port index.
+			return Err(UltrasonicError::BadEchoPort);
+		}
+
+        port_ping.configure(AdiDeviceType::Ultrasonic)?;
+
+        Ok(Self {
+            port_ping,
+            port_echo,
+        })
+    }
+
+    /// Get the distance reading of the ultrasonic sensor in centimeters.
+    ///
+    /// Round and/or fluffy objects can cause inaccurate values to be returned.
+    pub fn distance(&self) -> Result<u16, UltrasonicError> {
+        Ok(
+            unsafe { vexDeviceAdiValueGet(self.port_ping.device_handle(), self.port_ping.internal_index()) }
+                as u16,
+        )
+    }
+}
+
+impl AdiDevice for AdiUltrasonic {
+    type PortIndexOutput = (u8, u8);
+
+    fn port_index(&self) -> Self::PortIndexOutput {
+        (self.port_ping.index(), self.port_echo.index())
+    }
+
+    fn expander_port_index(&self) -> Option<u8> {
+        self.port_ping.expander_index()
+    }
+
+    fn device_type(&self) -> AdiDeviceType {
+        AdiDeviceType::Ultrasonic
+    }
+}
+
+#[derive(Debug, Snafu)]
+/// Errors that can occur when interacting with an ultrasonic range finder.
+pub enum UltrasonicError {
+    /// The index of the ping ("output") wire must be on an odd numbered port (A, C, E, G).
+    BadPingPort,
+
+    /// The echo ("input") wire must be plugged in directly above the ping wire.
+    BadEchoPort,
+
+	/// The specified ping and echo ports belong to different ADI expanders.
+	ExpanderPortMismatch,
+
+    /// Generic port related error.
+    #[snafu(display("{source}"), context(false))]
+    Port {
+        /// The source of the error.
+        source: PortError,
+    },
+}

--- a/packages/vexide-devices/src/adi/ultrasonic.rs
+++ b/packages/vexide-devices/src/adi/ultrasonic.rs
@@ -8,7 +8,7 @@ use crate::PortError;
 
 /// ADI Range Finders.
 ///
-/// Requires two ports one for pinging, and one for listening for the response.
+/// Requires two ports - one for pinging, and one for listening for the response.
 /// This ping port ("output") must be indexed directly below the echo ("input") port.
 #[derive(Debug, Eq, PartialEq)]
 pub struct AdiUltrasonic {

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -22,7 +22,7 @@ authors = [
 [dependencies]
 vexide-core = { version = "0.1.0", path = "../vexide-core" }
 vexide-devices = { version = "0.1.0", path = "../vexide-devices", optional = true }
-vex-sdk = "0.10.1"
+vex-sdk = "0.11.0"
 
 [features]
 default = ["display_panics"]

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vex-sdk = "0.10.1"
+vex-sdk = "0.11.0"
 vexide-startup-macro = { path = "../vexide-startup-macro" }
 vexide-core = { version = "0.1.0", path = "../vexide-core"}
 vexide-async = { version = "0.1.0", path = "../vexide-async" }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- Adds initial support for AdiUltrasonic sensors.
- Updates to `vex-sdk` 0.11.0.
- Fixes a critical bug in `validate_expander` resulting in port 21 being validated rather than port 22.

## Additional Context
- Tested on a V5 brain. Not sure if the units for it are right, but they're what the PROS docs claim are correct.