### PR TITLE
fix: flush serial buffer on program exit

### DIFF
--- a/packages/vexide-core/src/io/mod.rs
+++ b/packages/vexide-core/src/io/mod.rs
@@ -5,6 +5,5 @@
 mod stdio;
 
 pub use no_std_io::io::*;
-pub use stdio::{dbg, print, println, stdin, stdout, Stdin, StdinLock, Stdout, StdoutLock};
-
 pub(crate) use stdio::STDIO_CHANNEL;
+pub use stdio::{dbg, print, println, stdin, stdout, Stdin, StdinLock, Stdout, StdoutLock};

--- a/packages/vexide-core/src/io/mod.rs
+++ b/packages/vexide-core/src/io/mod.rs
@@ -6,3 +6,5 @@ mod stdio;
 
 pub use no_std_io::io::*;
 pub use stdio::{dbg, print, println, stdin, stdout, Stdin, StdinLock, Stdout, StdoutLock};
+
+pub(crate) use stdio::STDIO_CHANNEL;

--- a/packages/vexide-core/src/io/stdio.rs
+++ b/packages/vexide-core/src/io/stdio.rs
@@ -3,7 +3,7 @@ use vex_sdk::{vexSerialReadChar, vexSerialWriteBuffer};
 
 use crate::sync::{Mutex, MutexGuard};
 
-const STDIO_CHANNEL: u32 = 1;
+pub(crate) const STDIO_CHANNEL: u32 = 1;
 
 static STDOUT: Mutex<StdoutRaw> = Mutex::new(StdoutRaw);
 static STDIN: Mutex<StdinRaw> = Mutex::new(StdinRaw);

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -20,3 +20,23 @@ pub mod critical_section;
 pub mod io;
 pub mod sync;
 pub mod time;
