### PR TITLE
fix: get main macro working with only vexide as a dependency

### DIFF
--- a/packages/vexide-macro/Cargo.toml
+++ b/packages/vexide-macro/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "vexide-startup-macro"
+name = "vexide-macro"
 version = "0.1.0"
 edition = "2021"
 

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -60,21 +60,21 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     quote! {
         #[no_mangle]
         extern "Rust" fn main() {
-            let #peripherals_ident = ::vexide_devices::peripherals::Peripherals::take().unwrap();
+            let #peripherals_ident = ::vexide::devices::peripherals::Peripherals::take().unwrap();
 
-            ::vexide_async::block_on(async #block);
+            ::vexide::async_runtime::block_on(async #block);
         }
 
         #[no_mangle]
         #[link_section = ".boot"]
         unsafe extern "C" fn _entry() {
             unsafe {
-                ::vexide_startup::program_entry()
+                ::vexide::startup::program_entry()
             }
         }
 
         #[link_section = ".cold_magic"]
         #[used] // This is needed to prevent the linker from removing this object in release builds
-        static COLD_HEADER: ::vexide_startup::ColdHeader = ::vexide_startup::ColdHeader::new(2, 0, 0);
+        static COLD_HEADER: ::vexide::startup::ColdHeader = ::vexide::startup::ColdHeader::new(2, 0, 0);
     }.into()
 }

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 vex-sdk = "0.12.0"
-vexide-startup-macro = { path = "../vexide-startup-macro" }
 vexide-core = { version = "0.1.0", path = "../vexide-core"}
 vexide-async = { version = "0.1.0", path = "../vexide-async" }
 vexide-devices = { version = "0.1.0", path = "../vexide-devices" }

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -16,7 +16,6 @@
 use core::{arch::asm, ptr::addr_of_mut};
 
 use vexide_core::print;
-pub use vexide_startup_macro::main;
 
 extern "C" {
     // These symbols don't have real types so this is a little bit of a hack

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -25,10 +25,13 @@ vexide-panic = { version = "0.1.0", path = "../vexide-panic", optional = true }
 vexide-core = { version = "0.1.0", path = "../vexide-core", optional = true }
 vexide-math = { version = "0.1.0", path = "../vexide-math", optional = true }
 vexide-startup = { version = "0.1.0", path = "../vexide-startup", optional = true }
+vexide-macro = { version = "0.1.0", path = "../vexide-macro", optional = true }
 vex-sdk = "0.12.0"
 
 [features]
-default = ["async", "devices", "panic", "display_panics", "core", "math", "startup"]
+default = ["async", "devices", "panic", "display_panics", "core", "math", "startup", "macro"]
+
+macro = ["dep:vexide-macro", "startup", "async", "core", "devices"]
 
 core = ["dep:vexide-core"]
 startup = ["dep:vexide-startup"]

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -66,6 +66,13 @@ pub use vexide_devices as devices;
 pub use vexide_math as math;
 #[cfg(feature = "panic")]
 pub use vexide_panic as panic;
+#[cfg(feature = "macro")]
+pub use vexide_macro as r#macro;
+#[cfg(feature = "startup")]
+pub use vexide_startup as startup;
+
+#[cfg(feature = "macro")]
+pub use vexide_macro::main;
 
 /// Commonly used features of vexide.
 /// This module is meant to be glob imported.

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -62,17 +62,16 @@ pub use vexide_async as async_runtime;
 pub use vexide_core as core;
 #[cfg(feature = "devices")]
 pub use vexide_devices as devices;
+#[cfg(feature = "macro")]
+pub use vexide_macro as r#macro;
+#[cfg(feature = "macro")]
+pub use vexide_macro::main;
 #[cfg(feature = "math")]
 pub use vexide_math as math;
 #[cfg(feature = "panic")]
 pub use vexide_panic as panic;
-#[cfg(feature = "macro")]
-pub use vexide_macro as r#macro;
 #[cfg(feature = "startup")]
 pub use vexide_startup as startup;
-
-#[cfg(feature = "macro")]
-pub use vexide_macro::main;
 
 /// Commonly used features of vexide.
 /// This module is meant to be glob imported.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Moves the main proc macro attribute into a new crate `vexide-macro` which is a optional dependency of vexide. This also fixes the issue where you would have to add many crates to your dependencies to get the macro to work 
## Additional Context
- I have tested these changes on a VEX V5 brain.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- 
-->
