### PR TITLE
refactor: device error handling

### DIFF
--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -24,7 +24,7 @@ authors = [
 async-task = { version = "4.5.0", default-features = false }
 vexide-core = { version = "0.1.0", path = "../vexide-core" }
 waker-fn = "1.1.1"
-vex-sdk = "0.11.0"
+vex-sdk = "0.12.0"
 critical-section = { version = "1.1.2", features = ["restore-state-bool"] }
 
 [lints]

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -21,7 +21,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vex-sdk = "0.11.0"
+vex-sdk = "0.12.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -22,7 +22,7 @@ authors = [
 
 [dependencies]
 vexide-core = { version = "0.1.0", path = "../vexide-core" }
-vex-sdk = "0.11.0"
+vex-sdk = "0.12.0"
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",
     "unstable-core-error",

--- a/packages/vexide-devices/src/adi/accelerometer.rs
+++ b/packages/vexide-devices/src/adi/accelerometer.rs
@@ -14,14 +14,15 @@ pub struct AdiAccelerometer {
 
 impl AdiAccelerometer {
     /// Create a new accelerometer from an [`AdiPort`].
-    pub fn new(mut port: AdiPort, sensitivity: Sensitivity) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::Accelerometer)?;
+    pub fn new(port: AdiPort, sensitivity: Sensitivity) -> Self {
+        port.configure(AdiDeviceType::Accelerometer);
 
-        Ok(Self { port, sensitivity })
+        Self { port, sensitivity }
     }
 
     /// Get the type of ADI accelerometer device.
     pub fn sensitivity(&self) -> Result<Sensitivity, PortError> {
+        // Configuration check not required here since we don't access the SDK.
         self.port.validate_expander()?;
 
         Ok(self.sensitivity)
@@ -50,6 +51,7 @@ impl AdiAccelerometer {
     /// would instead represent a 2g reading ([`Sensitivity::LOW_MAX_ACCELERATION`]).
     pub fn raw_acceleration(&self) -> Result<u16, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         Ok(
             unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
@@ -60,7 +62,6 @@ impl AdiAccelerometer {
 
 /// The jumper state of the accelerometer.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-#[repr(i32)]
 pub enum Sensitivity {
     /// 0-2g sensitivity
     Low,

--- a/packages/vexide-devices/src/adi/analog.rs
+++ b/packages/vexide-devices/src/adi/analog.rs
@@ -24,10 +24,13 @@ pub struct AdiAnalogIn {
 
 impl AdiAnalogIn {
     /// Create a analog input from an ADI port.
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::AnalogIn)?;
+    pub fn new(port: AdiPort) -> Self {
+        // NOTE: Don't care about whether or not the expander is available at this point, since
+        // constructors need to be infalliable. We'll ensure that we're the right configuration
+        // before calling any other methods.
+        port.configure(AdiDeviceType::AnalogIn);
 
-        Ok(Self { port })
+        Self { port }
     }
 
     /// Reads an analog input channel and returns the 12-bit value.
@@ -38,6 +41,7 @@ impl AdiAnalogIn {
     /// The meaning of the returned value varies depending on the sensor attached.
     pub fn value(&self) -> Result<u16, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         Ok(
             unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -60,15 +60,16 @@ pub struct AdiDigitalIn {
 
 impl AdiDigitalIn {
     /// Create a digital input from an ADI port.
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::DigitalIn)?;
+    pub fn new(port: AdiPort) -> Self {
+        port.configure(AdiDeviceType::DigitalIn);
 
-        Ok(Self { port })
+        Self { port }
     }
 
     /// Gets the current logic level of a digital input pin.
     pub fn level(&self) -> Result<LogicLevel, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         let value =
             unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
@@ -115,14 +116,17 @@ pub struct AdiDigitalOut {
 
 impl AdiDigitalOut {
     /// Create a digital output from an [`AdiPort`].
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::DigitalOut)?;
+    pub fn new(port: AdiPort) -> Self {
+        port.configure(AdiDeviceType::DigitalOut);
 
-        Ok(Self { port })
+        Self { port }
     }
 
     /// Sets the digital logic level (high or low) of a pin.
     pub fn set_level(&mut self, level: LogicLevel) -> Result<(), PortError> {
+        self.port.validate_expander()?;
+        self.port.configure(self.device_type());
+
         unsafe {
             vexDeviceAdiValueSet(
                 self.port.device_handle(),

--- a/packages/vexide-devices/src/adi/light_sensor.rs
+++ b/packages/vexide-devices/src/adi/light_sensor.rs
@@ -16,10 +16,10 @@ pub struct AdiLightSensor {
 
 impl AdiLightSensor {
     /// Create a light sensor from an ADI port.
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::LightSensor)?;
+    pub fn new(port: AdiPort) -> Self {
+        port.configure(AdiDeviceType::LightSensor);
 
-        Ok(Self { port })
+        Self { port }
     }
 
     /// Get the brightness factor measured by the sensor. Higher numbers mean
@@ -38,6 +38,7 @@ impl AdiLightSensor {
     /// A low number (less voltage) represents a **brighter** light source.
     pub fn raw_brightness(&self) -> Result<u16, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         Ok(
             unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }

--- a/packages/vexide-devices/src/adi/line_tracker.rs
+++ b/packages/vexide-devices/src/adi/line_tracker.rs
@@ -35,10 +35,10 @@ pub struct AdiLineTracker {
 
 impl AdiLineTracker {
     /// Create a line tracker from an ADI port.
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::LineTracker)?;
+    pub fn new(port: AdiPort) -> Self {
+        port.configure(AdiDeviceType::LineTracker);
 
-        Ok(Self { port })
+        Self { port }
     }
 
     /// Get the reflectivity factor measured by the sensor. Higher numbers mean
@@ -60,6 +60,7 @@ impl AdiLineTracker {
     /// A low number (less voltage) represents a **more** reflective object.
     pub fn raw_reflectivity(&self) -> Result<u16, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         Ok(
             unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -117,6 +117,20 @@ impl<T: AdiDevice<PortIndexOutput = u8>> From<T> for AdiPort {
     }
 }
 
+impl From<AdiUltrasonic> for (AdiPort, AdiPort) {
+    fn from(device: AdiUltrasonic) -> Self {
+        let indexes = device.port_index();
+        let expander_index = device.expander_port_index();
+
+        unsafe {
+            (
+                AdiPort::new(indexes.0, expander_index),
+                AdiPort::new(indexes.1, expander_index),
+            )
+        }
+    }
+}
+
 /// Common functionality for a ADI (three-wire) devices.
 pub trait AdiDevice {
     /// The type that port_index should return. This is usually `u8`, but occasionally `(u8, u8)`.

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -109,6 +109,16 @@ impl AdiPort {
     }
 }
 
+impl<T: AdiDevice<PortIndexOutput = u8>> From<T> for AdiPort {
+    fn from(device: T) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smartport was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe {
+            Self::new(device.port_index(), device.expander_port_index())
+        }
+    }
+}
+
 /// Common functionality for a ADI (three-wire) devices.
 pub trait AdiDevice {
     /// The type that port_index should return. This is usually `u8`, but occasionally `(u8, u8)`.

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -91,14 +91,11 @@ impl AdiPort {
         )
     }
 
-    pub(crate) fn configure(&mut self, config: AdiDeviceType) -> Result<(), PortError> {
-        self.validate_expander()?;
-
+    /// Configures the ADI port to a specific type if it wasn't already configured.
+    pub(crate) fn configure(&self, config: AdiDeviceType) {
         unsafe {
             vexDeviceAdiPortConfigSet(self.device_handle(), self.internal_index(), config.into());
         }
-
-        Ok(())
     }
 
     /// Get the type of device this port is currently configured as.

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -113,9 +113,7 @@ impl<T: AdiDevice<PortIndexOutput = u8>> From<T> for AdiPort {
     fn from(device: T) -> Self {
         // SAFETY: We can do this, since we ensure that the old smartport was disposed of.
         // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe {
-            Self::new(device.port_index(), device.expander_port_index())
-        }
+        unsafe { Self::new(device.port_index(), device.expander_port_index()) }
     }
 }
 

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -17,13 +17,13 @@ impl AdiMotor {
     ///
     /// Motors can be optionally configured to use slew rate control to prevent the internal
     /// PTC from tripping on older cortex-era 393 motors.
-    pub fn new(mut port: AdiPort, slew: bool) -> Result<Self, PortError> {
+    pub fn new(port: AdiPort, slew: bool) -> Self {
         port.configure(match slew {
             false => AdiDeviceType::Motor,
             true => AdiDeviceType::MotorSlew,
-        })?;
+        });
 
-        Ok(Self { port, slew })
+        Self { port, slew }
     }
 
     /// Sets the PWM output of the given motor as an f64 from [-1.0, 1.0].
@@ -34,6 +34,7 @@ impl AdiMotor {
     /// Sets the PWM output of the given motor as an i8 from [-127, 127].
     pub fn set_raw_output(&mut self, pwm: i8) -> Result<(), PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         unsafe {
             vexDeviceAdiValueSet(
@@ -54,6 +55,7 @@ impl AdiMotor {
     /// Returns the last set PWM output of the motor on the given port as an i8 from [-127, 127].
     pub fn raw_output(&self) -> Result<i8, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         Ok(
             // TODO:

--- a/packages/vexide-devices/src/adi/potentiometer.rs
+++ b/packages/vexide-devices/src/adi/potentiometer.rs
@@ -14,23 +14,21 @@ pub struct AdiPotentiometer {
 
 impl AdiPotentiometer {
     /// Create a new potentiometer from an [`AdiPort`].
-    pub fn new(
-        mut port: AdiPort,
-        potentiometer_type: PotentiometerType,
-    ) -> Result<Self, PortError> {
+    pub fn new(port: AdiPort, potentiometer_type: PotentiometerType) -> Self {
         port.configure(match potentiometer_type {
             PotentiometerType::Legacy => AdiDeviceType::Potentiometer,
             PotentiometerType::V2 => AdiDeviceType::PotentimeterV2,
-        })?;
+        });
 
-        Ok(Self {
+        Self {
             port,
             potentiometer_type,
-        })
+        }
     }
 
     /// Get the type of ADI potentiometer device.
     pub fn potentiometer_type(&self) -> Result<PotentiometerType, PortError> {
+        // Configuration check not necessary since we don't fetch from the SDK.
         self.port.validate_expander()?;
 
         Ok(self.potentiometer_type)
@@ -49,6 +47,7 @@ impl AdiPotentiometer {
     /// thus returning an angle between 0-330 degrees.
     pub fn angle(&self) -> Result<f64, PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         Ok(
             unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }

--- a/packages/vexide-devices/src/adi/pwm.rs
+++ b/packages/vexide-devices/src/adi/pwm.rs
@@ -12,10 +12,10 @@ pub struct AdiPwmOut {
 
 impl AdiPwmOut {
     /// Create a pwm output from an [`AdiPort`].
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::PwmOut)?;
+    pub fn new(port: AdiPort) -> Self {
+        port.configure(AdiDeviceType::PwmOut);
 
-        Ok(Self { port })
+        Self { port }
     }
 
     /// Sets the PWM output width.
@@ -24,6 +24,7 @@ impl AdiPwmOut {
     /// 0.94mS to 2.03mS.
     pub fn set_output(&mut self, value: u8) -> Result<(), PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         unsafe {
             vexDeviceAdiValueSet(

--- a/packages/vexide-devices/src/adi/solenoid.rs
+++ b/packages/vexide-devices/src/adi/solenoid.rs
@@ -14,19 +14,20 @@ pub struct AdiSolenoid {
 
 impl AdiSolenoid {
     /// Create an AdiSolenoid.
-    pub fn new(mut port: AdiPort) -> Result<Self, PortError> {
-        port.configure(AdiDeviceType::DigitalOut)?;
+    pub fn new(port: AdiPort) -> Self {
+        port.configure(AdiDeviceType::DigitalOut);
 
-        Ok(Self {
+        Self {
             port,
             level: LogicLevel::Low,
-        })
+        }
     }
 
     /// Sets the digital logic level of the solenoid. [`LogicLevel::Low`] will close the solenoid,
     /// and [`LogicLevel::High`] will open it.
     pub fn set_level(&mut self, level: LogicLevel) -> Result<(), PortError> {
         self.port.validate_expander()?;
+        self.port.configure(self.device_type());
 
         unsafe {
             vexDeviceAdiValueSet(

--- a/packages/vexide-devices/src/adi/ultrasonic.rs
+++ b/packages/vexide-devices/src/adi/ultrasonic.rs
@@ -19,7 +19,7 @@ pub struct AdiUltrasonic {
 impl AdiUltrasonic {
     /// Create a new ultrasonic sensor from a ping and echo [`AdiPort`].
     pub fn new(ports: (AdiPort, AdiPort)) -> Result<Self, UltrasonicError> {
-        let mut port_ping = ports.0;
+        let port_ping = ports.0;
         let port_echo = ports.1;
 
         // Port error handling - two-wire devices are a little weird with this sort of thing.
@@ -34,7 +34,7 @@ impl AdiUltrasonic {
             return Err(UltrasonicError::BadEchoPort);
         }
 
-        port_ping.configure(AdiDeviceType::Ultrasonic)?;
+        port_ping.configure(AdiDeviceType::Ultrasonic);
 
         Ok(Self {
             port_ping,

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -28,14 +28,6 @@ impl DistanceSensor {
         }
     }
 
-    /// Creates a new distance sensor on a smart port, returning a [`PortError`] if the device is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Distance)?;
-
-        Ok(Self::new(port))
-    }
-
     /// Validates that the sensor is currently connected to its port, and that its status code
     /// is either 0x82 or 0x86.
     ///

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -5,10 +5,10 @@
 use snafu::Snafu;
 use vex_sdk::{
     vexDeviceDistanceConfidenceGet, vexDeviceDistanceDistanceGet, vexDeviceDistanceObjectSizeGet,
-    vexDeviceDistanceObjectVelocityGet, vexDeviceDistanceStatusGet,
+    vexDeviceDistanceObjectVelocityGet, vexDeviceDistanceStatusGet, V5_DeviceT,
 };
 
-use super::{SmartDevice, SmartDeviceInternal, SmartDeviceType, SmartPort};
+use super::{SmartDevice, SmartDeviceType, SmartPort};
 use crate::PortError;
 
 /// A physical distance sensor plugged into a port.
@@ -16,12 +16,24 @@ use crate::PortError;
 #[derive(Debug, Eq, PartialEq)]
 pub struct DistanceSensor {
     port: SmartPort,
+    device: V5_DeviceT,
 }
 
 impl DistanceSensor {
     /// Create a new distance sensor from a smart port index.
-    pub const fn new(port: SmartPort) -> Self {
-        Self { port }
+    pub fn new(port: SmartPort) -> Self {
+        Self {
+            device: unsafe { port.device_handle() },
+            port,
+        }
+    }
+
+    /// Creates a new distance sensor on a smart port, returning a [`PortError`] if the device is disconnected,
+    /// an incorrect device, or otherwise unavailable.
+    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
+        port.validate_type(SmartDeviceType::Distance)?;
+
+        Ok(Self::new(port))
     }
 
     /// Validates that the sensor is currently connected to its port, and that its status code
@@ -42,14 +54,14 @@ impl DistanceSensor {
     pub fn distance(&self) -> Result<u32, DistanceError> {
         self.validate()?;
 
-        Ok(unsafe { vexDeviceDistanceDistanceGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceDistanceDistanceGet(self.device) })
     }
 
     /// Returns the velocity of the object the sensor detects in m/s
     pub fn velocity(&self) -> Result<f64, DistanceError> {
         self.validate()?;
 
-        Ok(unsafe { vexDeviceDistanceObjectVelocityGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceDistanceObjectVelocityGet(self.device) })
     }
 
     /// Get the current guess at relative "object size".
@@ -66,21 +78,21 @@ impl DistanceSensor {
     pub fn relative_size(&self) -> Result<u32, DistanceError> {
         self.validate()?;
 
-        Ok(unsafe { vexDeviceDistanceObjectSizeGet(self.device_handle()) as u32 })
+        Ok(unsafe { vexDeviceDistanceObjectSizeGet(self.device) as u32 })
     }
 
     /// Returns the confidence in the distance measurement from 0.0 to 1.0.
     pub fn distance_confidence(&self) -> Result<f64, DistanceError> {
         self.validate()?;
 
-        Ok(unsafe { vexDeviceDistanceConfidenceGet(self.device_handle()) as u32 } as f64 / 63.0)
+        Ok(unsafe { vexDeviceDistanceConfidenceGet(self.device) as u32 } as f64 / 63.0)
     }
 
     /// Gets the status code of the distance sensor
     pub fn status(&self) -> Result<u32, DistanceError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceDistanceStatusGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceDistanceStatusGet(self.device) })
     }
 }
 

--- a/packages/vexide-devices/src/smart/expander.rs
+++ b/packages/vexide-devices/src/smart/expander.rs
@@ -5,7 +5,7 @@
 //! This is because they require a [`SmartPort`] to be created which can only be created without either peripherals struct unsafely.
 
 use super::{SmartDevice, SmartDeviceType, SmartPort};
-use crate::adi::AdiPort;
+use crate::{adi::AdiPort, PortError};
 
 /// Represents an ADI expander module plugged into a smart port.
 ///
@@ -52,6 +52,14 @@ impl AdiExpander {
                 port,
             }
         }
+    }
+
+    /// Creates a new expander on a smart port, returning a [`PortError`] if the device is disconnected,
+    /// an incorrect device, or otherwise unavailable.
+    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
+        port.validate_type(SmartDeviceType::Adi)?;
+
+        Ok(Self::new(port))
     }
 }
 

--- a/packages/vexide-devices/src/smart/expander.rs
+++ b/packages/vexide-devices/src/smart/expander.rs
@@ -5,7 +5,7 @@
 //! This is because they require a [`SmartPort`] to be created which can only be created without either peripherals struct unsafely.
 
 use super::{SmartDevice, SmartDeviceType, SmartPort};
-use crate::{adi::AdiPort, PortError};
+use crate::adi::AdiPort;
 
 /// Represents an ADI expander module plugged into a smart port.
 ///

--- a/packages/vexide-devices/src/smart/expander.rs
+++ b/packages/vexide-devices/src/smart/expander.rs
@@ -53,14 +53,6 @@ impl AdiExpander {
             }
         }
     }
-
-    /// Creates a new expander on a smart port, returning a [`PortError`] if the device is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Adi)?;
-
-        Ok(Self::new(port))
-    }
 }
 
 impl SmartDevice for AdiExpander {

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -52,14 +52,6 @@ impl InertialSensor {
         }
     }
 
-    /// Creates a new imu on a smart port, returning a [`PortError`] if the device is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Imu)?;
-
-        Ok(Self::new(port))
-    }
-
     /// Validates that the sensor is currently connected to its port, and that it isn't currently
     /// calibrating.
     fn validate(&self) -> Result<(), InertialError> {

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -106,6 +106,16 @@ pub trait SmartDevice {
     }
 }
 
+impl<T: SmartDevice> From<T> for SmartPort {
+    fn from(device: T) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smartport was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe {
+            Self::new(device.port_index())
+        }
+    }
+}
+
 /// Verify that the device type is currently plugged into this port.
 ///
 /// This function provides the internal implementations of [`SmartDevice::validate_port`], [`SmartPort::validate_type`],

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -98,23 +98,18 @@ pub trait SmartDevice {
             vexDeviceGetTimestamp(vexDeviceGetByIndex((self.port_index() - 1) as u32))
         }))
     }
-}
 
-/// Internal helper functions for port validation, error handling, and interaction with
-/// vex-sys on various smart devices.
-pub(crate) trait SmartDeviceInternal: SmartDevice {
-    /// Get the raw device handle connected to this port.
-    fn device_handle(&self) -> V5_DeviceT {
-        unsafe { vexDeviceGetByIndex((self.port_index() - 1) as u32) }
-    }
-
-    /// Verify that the device type is currently plugged into this port.
+    /// Verify that the device type is currently plugged into this port, returning an appropriate
+    /// [`PortError`] if not available.
     fn validate_port(&self) -> Result<(), PortError> {
         validate_port(self.port_index(), self.device_type())
     }
 }
 
 /// Verify that the device type is currently plugged into this port.
+///
+/// This function provides the internal implementations of [`SmartDevice::validate_port`], [`SmartPort::validate_type`],
+/// and [`AdiPort::validate_expander`].
 pub(crate) fn validate_port(index: u8, device_type: SmartDeviceType) -> Result<(), PortError> {
     let device = unsafe { *vexDeviceGetByIndex((index - 1) as u32) };
     let plugged_type: SmartDeviceType = device.device_type.into();
@@ -129,8 +124,6 @@ pub(crate) fn validate_port(index: u8, device_type: SmartDeviceType) -> Result<(
 
     Ok(())
 }
-
-impl<T: SmartDevice> SmartDeviceInternal for T {}
 
 /// Represents a smart port on a V5 Brain
 #[derive(Debug, Eq, PartialEq)]
@@ -191,6 +184,17 @@ impl SmartPort {
         Ok(unsafe { *vexDeviceGetByIndex((self.index() - 1) as u32) }
             .device_type
             .into())
+    }
+
+    /// Verify that a device type is currently plugged into this port, returning an appropriate
+    /// [`PortError`] if not available.
+    pub fn validate_type(&self, device_type: SmartDeviceType) -> Result<(), PortError> {
+        validate_port(self.index(), device_type)
+    }
+
+    /// Get the raw handle of the underlying smart device connected to this port.
+    pub(crate) unsafe fn device_handle(&self) -> V5_DeviceT {
+        unsafe { vexDeviceGetByIndex((self.index() - 1) as u32) }
     }
 }
 

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -110,9 +110,7 @@ impl<T: SmartDevice> From<T> for SmartPort {
     fn from(device: T) -> Self {
         // SAFETY: We can do this, since we ensure that the old smartport was disposed of.
         // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe {
-            Self::new(device.port_index())
-        }
+        unsafe { Self::new(device.port_index()) }
     }
 }
 

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -74,6 +74,17 @@ impl Direction {
     }
 }
 
+impl core::ops::Not for Direction {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Self::Forward => Self::Reverse,
+            Self::Reverse => Self::Forward,
+        }
+    }
+}
+
 impl Motor {
     /// The maximum voltage value that can be sent to a [`Motor`].
     pub const MAX_VOLTAGE: f64 = 12.0;

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -14,12 +14,12 @@ use vex_sdk::{
     vexDeviceMotorTemperatureGet, vexDeviceMotorTorqueGet, vexDeviceMotorVelocityGet,
     vexDeviceMotorVelocitySet, vexDeviceMotorVelocityUpdate, vexDeviceMotorVoltageGet,
     vexDeviceMotorVoltageLimitGet, vexDeviceMotorVoltageLimitSet, vexDeviceMotorVoltageSet,
-    V5MotorBrakeMode, V5MotorGearset,
+    V5MotorBrakeMode, V5MotorGearset, V5_DeviceT,
 };
 #[cfg(feature = "dangerous_motor_tuning")]
 use vex_sdk::{vexDeviceMotorPositionPidSet, vexDeviceMotorVelocityPidSet, V5_DeviceMotorPid};
 
-use super::{SmartDevice, SmartDeviceInternal, SmartDeviceTimestamp, SmartDeviceType, SmartPort};
+use super::{SmartDevice, SmartDeviceTimestamp, SmartDeviceType, SmartPort};
 use crate::{PortError, Position};
 
 /// The basic motor struct.
@@ -27,6 +27,7 @@ use crate::{PortError, Position};
 pub struct Motor {
     port: SmartPort,
     target: MotorControl,
+    device: V5_DeviceT,
 }
 
 /// Represents a possible target for a [`Motor`].
@@ -84,27 +85,40 @@ impl Motor {
     pub const DATA_WRITE_RATE: Duration = Duration::from_millis(5);
 
     /// Create a new motor from a smart port index.
-    pub fn new(
+    pub fn new(port: SmartPort, gearset: Gearset, direction: Direction) -> Self {
+        let device = unsafe { port.device_handle() }; // SAFETY: This function is only called once on this port.
+
+        // NOTE: SDK properly stores device state when unplugged, meaning that we can safely
+        // set these without consequence even if the device is not available. If the user wants
+        // a falliable version of this, they can use [`Self::try_new`] instead, which just wraps
+        // this method in [`Self::validate_port`]. This is an edge case for the SDK though, and
+        // seems to just be a thing for motors.
+        unsafe {
+            vexDeviceMotorEncoderUnitsSet(
+                device,
+                vex_sdk::V5MotorEncoderUnits::kMotorEncoderDegrees,
+            );
+            vexDeviceMotorGearingSet(device, gearset.into());
+            vexDeviceMotorReverseFlagSet(device, direction.is_reverse());
+        }
+
+        Self {
+            port,
+            target: MotorControl::Voltage(0.0),
+            device,
+        }
+    }
+
+    /// Create a new motor from a smart port index, returning a [`PortError`] if the motor is disconnected,
+    /// an incorrect device, or otherwise unavailable.
+    pub fn try_new(
         port: SmartPort,
         gearset: Gearset,
         direction: Direction,
-    ) -> Result<Self, MotorError> {
-        let mut motor = Self {
-            port,
-            target: MotorControl::Voltage(0.0),
-        };
+    ) -> Result<Self, PortError> {
+        port.validate_type(SmartDeviceType::Motor)?;
 
-        motor.set_gearset(gearset)?;
-        motor.set_direction(direction)?;
-
-        unsafe {
-            vexDeviceMotorEncoderUnitsSet(
-                motor.device_handle(),
-                vex_sdk::V5MotorEncoderUnits::kMotorEncoderDegrees,
-            );
-        }
-
-        Ok(motor)
+        Ok(Self::new(port, gearset, direction))
     }
 
     /// Sets the target that the motor should attempt to reach.
@@ -116,34 +130,30 @@ impl Motor {
 
         match target {
             MotorControl::Brake(mode) => unsafe {
-                vexDeviceMotorBrakeModeSet(self.device_handle(), mode.into());
+                vexDeviceMotorBrakeModeSet(self.device, mode.into());
                 // Force motor into braking by putting it into velocity control with a 0rpm setpoint.
-                vexDeviceMotorVelocitySet(self.device_handle(), 0);
+                vexDeviceMotorVelocitySet(self.device, 0);
             },
             MotorControl::Velocity(rpm) => unsafe {
                 vexDeviceMotorBrakeModeSet(
-                    self.device_handle(),
+                    self.device,
                     vex_sdk::V5MotorBrakeMode::kV5MotorBrakeModeCoast,
                 );
-                vexDeviceMotorVelocitySet(self.device_handle(), rpm);
+                vexDeviceMotorVelocitySet(self.device, rpm);
             },
             MotorControl::Voltage(volts) => unsafe {
                 vexDeviceMotorBrakeModeSet(
-                    self.device_handle(),
+                    self.device,
                     vex_sdk::V5MotorBrakeMode::kV5MotorBrakeModeCoast,
                 );
-                vexDeviceMotorVoltageSet(self.device_handle(), (volts * 1000.0) as i32);
+                vexDeviceMotorVoltageSet(self.device, (volts * 1000.0) as i32);
             },
             MotorControl::Position(position, velocity) => unsafe {
                 vexDeviceMotorBrakeModeSet(
-                    self.device_handle(),
+                    self.device,
                     vex_sdk::V5MotorBrakeMode::kV5MotorBrakeModeCoast,
                 );
-                vexDeviceMotorAbsoluteTargetSet(
-                    self.device_handle(),
-                    position.into_degrees(),
-                    velocity,
-                );
+                vexDeviceMotorAbsoluteTargetSet(self.device, position.into_degrees(), velocity);
             },
         }
 
@@ -188,7 +198,7 @@ impl Motor {
         self.validate_port()?;
 
         unsafe {
-            vexDeviceMotorVelocityUpdate(self.device_handle(), velocity);
+            vexDeviceMotorVelocityUpdate(self.device, velocity);
         }
 
         if let MotorControl::Position(position, _) = self.target {
@@ -208,7 +218,7 @@ impl Motor {
     pub fn set_gearset(&mut self, gearset: Gearset) -> Result<(), MotorError> {
         self.validate_port()?;
         unsafe {
-            vexDeviceMotorGearingSet(self.device_handle(), gearset.into());
+            vexDeviceMotorGearingSet(self.device, gearset.into());
         }
         Ok(())
     }
@@ -216,38 +226,38 @@ impl Motor {
     /// Gets the gearset of the motor.
     pub fn gearset(&self) -> Result<Gearset, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorGearingGet(self.device_handle()) }.into())
+        Ok(unsafe { vexDeviceMotorGearingGet(self.device) }.into())
     }
 
     /// Gets the estimated angular velocity (RPM) of the motor.
     pub fn velocity(&self) -> Result<i32, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorVelocityGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceMotorVelocityGet(self.device) })
     }
 
     /// Returns the power drawn by the motor in Watts.
     pub fn power(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorPowerGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceMotorPowerGet(self.device) })
     }
 
     /// Returns the torque output of the motor in Nm.
     pub fn torque(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorTorqueGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceMotorTorqueGet(self.device) })
     }
 
     /// Returns the voltage the motor is drawing in volts.
     pub fn voltage(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorVoltageGet(self.device_handle()) } as f64 / 1000.0)
+        Ok(unsafe { vexDeviceMotorVoltageGet(self.device) } as f64 / 1000.0)
     }
 
     /// Returns the current position of the motor.
     pub fn position(&self) -> Result<Position, MotorError> {
         self.validate_port()?;
         Ok(Position::from_degrees(unsafe {
-            vexDeviceMotorPositionGet(self.device_handle())
+            vexDeviceMotorPositionGet(self.device)
         }))
     }
 
@@ -258,7 +268,7 @@ impl Motor {
         self.validate_port()?;
 
         let mut timestamp: u32 = 0;
-        let ticks = unsafe { vexDeviceMotorPositionRawGet(self.device_handle(), &mut timestamp) };
+        let ticks = unsafe { vexDeviceMotorPositionRawGet(self.device, &mut timestamp) };
 
         Ok((ticks, SmartDeviceTimestamp(timestamp)))
     }
@@ -266,7 +276,7 @@ impl Motor {
     /// Returns the electrical current draw of the motor in amps.
     pub fn current(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorCurrentGet(self.device_handle()) } as f64 / 1000.0)
+        Ok(unsafe { vexDeviceMotorCurrentGet(self.device) } as f64 / 1000.0)
     }
 
     /// Gets the efficiency of the motor from a range of [0.0, 1.0].
@@ -277,14 +287,14 @@ impl Motor {
     pub fn efficiency(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceMotorEfficiencyGet(self.device_handle()) } / 100.0)
+        Ok(unsafe { vexDeviceMotorEfficiencyGet(self.device) } / 100.0)
     }
 
     /// Sets the current encoder position to zero without moving the motor.
     /// Analogous to taring or resetting the encoder to the current position.
     pub fn reset_position(&mut self) -> Result<(), MotorError> {
         self.validate_port()?;
-        unsafe { vexDeviceMotorPositionReset(self.device_handle()) }
+        unsafe { vexDeviceMotorPositionReset(self.device) }
         Ok(())
     }
 
@@ -292,14 +302,14 @@ impl Motor {
     /// Analogous to taring or resetting the encoder so that the new position is equal to the given position.
     pub fn set_position(&mut self, position: Position) -> Result<(), MotorError> {
         self.validate_port()?;
-        unsafe { vexDeviceMotorPositionSet(self.device_handle(), position.into_degrees()) }
+        unsafe { vexDeviceMotorPositionSet(self.device, position.into_degrees()) }
         Ok(())
     }
 
     /// Sets the current limit for the motor in amps.
     pub fn set_current_limit(&mut self, limit: f64) -> Result<(), MotorError> {
         self.validate_port()?;
-        unsafe { vexDeviceMotorCurrentLimitSet(self.device_handle(), (limit * 1000.0) as i32) }
+        unsafe { vexDeviceMotorCurrentLimitSet(self.device, (limit * 1000.0) as i32) }
         Ok(())
     }
 
@@ -308,7 +318,7 @@ impl Motor {
         self.validate_port()?;
 
         unsafe {
-            vexDeviceMotorVoltageLimitSet(self.device_handle(), (limit * 1000.0) as i32);
+            vexDeviceMotorVoltageLimitSet(self.device, (limit * 1000.0) as i32);
         }
 
         Ok(())
@@ -317,27 +327,26 @@ impl Motor {
     /// Gets the current limit for the motor in amps.
     pub fn current_limit(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorCurrentLimitGet(self.device_handle()) } as f64 / 1000.0)
+        Ok(unsafe { vexDeviceMotorCurrentLimitGet(self.device) } as f64 / 1000.0)
     }
 
     /// Gets the voltage limit for the motor if one has been explicitly set.
     pub fn voltage_limit(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorVoltageLimitGet(self.device_handle()) } as f64 / 1000.0)
+        Ok(unsafe { vexDeviceMotorVoltageLimitGet(self.device) } as f64 / 1000.0)
     }
 
     /// Returns the internal teperature recorded by the motor in increments of 5°C.
     pub fn temperature(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorTemperatureGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceMotorTemperatureGet(self.device) })
     }
 
     /// Get the status flags of a motor.
     pub fn status(&self) -> Result<MotorStatus, MotorError> {
         self.validate_port()?;
 
-        let status =
-            MotorStatus::from_bits_retain(unsafe { vexDeviceMotorFlagsGet(self.device_handle()) });
+        let status = MotorStatus::from_bits_retain(unsafe { vexDeviceMotorFlagsGet(self.device) });
 
         // This is technically just a flag, but it indicates that an error occurred when trying
         // to get the flags, so we return early here.
@@ -353,7 +362,7 @@ impl Motor {
         self.validate_port()?;
 
         Ok(MotorFaults::from_bits_retain(unsafe {
-            vexDeviceMotorFaultsGet(self.device_handle())
+            vexDeviceMotorFaultsGet(self.device)
         }))
     }
 
@@ -382,7 +391,7 @@ impl Motor {
         self.validate_port()?;
 
         unsafe {
-            vexDeviceMotorReverseFlagSet(self.device_handle(), direction.is_reverse());
+            vexDeviceMotorReverseFlagSet(self.device, direction.is_reverse());
         }
 
         Ok(())
@@ -392,12 +401,10 @@ impl Motor {
     pub fn direction(&self) -> Result<Direction, MotorError> {
         self.validate_port()?;
 
-        Ok(
-            match unsafe { vexDeviceMotorReverseFlagGet(self.device_handle()) } {
-                false => Direction::Forward,
-                true => Direction::Reverse,
-            },
-        )
+        Ok(match unsafe { vexDeviceMotorReverseFlagGet(self.device) } {
+            false => Direction::Forward,
+            true => Direction::Reverse,
+        })
     }
 
     /// Adjusts the internal tuning constants of the motor when using velocity control.
@@ -418,7 +425,7 @@ impl Motor {
     ) -> Result<(), MotorError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceMotorVelocityPidSet(self.device_handle(), constants.into()) }
+        unsafe { vexDeviceMotorVelocityPidSet(self.device, constants.into()) }
 
         Ok(())
     }
@@ -441,7 +448,7 @@ impl Motor {
     ) -> Result<(), MotorError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceMotorPositionPidSet(self.device_handle(), constants.into()) }
+        unsafe { vexDeviceMotorPositionPidSet(self.device, constants.into()) }
 
         Ok(())
     }

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -89,10 +89,8 @@ impl Motor {
         let device = unsafe { port.device_handle() }; // SAFETY: This function is only called once on this port.
 
         // NOTE: SDK properly stores device state when unplugged, meaning that we can safely
-        // set these without consequence even if the device is not available. If the user wants
-        // a falliable version of this, they can use [`Self::try_new`] instead, which just wraps
-        // this method in [`Self::validate_port`]. This is an edge case for the SDK though, and
-        // seems to just be a thing for motors.
+        // set these without consequence even if the device is not available. This is an edge
+        // case for the SDK though, and seems to just be a thing for motors and rotation sensors.
         unsafe {
             vexDeviceMotorEncoderUnitsSet(
                 device,
@@ -107,18 +105,6 @@ impl Motor {
             target: MotorControl::Voltage(0.0),
             device,
         }
-    }
-
-    /// Create a new motor from a smart port index, returning a [`PortError`] if the motor is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    pub fn try_new(
-        port: SmartPort,
-        gearset: Gearset,
-        direction: Direction,
-    ) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Motor)?;
-
-        Ok(Self::new(port, gearset, direction))
     }
 
     /// Sets the target that the motor should attempt to reach.

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -40,14 +40,6 @@ impl OpticalSensor {
         }
     }
 
-    /// Creates a new inertial sensor from a smart port index, returning a [`PortError`] if the device is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Optical)?;
-
-        Ok(Self::new(port))
-    }
-
     /// Get the PWM percentage (intensity/brightness) of the sensor's LED indicator.
     pub fn led_brightness(&self) -> Result<i32, PortError> {
         self.validate_port()?;

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -2,24 +2,23 @@
 
 use core::time::Duration;
 
-use snafu::Snafu;
 use vex_sdk::{
-    vexDeviceOpticalBrightnessGet, vexDeviceOpticalGestureDisable, vexDeviceOpticalGestureEnable,
-    vexDeviceOpticalGestureGet, vexDeviceOpticalHueGet, vexDeviceOpticalIntegrationTimeGet,
-    vexDeviceOpticalIntegrationTimeSet, vexDeviceOpticalLedPwmGet, vexDeviceOpticalLedPwmSet,
-    vexDeviceOpticalProximityGet, vexDeviceOpticalRawGet, vexDeviceOpticalRgbGet,
-    vexDeviceOpticalSatGet, vexDeviceOpticalStatusGet, V5_DeviceOpticalGesture,
-    V5_DeviceOpticalRaw, V5_DeviceOpticalRgb,
+    vexDeviceOpticalBrightnessGet, vexDeviceOpticalGestureEnable, vexDeviceOpticalGestureGet,
+    vexDeviceOpticalHueGet, vexDeviceOpticalIntegrationTimeGet, vexDeviceOpticalIntegrationTimeSet,
+    vexDeviceOpticalLedPwmGet, vexDeviceOpticalLedPwmSet, vexDeviceOpticalProximityGet,
+    vexDeviceOpticalRawGet, vexDeviceOpticalRgbGet, vexDeviceOpticalSatGet,
+    vexDeviceOpticalStatusGet, V5_DeviceOpticalGesture, V5_DeviceOpticalRaw, V5_DeviceOpticalRgb,
+    V5_DeviceT,
 };
 
-use super::{SmartDevice, SmartDeviceInternal, SmartDeviceType, SmartPort};
+use super::{SmartDevice, SmartDeviceType, SmartPort};
 use crate::PortError;
 
 /// Represents a smart port configured as a V5 optical sensor
 #[derive(Debug, Eq, PartialEq)]
 pub struct OpticalSensor {
     port: SmartPort,
-    gesture_detection_enabled: bool,
+    device: V5_DeviceT,
 }
 
 impl OpticalSensor {
@@ -33,47 +32,45 @@ impl OpticalSensor {
     /// Source: <https://www.vexforum.com/t/v5-optical-sensor-refresh-rate/109632/9>
     pub const MAX_INTEGRATION_TIME: Duration = Duration::from_millis(712);
 
-    /// Creates a new inertial sensor from a smart port index.
-    ///
-    /// Gesture detection features can be optionally enabled, allowing the use of [`Self::last_gesture_direction()`] and [`Self::last_gesture_direction()`].
-    pub fn new(port: SmartPort, gesture_detection_enabled: bool) -> Result<Self, OpticalError> {
-        let mut sensor = Self {
+    /// Creates a new optical sensor from a smart port index.
+    pub fn new(port: SmartPort) -> Self {
+        Self {
+            device: unsafe { port.device_handle() },
             port,
-            gesture_detection_enabled,
-        };
-
-        if gesture_detection_enabled {
-            sensor.enable_gesture_detection()?;
-        } else {
-            sensor.disable_gesture_detection()?;
         }
+    }
 
-        Ok(sensor)
+    /// Creates a new inertial sensor from a smart port index, returning a [`PortError`] if the device is disconnected,
+    /// an incorrect device, or otherwise unavailable.
+    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
+        port.validate_type(SmartDeviceType::Optical)?;
+
+        Ok(Self::new(port))
     }
 
     /// Get the PWM percentage (intensity/brightness) of the sensor's LED indicator.
-    pub fn led_brightness(&self) -> Result<i32, OpticalError> {
+    pub fn led_brightness(&self) -> Result<i32, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceOpticalLedPwmGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceOpticalLedPwmGet(self.device) })
     }
 
     /// Set the PWM percentage (intensity/brightness) of the sensor's LED indicator.
-    pub fn set_led_brightness(&mut self, brightness: f64) -> Result<(), OpticalError> {
+    pub fn set_led_brightness(&mut self, brightness: f64) -> Result<(), PortError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceOpticalLedPwmSet(self.device_handle(), (brightness * 100.0) as i32) }
+        unsafe { vexDeviceOpticalLedPwmSet(self.device, (brightness * 100.0) as i32) }
 
         Ok(())
     }
 
     /// Get integration time (update rate) of the optical sensor in milliseconds, with
     /// minimum time being 3ms and the maximum time being 712ms.
-    pub fn integration_time(&self) -> Result<Duration, OpticalError> {
+    pub fn integration_time(&self) -> Result<Duration, PortError> {
         self.validate_port()?;
 
         Ok(Duration::from_millis(
-            unsafe { vexDeviceOpticalIntegrationTimeGet(self.device_handle()) } as u64,
+            unsafe { vexDeviceOpticalIntegrationTimeGet(self.device) } as u64,
         ))
     }
 
@@ -85,7 +82,7 @@ impl OpticalSensor {
     /// Time value must be a [`Duration`] between 3 and 712 milliseconds. See
     /// <https://www.vexforum.com/t/v5-optical-sensor-refresh-rate/109632/9> for
     /// more information.
-    pub fn set_integration_time(&mut self, time: Duration) -> Result<(), OpticalError> {
+    pub fn set_integration_time(&mut self, time: Duration) -> Result<(), PortError> {
         self.validate_port()?;
 
         let time_ms = time.as_millis().clamp(
@@ -93,7 +90,7 @@ impl OpticalSensor {
             Self::MAX_INTEGRATION_TIME.as_millis(),
         ) as f64;
 
-        unsafe { vexDeviceOpticalIntegrationTimeSet(self.device_handle(), time_ms) }
+        unsafe { vexDeviceOpticalIntegrationTimeSet(self.device, time_ms) }
 
         Ok(())
     }
@@ -101,101 +98,73 @@ impl OpticalSensor {
     /// Get the detected color hue.
     ///
     /// Hue has a range of `0` to `359.999`.
-    pub fn hue(&self) -> Result<f64, OpticalError> {
+    pub fn hue(&self) -> Result<f64, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceOpticalHueGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceOpticalHueGet(self.device) })
     }
 
     /// Gets the detected color saturation.
     ///
     /// Saturation has a range `0` to `1.0`.
-    pub fn saturation(&self) -> Result<f64, OpticalError> {
+    pub fn saturation(&self) -> Result<f64, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceOpticalSatGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceOpticalSatGet(self.device) })
     }
 
     /// Get the detected color brightness.
     ///
     /// Brightness values range from `0` to `1.0`.
-    pub fn brightness(&self) -> Result<f64, OpticalError> {
+    pub fn brightness(&self) -> Result<f64, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceOpticalBrightnessGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceOpticalBrightnessGet(self.device) })
     }
 
     /// Get the analog proximity value from `0` to `1.0`.
     ///
     /// A reading of 1.0 indicates that the object is close to the sensor, while 0.0
     /// indicates that no object is detected in range of the sensor.
-    pub fn proximity(&self) -> Result<f64, OpticalError> {
+    pub fn proximity(&self) -> Result<f64, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceOpticalProximityGet(self.device_handle()) } as f64 / 255.0)
+        Ok(unsafe { vexDeviceOpticalProximityGet(self.device) } as f64 / 255.0)
     }
 
     /// Get the processed RGB data from the sensor
-    pub fn rgb(&self) -> Result<OpticalRgb, OpticalError> {
+    pub fn rgb(&self) -> Result<OpticalRgb, PortError> {
         self.validate_port()?;
 
         let mut data = V5_DeviceOpticalRgb::default();
-        unsafe { vexDeviceOpticalRgbGet(self.device_handle(), &mut data) };
+        unsafe { vexDeviceOpticalRgbGet(self.device, &mut data) };
 
         Ok(data.into())
     }
 
     /// Get the raw, unprocessed RGBC data from the sensor
-    pub fn raw(&self) -> Result<OpticalRaw, OpticalError> {
+    pub fn raw(&self) -> Result<OpticalRaw, PortError> {
         self.validate_port()?;
 
         let mut data = V5_DeviceOpticalRaw::default();
-        unsafe { vexDeviceOpticalRawGet(self.device_handle(), &mut data) };
+        unsafe { vexDeviceOpticalRawGet(self.device, &mut data) };
 
         Ok(data.into())
     }
 
-    /// Enables gesture detection features on the sensor.
-    ///
-    /// This allows [`Self::last_gesture_direction()`] and [`Self::last_gesture_direction()`] to be called without error, if
-    /// gesture detection wasn't already enabled.
-    pub fn enable_gesture_detection(&mut self) -> Result<(), OpticalError> {
-        self.validate_port()?;
-
-        unsafe { vexDeviceOpticalGestureEnable(self.device_handle()) }
-        self.gesture_detection_enabled = true;
-
-        Ok(())
-    }
-
-    /// Disables gesture detection features on the sensor.
-    pub fn disable_gesture_detection(&mut self) -> Result<(), OpticalError> {
-        self.validate_port()?;
-
-        unsafe { vexDeviceOpticalGestureDisable(self.device_handle()) }
-        self.gesture_detection_enabled = true;
-
-        Ok(())
-    }
-
-    /// Determine if gesture detection is enabled or not on the sensor.
-    pub const fn gesture_detection_enabled(&self) -> bool {
-        self.gesture_detection_enabled
-    }
-
     /// Get the most recent gesture data from the sensor. Gestures will be cleared after 500mS.
-    ///
-    /// Will return [`OpticalError::GestureDetectionDisabled`] if the sensor is not
-    /// confgured to detect gestures.
-    pub fn last_gesture(&self) -> Result<Gesture, OpticalError> {
-        if !self.gesture_detection_enabled {
-            return Err(OpticalError::GestureDetectionDisabled);
-        }
+    pub fn last_gesture(&self) -> Result<Gesture, PortError> {
         self.validate_port()?;
+
+        // Enable gesture detection if not already enabled.
+        //
+        // For some reason, PROS docs claim that this function makes color reading
+        // unavilable, but from hardware testing this is false.
+        unsafe { vexDeviceOpticalGestureEnable(self.device) };
 
         let mut gesture = V5_DeviceOpticalGesture::default();
         let direction: GestureDirection =
-            unsafe { vexDeviceOpticalGestureGet(self.device_handle(), &mut gesture) }.into();
+            unsafe { vexDeviceOpticalGestureGet(self.device, &mut gesture) }.into();
 
         Ok(Gesture {
             direction,
@@ -210,10 +179,10 @@ impl OpticalSensor {
     }
 
     /// Gets the status code of the distance sensor
-    pub fn status(&self) -> Result<u32, OpticalError> {
+    pub fn status(&self) -> Result<u32, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceOpticalStatusGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceOpticalStatusGet(self.device) })
     }
 }
 
@@ -326,18 +295,4 @@ impl From<V5_DeviceOpticalRaw> for OpticalRaw {
             clear: value.clear,
         }
     }
-}
-
-#[derive(Debug, Snafu)]
-/// Errors that can occur when interacting with an optical sensor.
-pub enum OpticalError {
-    /// Gesture detection is not enabled for this sensor.
-    GestureDetectionDisabled,
-
-    #[snafu(display("{source}"), context(false))]
-    /// Generic port related error.
-    Port {
-        /// The source of the error
-        source: PortError,
-    },
 }

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -5,7 +5,9 @@
 use core::time::Duration;
 
 use vex_sdk::{
-    vexDeviceAbsEncAngleGet, vexDeviceAbsEncDataRateSet, vexDeviceAbsEncPositionGet, vexDeviceAbsEncPositionSet, vexDeviceAbsEncReset, vexDeviceAbsEncStatusGet, vexDeviceAbsEncVelocityGet, V5_DeviceT
+    vexDeviceAbsEncAngleGet, vexDeviceAbsEncDataRateSet, vexDeviceAbsEncPositionGet,
+    vexDeviceAbsEncPositionSet, vexDeviceAbsEncReset, vexDeviceAbsEncStatusGet,
+    vexDeviceAbsEncVelocityGet, V5_DeviceT,
 };
 
 use super::{motor::Direction, SmartDevice, SmartDeviceType, SmartPort};

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -2,31 +2,59 @@
 //!
 //! Rotation sensors operate on the same [`Position`] type as motors to measure rotation.
 
+use core::time::Duration;
+
 use vex_sdk::{
-    vexDeviceAbsEncAngleGet, vexDeviceAbsEncPositionGet, vexDeviceAbsEncPositionSet,
+    vexDeviceAbsEncAngleGet, vexDeviceAbsEncDataRateSet, vexDeviceAbsEncPositionSet,
     vexDeviceAbsEncReset, vexDeviceAbsEncReverseFlagGet, vexDeviceAbsEncReverseFlagSet,
-    vexDeviceAbsEncStatusGet, vexDeviceAbsEncVelocityGet,
+    vexDeviceAbsEncStatusGet, vexDeviceAbsEncVelocityGet, V5_DeviceT,
 };
 
-use super::{motor::Direction, SmartDevice, SmartDeviceInternal, SmartDeviceType, SmartPort};
+use super::{motor::Direction, SmartDevice, SmartDeviceType, SmartPort};
 use crate::{position::Position, PortError};
 
 /// A physical rotation sensor plugged into a port.
 #[derive(Debug, Eq, PartialEq)]
 pub struct RotationSensor {
     port: SmartPort,
+    device: V5_DeviceT,
 }
 
 impl RotationSensor {
+    /// The minimum data rate that you can set a rotation sensor to.
+    pub const MIN_DATA_RATE: Duration = Duration::from_millis(5);
+
     /// Creates a new rotation sensor on the given port.
     /// Whether or not the sensor should be reversed on creation can be specified.
-    pub fn new(port: SmartPort, direction: Direction) -> Result<Self, PortError> {
-        let mut sensor = Self { port };
+    pub fn new(port: SmartPort, direction: Direction) -> Self {
+        let device = unsafe { port.device_handle() };
 
-        sensor.reset()?;
-        sensor.set_direction(direction)?;
+        // NOTE: This is safe to do without port validation, since the SDK has special handling
+        // for this sensor if it is initialized when unplugged.
+        //
+        // FIXME: There's a known race condition with this function that can cause the position
+        // reading to become incorrect if it's ran before device initialization occurs. The only
+        // reasonable fix is reimplementing the reverse flag ourselves, but that's a little
+        // nontrivial to do, since angle and position have different reversing behaviors and require
+        // tracking some weird offsets.
+        //
+        // This forum post provides a better overview of the issue than I can describe here:
+        // <https://www.vexforum.com/t/rotation-sensor-bug-workaround-on-vexos-1-1-0/96577/6>
+        unsafe {
+            vexDeviceAbsEncReverseFlagSet(device, direction.is_reverse());
+        }
 
-        Ok(sensor)
+        Self { device, port }
+    }
+
+    /// Creates a new rotation sensor on the given port, returning a [`PortError`] if the sensor is disconnected,
+    /// an incorrect device, or otherwise unavailable.
+    ///
+    /// Whether or not the sensor should be reversed on creation can be specified.
+    pub fn try_new(port: SmartPort, direction: Direction) -> Result<Self, PortError> {
+        port.validate_type(SmartDeviceType::Rotation)?;
+
+        Ok(Self::new(port, direction))
     }
 
     /// Sets the position to zero.
@@ -34,7 +62,7 @@ impl RotationSensor {
         self.validate_port()?;
 
         unsafe {
-            vexDeviceAbsEncReset(self.device_handle());
+            vexDeviceAbsEncReset(self.device);
         }
 
         Ok(())
@@ -44,7 +72,9 @@ impl RotationSensor {
     pub fn set_position(&mut self, position: Position) -> Result<(), PortError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceAbsEncPositionSet(self.device_handle(), position.into_degrees() as i32) }
+        unsafe {
+            vexDeviceAbsEncPositionSet(self.device, (position.into_degrees() * 1000.0) as i32)
+        }
 
         Ok(())
     }
@@ -53,7 +83,23 @@ impl RotationSensor {
     pub fn set_direction(&mut self, direction: Direction) -> Result<(), PortError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceAbsEncReverseFlagSet(self.device_handle(), direction.is_reverse()) }
+        unsafe {
+            vexDeviceAbsEncReverseFlagSet(self.device, direction.is_reverse());
+        }
+
+        Ok(())
+    }
+
+    /// Sets the update rate of the sensor.
+    ///
+    /// This duration should be above [`Self::MIN_DATA_RATE`] (5 milliseconds).
+    pub fn set_data_rate(&mut self, data_rate: Duration) -> Result<(), PortError> {
+        self.validate_port()?;
+
+        let mut time_ms = data_rate.as_millis().max(Self::MIN_DATA_RATE.as_millis()) as u32;
+        time_ms -= time_ms % 5; // Rate is in increments of 5ms - not sure if this is necessary, but PROS does it.
+
+        unsafe { vexDeviceAbsEncDataRateSet(self.device, time_ms) }
 
         Ok(())
     }
@@ -63,7 +109,7 @@ impl RotationSensor {
         self.validate_port()?;
 
         Ok(
-            match unsafe { vexDeviceAbsEncReverseFlagGet(self.device_handle()) } {
+            match unsafe { vexDeviceAbsEncReverseFlagGet(self.device) } {
                 false => Direction::Forward,
                 true => Direction::Reverse,
             },
@@ -75,7 +121,7 @@ impl RotationSensor {
         self.validate_port()?;
 
         Ok(Position::from_degrees(
-            unsafe { vexDeviceAbsEncPositionGet(self.device_handle()) } as f64 / 100.0,
+            unsafe { vexDeviceAbsEncAngleGet(self.device) } as f64 / 100.0,
         ))
     }
 
@@ -86,7 +132,7 @@ impl RotationSensor {
         self.validate_port()?;
 
         Ok(Position::from_degrees(
-            unsafe { vexDeviceAbsEncAngleGet(self.device_handle()) } as f64 / 100.0,
+            unsafe { vexDeviceAbsEncAngleGet(self.device) } as f64 / 100.0,
         ))
     }
 
@@ -94,14 +140,14 @@ impl RotationSensor {
     pub fn velocity(&self) -> Result<f64, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceAbsEncVelocityGet(self.device_handle()) as f64 / 1000.0 })
+        Ok(unsafe { vexDeviceAbsEncVelocityGet(self.device) as f64 / 1000.0 })
     }
 
     /// Returns the sensor's status code.
     pub fn status(&self) -> Result<u32, PortError> {
         self.validate_port()?;
 
-        Ok(unsafe { vexDeviceAbsEncStatusGet(self.device_handle()) })
+        Ok(unsafe { vexDeviceAbsEncStatusGet(self.device) })
     }
 }
 

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -47,16 +47,6 @@ impl RotationSensor {
         Self { device, port }
     }
 
-    /// Creates a new rotation sensor on the given port, returning a [`PortError`] if the sensor is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    ///
-    /// Whether or not the sensor should be reversed on creation can be specified.
-    pub fn try_new(port: SmartPort, direction: Direction) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Rotation)?;
-
-        Ok(Self::new(port, direction))
-    }
-
     /// Sets the position to zero.
     pub fn reset(&mut self) -> Result<(), PortError> {
         self.validate_port()?;

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -6,8 +6,7 @@ use core::time::Duration;
 
 use vex_sdk::{
     vexDeviceAbsEncAngleGet, vexDeviceAbsEncDataRateSet, vexDeviceAbsEncPositionGet,
-    vexDeviceAbsEncPositionSet, vexDeviceAbsEncReset, vexDeviceAbsEncStatusGet,
-    vexDeviceAbsEncVelocityGet, V5_DeviceT,
+    vexDeviceAbsEncPositionSet, vexDeviceAbsEncStatusGet, vexDeviceAbsEncVelocityGet, V5_DeviceT,
 };
 
 use super::{motor::Direction, SmartDevice, SmartDeviceType, SmartPort};

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -80,14 +80,6 @@ impl VisionSensor {
         }
     }
 
-    /// Creates a new vision sensor on a smart port, returning a [`VisionError`] if the device is disconnected,
-    /// an incorrect device, or otherwise unavailable.
-    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Vision)?;
-
-        Ok(Self::new(port))
-    }
-
     /// Adds a detection signature to the sensor's onboard memory. This signature will be used to
     /// identify objects when using [`VisionSensor::objects`].
     ///

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -33,10 +33,11 @@ use vex_sdk::{
     vexDeviceVisionWhiteBalanceGet, vexDeviceVisionWhiteBalanceModeGet,
     vexDeviceVisionWhiteBalanceModeSet, vexDeviceVisionWhiteBalanceSet, vexDeviceVisionWifiModeGet,
     vexDeviceVisionWifiModeSet, V5VisionBlockType, V5VisionLedMode, V5VisionMode, V5VisionWBMode,
-    V5VisionWifiMode, V5_DeviceVisionObject, V5_DeviceVisionRgb, V5_DeviceVisionSignature,
+    V5VisionWifiMode, V5_DeviceT, V5_DeviceVisionObject, V5_DeviceVisionRgb,
+    V5_DeviceVisionSignature,
 };
 
-use super::{SmartDevice, SmartDeviceInternal, SmartDeviceType, SmartPort};
+use super::{SmartDevice, SmartDeviceType, SmartPort};
 use crate::{color::Rgb, PortError};
 
 /// VEX Vision Sensor
@@ -46,6 +47,7 @@ use crate::{color::Rgb, PortError};
 pub struct VisionSensor {
     port: SmartPort,
     codes: Vec<VisionCode>,
+    device: V5_DeviceT,
 }
 
 impl VisionSensor {
@@ -70,15 +72,20 @@ impl VisionSensor {
     /// // Register a vision sensor on port 1.
     /// let mut sensor = VisionSensor::new(peripherals.port_1);
     /// ```
-    pub fn new(port: SmartPort, mode: VisionMode) -> Result<Self, VisionError> {
-        let mut sensor = Self {
+    pub fn new(port: SmartPort) -> Self {
+        Self {
+            device: unsafe { port.device_handle() },
             port,
             codes: Vec::new(),
-        };
+        }
+    }
 
-        sensor.set_mode(mode)?;
+    /// Creates a new vision sensor on a smart port, returning a [`VisionError`] if the device is disconnected,
+    /// an incorrect device, or otherwise unavailable.
+    pub fn try_new(port: SmartPort) -> Result<Self, PortError> {
+        port.validate_type(SmartDeviceType::Vision)?;
 
-        Ok(sensor)
+        Ok(Self::new(port))
     }
 
     /// Adds a detection signature to the sensor's onboard memory. This signature will be used to
@@ -118,7 +125,7 @@ impl VisionSensor {
             ..Default::default()
         };
 
-        unsafe { vexDeviceVisionSignatureSet(self.device_handle(), &mut signature) }
+        unsafe { vexDeviceVisionSignatureSet(self.device, &mut signature) }
 
         Ok(())
     }
@@ -129,9 +136,8 @@ impl VisionSensor {
         }
 
         let mut raw_signature = V5_DeviceVisionSignature::default();
-        let read_operation = unsafe {
-            vexDeviceVisionSignatureGet(self.device_handle(), id as u32, &mut raw_signature)
-        };
+        let read_operation =
+            unsafe { vexDeviceVisionSignatureGet(self.device, id as u32, &mut raw_signature) };
 
         if !read_operation {
             return Ok(None);
@@ -153,7 +159,7 @@ impl VisionSensor {
     fn set_signature_type(&mut self, id: u8, sig_type: u32) -> Result<(), VisionError> {
         if let Some(mut sig) = self.raw_signature(id)? {
             sig.mType = sig_type;
-            unsafe { vexDeviceVisionSignatureSet(self.device_handle(), &mut sig) }
+            unsafe { vexDeviceVisionSignatureSet(self.device, &mut sig) }
         } else {
             return Err(VisionError::ReadingFailed);
         }
@@ -221,22 +227,20 @@ impl VisionSensor {
         self.validate_port()?;
 
         // SDK function gives us brightness percentage 0-100.
-        Ok(unsafe { vexDeviceVisionBrightnessGet(self.device_handle()) } as f64 / 100.0)
+        Ok(unsafe { vexDeviceVisionBrightnessGet(self.device) } as f64 / 100.0)
     }
 
     /// Get the current white balance of the vision sensor as an RGB color.
     pub fn white_balance(&self) -> Result<WhiteBalance, VisionError> {
         self.validate_port()?;
 
-        let handle = self.device_handle();
-
         Ok(
-            match unsafe { vexDeviceVisionWhiteBalanceModeGet(handle) } {
+            match unsafe { vexDeviceVisionWhiteBalanceModeGet(self.device) } {
                 V5VisionWBMode::kVisionWBNormal => WhiteBalance::Auto,
                 V5VisionWBMode::kVisionWBStart => WhiteBalance::StartupAuto,
-                V5VisionWBMode::kVisionWBManual => {
-                    WhiteBalance::Manual(unsafe { vexDeviceVisionWhiteBalanceGet(handle) }.into())
-                }
+                V5VisionWBMode::kVisionWBManual => WhiteBalance::Manual(
+                    unsafe { vexDeviceVisionWhiteBalanceGet(self.device) }.into(),
+                ),
                 _ => unreachable!(),
             },
         )
@@ -246,7 +250,7 @@ impl VisionSensor {
     pub fn set_brightness(&mut self, brightness: f64) -> Result<(), VisionError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceVisionBrightnessSet(self.device_handle(), (brightness * 100.0) as u8) }
+        unsafe { vexDeviceVisionBrightnessSet(self.device, (brightness * 100.0) as u8) }
 
         Ok(())
     }
@@ -257,12 +261,12 @@ impl VisionSensor {
     pub fn set_white_balance(&mut self, white_balance: WhiteBalance) -> Result<(), VisionError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceVisionWhiteBalanceModeSet(self.device_handle(), white_balance.into()) }
+        unsafe { vexDeviceVisionWhiteBalanceModeSet(self.device, white_balance.into()) }
 
         if let WhiteBalance::Manual(rgb) = white_balance {
             unsafe {
                 vexDeviceVisionWhiteBalanceSet(
-                    self.device_handle(),
+                    self.device,
                     V5_DeviceVisionRgb {
                         red: rgb.red(),
                         green: rgb.green(),
@@ -289,12 +293,12 @@ impl VisionSensor {
     pub fn set_led_mode(&mut self, mode: LedMode) -> Result<(), VisionError> {
         self.validate_port()?;
 
-        unsafe { vexDeviceVisionLedModeSet(self.device_handle(), mode.into()) }
+        unsafe { vexDeviceVisionLedModeSet(self.device, mode.into()) }
 
         if let LedMode::Manual(rgb, brightness) = mode {
             unsafe {
                 vexDeviceVisionLedColorSet(
-                    self.device_handle(),
+                    self.device,
                     V5_DeviceVisionRgb {
                         red: rgb.red(),
                         green: rgb.green(),
@@ -312,20 +316,18 @@ impl VisionSensor {
     pub fn led_mode(&self) -> Result<LedMode, VisionError> {
         self.validate_port()?;
 
-        Ok(
-            match unsafe { vexDeviceVisionLedModeGet(self.device_handle()) } {
-                V5VisionLedMode::kVisionLedModeAuto => LedMode::Auto,
-                V5VisionLedMode::kVisionLedModeManual => {
-                    let led_color = unsafe { vexDeviceVisionLedColorGet(self.device_handle()) };
+        Ok(match unsafe { vexDeviceVisionLedModeGet(self.device) } {
+            V5VisionLedMode::kVisionLedModeAuto => LedMode::Auto,
+            V5VisionLedMode::kVisionLedModeManual => {
+                let led_color = unsafe { vexDeviceVisionLedColorGet(self.device) };
 
-                    LedMode::Manual(
-                        Rgb::new(led_color.red, led_color.green, led_color.blue),
-                        led_color.brightness as f64 / 100.0,
-                    )
-                }
-                _ => unreachable!(),
-            },
-        )
+                LedMode::Manual(
+                    Rgb::new(led_color.red, led_color.green, led_color.blue),
+                    led_color.brightness as f64 / 100.0,
+                )
+            }
+            _ => unreachable!(),
+        })
     }
 
     /// Returns a [`Vec`] of objects detected by the sensor.
@@ -334,15 +336,13 @@ impl VisionSensor {
             return Err(VisionError::WifiMode);
         }
 
-        let device = self.device_handle();
-
-        let object_count = unsafe { vexDeviceVisionObjectCountGet(device) } as usize;
+        let object_count = unsafe { vexDeviceVisionObjectCountGet(self.device) } as usize;
         let mut objects = Vec::with_capacity(object_count);
 
         for i in 0..object_count {
             let mut object = V5_DeviceVisionObject::default();
 
-            if unsafe { vexDeviceVisionObjectGet(device, i as u32, &mut object) } == 0 {
+            if unsafe { vexDeviceVisionObjectGet(self.device, i as u32, &mut object) } == 0 {
                 return Err(VisionError::ReadingFailed);
             }
 
@@ -381,11 +381,9 @@ impl VisionSensor {
     pub fn set_mode(&mut self, mode: VisionMode) -> Result<(), VisionError> {
         self.validate_port()?;
 
-        let device = self.device_handle();
-
         unsafe {
             vexDeviceVisionWifiModeSet(
-                device,
+                self.device,
                 match mode {
                     VisionMode::Wifi => V5VisionWifiMode::kVisionWifiModeOn,
                     _ => V5VisionWifiMode::kVisionWifiModeOff,
@@ -393,7 +391,7 @@ impl VisionSensor {
             );
 
             vexDeviceVisionModeSet(
-                device,
+                self.device,
                 match mode {
                     VisionMode::ColorDetection => V5VisionMode::kVisionModeNormal,
                     VisionMode::LineDetection => V5VisionMode::kVisionModeLineDetect,
@@ -413,13 +411,12 @@ impl VisionSensor {
     pub fn mode(&self) -> Result<VisionMode, VisionError> {
         self.validate_port()?;
 
-        let device = self.device_handle();
-
-        if unsafe { vexDeviceVisionWifiModeGet(device) } == V5VisionWifiMode::kVisionWifiModeOn {
+        if unsafe { vexDeviceVisionWifiModeGet(self.device) } == V5VisionWifiMode::kVisionWifiModeOn
+        {
             return Ok(VisionMode::Wifi);
         }
 
-        Ok(unsafe { vexDeviceVisionModeGet(device) }.into())
+        Ok(unsafe { vexDeviceVisionModeGet(self.device) }.into())
     }
 }
 

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -22,7 +22,7 @@ authors = [
 [dependencies]
 vexide-core = { version = "0.1.0", path = "../vexide-core" }
 vexide-devices = { version = "0.1.0", path = "../vexide-devices", optional = true }
-vex-sdk = "0.11.0"
+vex-sdk = "0.12.0"
 
 [features]
 default = ["display_panics"]

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vex-sdk = "0.11.0"
+vex-sdk = "0.12.0"
 vexide-startup-macro = { path = "../vexide-startup-macro" }
 vexide-core = { version = "0.1.0", path = "../vexide-core"}
 vexide-async = { version = "0.1.0", path = "../vexide-async" }

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -25,6 +25,7 @@ vexide-panic = { version = "0.1.0", path = "../vexide-panic", optional = true }
 vexide-core = { version = "0.1.0", path = "../vexide-core", optional = true }
 vexide-math = { version = "0.1.0", path = "../vexide-math", optional = true }
 vexide-startup = { version = "0.1.0", path = "../vexide-startup", optional = true }
+vex-sdk = "0.12.0"
 
 [features]
 default = ["async", "devices", "panic", "display_panics", "core", "math", "startup"]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- Makes all device constructors infallible by ensuring safe recovery from disconnects after construction.
- Refactors internal error handling and SDK communication to (hopefully) make things simpler.
- Adds support for hotplugging device types by allowing conversion from a `SmartDevice` back into a `SmartPort` (by consuming the device).

## Additional Context
- `RadioLink` cannot be made infallible, since it needs to establish a connection upon device creation.
- `OpticalSensor` now only enables gesture detection mode the first time `last_gesture` was called, rather than giving the option to the user.
- `VisionSensor` can no longer take a `mode` in `VisionSensor::new`, since that data gets wiped when its unplugged.
- All ADI devices attempt to configure the port before accessing the SDK in the event that the constructor failed.
- Two-wire ADI devices that take up multiple triports no longer validate the expander, but still have to return `Result`, since there are possible logic errors with the two ports (being on the wrong expander, etc...)
- Fixed a few random bugs in devices that I came across in the process (datarate setters in IMU and rotation, some rotation position behavior).