+
+/// Exits the program using vexSystemExitRequest.
+/// This function will not instantly exit the program,
+/// but will instead wait 3ms to force the serial buffer to flush.
+pub fn exit() -> ! {
+    unsafe {
+        // Force the serial buffer to flush
+        let exit_time = time::Instant::now();
+        while exit_time.elapsed().as_millis() < 3 {
+            vex_sdk::vexTasksRun();
+        }
+        // Exit the program
+        // Everything after this point is unreachable.
+        vex_sdk::vexSystemExitRequest();
+    }
+    // unreachable.
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -18,6 +18,6 @@ pub mod competition;
 #[cfg(feature = "critical-section")]
 pub mod critical_section;
 pub mod io;
+pub mod program;
 pub mod sync;
 pub mod time;
-pub mod program;

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -20,23 +20,4 @@ pub mod critical_section;
 pub mod io;
 pub mod sync;
 pub mod time;
-
-/// Exits the program using vexSystemExitRequest.
-/// This function will not instantly exit the program,
-/// but will instead wait 3ms to force the serial buffer to flush.
-pub fn exit() -> ! {
-    unsafe {
-        // Force the serial buffer to flush
-        let exit_time = time::Instant::now();
-        while exit_time.elapsed().as_millis() < 3 {
-            vex_sdk::vexTasksRun();
-        }
-        // Exit the program
-        // Everything after this point is unreachable.
-        vex_sdk::vexSystemExitRequest();
-    }
-    // unreachable.
-    loop {
-        core::hint::spin_loop();
-    }
-}
+pub mod program;

--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -5,10 +5,9 @@
 
 use core::time::Duration;
 
-pub use vex_sdk::{vexSystemExitRequest, vexTasksRun, vexSerialWriteFree};
+pub use vex_sdk::{vexSerialWriteFree, vexSystemExitRequest, vexTasksRun};
 
-pub use crate::time::Instant;
-pub use crate::io;
+pub use crate::{io, time::Instant};
 
 /// Exits the program using vexSystemExitRequest.
 /// This function will not instantly exit the program,

--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -3,6 +3,8 @@
 //! This module contains functions for accessing/modifying the state of the current
 //! user program.
 
+use core::time::Duration;
+
 pub use vex_sdk::{vexSystemExitRequest, vexTasksRun, vexSerialWriteFree};
 
 pub use crate::time::Instant;
@@ -12,9 +14,15 @@ pub use crate::io;
 /// This function will not instantly exit the program,
 /// but will instead wait 3ms to force the serial buffer to flush.
 pub fn exit() -> ! {
+    let exit_time = Instant::now();
+    const FLUSH_TIMEOUT: Duration = Duration::from_millis(15);
     unsafe {
         // Force the serial buffer to flush
-        while vexSerialWriteFree(io::STDIO_CHANNEL) != (io::Stdout::INTERNAL_BUFFER_SIZE as i32) {
+        while exit_time.elapsed() < FLUSH_TIMEOUT {
+            // If the buffer has been fully flushed, exit the loop
+            if vexSerialWriteFree(io::STDIO_CHANNEL) == (io::Stdout::INTERNAL_BUFFER_SIZE as i32) {
+                break;
+            }
             vexTasksRun();
         }
         // Exit the program

--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -1,3 +1,8 @@
+//! User Program Module
+//!
+//! This module contains functions for accessing/modifying the state of the current
+//! user program.
+
 pub use vex_sdk::{vexSystemExitRequest, vexTasksRun, vexSerialWriteFree};
 
 pub use crate::time::Instant;

--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -1,0 +1,24 @@
+pub use vex_sdk::{vexSystemExitRequest, vexTasksRun, vexSerialWriteFree};
+
+pub use crate::time::Instant;
+pub use crate::io;
+
+/// Exits the program using vexSystemExitRequest.
+/// This function will not instantly exit the program,
+/// but will instead wait 3ms to force the serial buffer to flush.
+pub fn exit() -> ! {
+    unsafe {
+        // Force the serial buffer to flush
+        while vexSerialWriteFree(io::STDIO_CHANNEL) != (io::Stdout::INTERNAL_BUFFER_SIZE as i32) {
+            vexTasksRun();
+        }
+        // Exit the program
+        // Everything after this point is unreachable.
+        vexSystemExitRequest();
+    }
+
+    // unreachable.
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -97,8 +97,9 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
         sim_log_backtrace();
 
         #[cfg(not(feature = "display_panics"))]
-        vex_sdk::vexSystemExitRequest();
+        vexide_core::exit();
         // unreachable without display_panics
+        #[cfg_attr(not(feature = "display_panics"), allow(unreachable_code))]
         loop {
             // Flush the serial buffer so that the panic message is printed
             vex_sdk::vexTasksRun();

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -97,7 +97,7 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
         sim_log_backtrace();
 
         #[cfg(not(feature = "display_panics"))]
-        vexide_core::exit();
+        vexide_core::program::exit();
         // unreachable without display_panics
         #[cfg_attr(not(feature = "display_panics"), allow(unreachable_code))]
         loop {

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -115,10 +115,20 @@ Running user code...
         // Call the user code
         main();
         // Exit the program
+        exit();
+    }
+}
+
+/// Exits the program cleanly.
+pub fn exit() -> ! {
+    unsafe {
+        // Flush the serial buffer and other final processing.
+        vex_sdk::vexTasksRun();
+        // Exit the program
+        // Everything after this point is unreachable.
         vex_sdk::vexSystemExitRequest();
     }
-
-    // Technically unreachable, but the compiler doesn't know that
+    // Technically unreachable.
     loop {
         hint::spin_loop();
     }

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -13,7 +13,7 @@
 #![feature(asm_experimental_arch)]
 #![allow(clippy::needless_doctest_main)]
 
-use core::{arch::asm, hint, ptr::addr_of_mut};
+use core::{arch::asm, ptr::addr_of_mut};
 
 use vexide_core::print;
 pub use vexide_startup_macro::main;

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -115,26 +115,6 @@ Running user code...
         // Call the user code
         main();
         // Exit the program
-        exit();
-    }
-}
-
-/// Exits the program using vexSystemExitRequest.
-/// This function will not instantly exit the program,
-/// but will instead wait 3ms to force the serial buffer to flush.
-pub fn exit() -> ! {
-    unsafe {
-        // Force the serial buffer to flush
-        let exit_time = vexide_core::time::Instant::now();
-        while exit_time.elapsed().as_millis() < 3 {
-            vex_sdk::vexTasksRun();
-        }
-        // Exit the program
-        // Everything after this point is unreachable.
-        vex_sdk::vexSystemExitRequest();
-    }
-    // unreachable.
-    loop {
-        hint::spin_loop();
+        vexide_core::exit();
     }
 }

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -115,6 +115,6 @@ Running user code...
         // Call the user code
         main();
         // Exit the program
-        vexide_core::exit();
+        vexide_core::program::exit();
     }
 }

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -119,16 +119,21 @@ Running user code...
     }
 }
 
-/// Exits the program cleanly.
+/// Exits the program using vexSystemExitRequest.
+/// This function will not instantly exit the program,
+/// but will instead wait 3ms to force the serial buffer to flush.
 pub fn exit() -> ! {
     unsafe {
-        // Flush the serial buffer and other final processing.
-        vex_sdk::vexTasksRun();
+        // Force the serial buffer to flush
+        let exit_time = vexide_core::time::Instant::now();
+        while exit_time.elapsed().as_millis() < 3 {
+            vex_sdk::vexTasksRun();
+        }
         // Exit the program
         // Everything after this point is unreachable.
         vex_sdk::vexSystemExitRequest();
     }
-    // Technically unreachable.
+    // unreachable.
     loop {
         hint::spin_loop();
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR adds a exit function to vexide-startup which blocks for 3ms to flush the serial buffer and then exits the program with `vexSystemExitRequest`.

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
