### PR TITLE
fix: remove critical-section feature

### DIFF
--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -29,14 +29,10 @@ snafu = { version = "0.8.0", default-features = false, features = [
 ] }
 talc = "4.3.1"
 lock_api = "0.4.11"
-critical-section = { version = "1.1.2", features = ["restore-state-bool"], optional = true }
+critical-section = { version = "1.1.2", features = ["restore-state-bool"] }
 bitflags = "2.4.2"
 futures-core = { version = "0.3.30", default-features = false, features = ["alloc"] }
 pin-project = "1.1.5"
-
-[features]
-default = ["critical-section"]
-critical-section = ["dep:critical-section"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dlmalloc = { version = "0.2.4", features = ["global"] }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR completely removes the `critical-section` feature from vexide-core because the critical-section implementation is necessary for vexide-core internally.
This PR fixes #32.
## Additional Context
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
