### PR TITLE
fix: correct user stack length

### DIFF
--- a/packages/vexide-startup/link/prelude.ld
+++ b/packages/vexide-startup/link/prelude.ld
@@ -6,6 +6,6 @@ __cold_start = 0x03800000;
 __cold_length = 0x04800000; /* 72 MiB */
 
 __heap_start = 0x04a00000;
-__heap_length = 0x02c00a60; /* 44 MiB */
+__heap_length = 0x02e00000; /* 44 MiB */
 
-__user_stack_length = 278528; /* 2.125 MiB */
+__user_stack_length = 0x204000; /* 2.114 MiB */


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This pr changes the user stack size to actually be 2 MiB instead of about and 8th of the correct size.

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
