### PR TITLE
feat: support multiple main function return types with `vexide_core::program::Termination`

### DIFF
--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -11,11 +11,10 @@
 
 #![no_std]
 #![feature(error_in_core, never_type)]
-#![cfg_attr(feature = "critical-section", feature(asm_experimental_arch))]
+#![feature(asm_experimental_arch)]
 
 pub mod allocator;
 pub mod competition;
-#[cfg(feature = "critical-section")]
 pub mod critical_section;
 pub mod io;
 pub mod program;

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -10,7 +10,7 @@
 //! - FreeRTOS task management: [`task`]
 
 #![no_std]
-#![feature(error_in_core)]
+#![feature(error_in_core, never_type)]
 #![cfg_attr(feature = "critical-section", feature(asm_experimental_arch))]
 
 pub mod allocator;

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, FnArg, ItemFn, Pat, Signature, Type};
+use syn::{parse_macro_input, FnArg, ItemFn, Pat, Signature};
 
 fn verify_function_sig(sig: &Signature) -> Result<(), syn::Error> {
     let mut error = None;

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Type, FnArg, ItemFn, Pat, Signature};
+use syn::{parse_macro_input, FnArg, ItemFn, Pat, Signature, Type};
 
 fn verify_function_sig(sig: &Signature) -> Result<(), syn::Error> {
     let mut error = None;

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -62,7 +62,8 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         extern "Rust" fn main() {
             let #peripherals_ident = ::vexide::devices::peripherals::Peripherals::take().unwrap();
 
-            ::vexide::async_runtime::block_on(async #block);
+            let termination = ::vexide::async_runtime::block_on(async #block);
+            <termination as ::vexide::core::program::Termination>::report(termination);
         }
 
         #[no_mangle]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR adds the `vexide_core::program::Termination` trait and allows the main function to return it. It also fixes a broken cfg related to the critical-section implementation
## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
