### PR TITLE
feat: double-buffered screen rendering support

### DIFF
--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -356,10 +356,12 @@ impl Screen {
     /// For more info on render modes, look at the [`RenderMode`] docs.
     pub fn set_render_mode(&mut self, mode: RenderMode) {
         self.render_mode = mode;
-        unsafe { match mode {
-            RenderMode::Immediate => vex_sdk::vexDisplayDoubleBufferDisable(),
-            RenderMode::DoubleBuffered => vex_sdk::vexDisplayRender(false, true),
-        }}
+        unsafe {
+            match mode {
+                RenderMode::Immediate => vex_sdk::vexDisplayDoubleBufferDisable(),
+                RenderMode::DoubleBuffered => vex_sdk::vexDisplayRender(false, true),
+            }
+        }
     }
 
     /// Flushes the screens double buffer if it is enabled.

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -364,6 +364,11 @@ impl Screen {
         }
     }
 
+    /// Gets the [`RenderMode`] of the screen.
+    pub fn render_mode(&self) -> RenderMode {
+        self.render_mode
+    }
+
     /// Flushes the screens double buffer if it is enabled.
     /// This is a no-op with the [`Immediate`](RenderMode::Immediate) rendering mode,
     /// but is necessary for anything to be displayed on the screen when using the  [`DoubleBuffered`](RenderMode::DoubleBuffered) mode.

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -351,9 +351,14 @@ impl Screen {
         }}
     }
 
+    /// Flushes the screens double buffer if it is enabled.
+    /// This is a no-op with the [`Immediate`](RenderMode::Immediate) rendering mode,
+    /// but is necessary for anything to be displayed on the screen when using the  [`DoubleBuffered`](RenderMode::DoubleBuffered) mode.
     pub fn render(&mut self) {
-        unsafe {
-            vex_sdk::vexDisplayRender(false, false)
+        if let RenderMode::DoubleBuffered = self.render_mode {
+            unsafe {
+                vex_sdk::vexDisplayRender(false, false)
+            }
         }
     }
 

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -292,9 +292,18 @@ impl From<V5_TouchEvent> for TouchState {
     }
 }
 
+/// The rendering mode for the screen.
+/// When the screen is on the [`Immediate`](RenderMode::Immediate) mode, all draw calls will immediately show up on the display.
+/// The [`DoubleBuffered`](RenderMode::DoubleBuffered) mode instead pushes all draw calls onto an intermediate buffer
+/// that can be swapped onto the screen by calling [`Screen::render`].
+/// By default the screen uses the [`Immediate`](RenderMode::Immediate) mode.
+/// # Note
+/// [`Screen::render`] **MUST** be called for anything to appear on the screen when using the [`DoubleBuffered`](RenderMode::DoubleBuffered) mode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RenderMode {
+    /// Draw calls are immediately pushed to the screen.
     Immediate,
+    /// Draw calls are pushed to an intermediary buffer which can be pushed to the screen with [`Screen::render`].
     DoubleBuffered,
 }
 
@@ -343,6 +352,8 @@ impl Screen {
         self.writer_buffer.clear();
     }
 
+    /// Set the render mode for the screen.
+    /// For more info on render modes, look at the [`RenderMode`] docs.
     pub fn set_render_mode(&mut self, mode: RenderMode) {
         self.render_mode = mode;
         unsafe { match mode {
@@ -357,6 +368,7 @@ impl Screen {
     pub fn render(&mut self) {
         if let RenderMode::DoubleBuffered = self.render_mode {
             unsafe {
+                // TODO: create an async function that does the equivalent of bVsyncWait.
                 vex_sdk::vexDisplayRender(false, false)
             }
         }

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -302,8 +302,10 @@ impl From<V5_TouchEvent> for TouchState {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RenderMode {
     /// Draw calls are immediately pushed to the screen.
+    /// This mode is more convenient because you dont have to call [`Screen::render`] to see anything on the screen.
     Immediate,
     /// Draw calls are pushed to an intermediary buffer which can be pushed to the screen with [`Screen::render`].
+    /// This mode is useful for removing screen flicker when drawing at high speeds.
     DoubleBuffered,
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR adds support for double buffered screen rendering by adding a `RenderMode` enum and methods to set the screens render mode.
## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).

-->
