### PR TITLE
fix(screen): flush before advancing lines

### DIFF
--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -15,6 +15,7 @@ use vex_sdk::{
     vexDisplayScrollRect, vexDisplaySmallStringAt, vexDisplayString, vexDisplayStringAt,
     vexTouchDataGet, V5_TouchEvent, V5_TouchStatus,
 };
+use vexide_core::{print, println};
 
 use crate::color::{IntoRgb, Rgb};
 
@@ -32,11 +33,11 @@ impl core::fmt::Write for Screen {
             if character == '\n' {
                 if self.current_line > (Self::MAX_VISIBLE_LINES as i16 - 2) {
                     self.scroll(0, Self::LINE_HEIGHT);
+                    self.flush_writer();
                 } else {
+                    self.flush_writer();
                     self.current_line += 1;
                 }
-
-                self.flush_writer();
             } else {
                 self.writer_buffer.push(character);
             }

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -15,7 +15,6 @@ use vex_sdk::{
     vexDisplayScrollRect, vexDisplaySmallStringAt, vexDisplayString, vexDisplayStringAt,
     vexTouchDataGet, V5_TouchEvent, V5_TouchStatus,
 };
-use vexide_core::{print, println};
 
 use crate::color::{IntoRgb, Rgb};
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This fixes an issue where all text would be drawn 1 line below where it was supposed to be, unless it did not end in "\n".

## Additional Context
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.

Test program:
```rs
#[vexide::main]
async fn main(peripherals: Peripherals) {
    let mut p = peripherals;
    writeln!(p.screen, "Hello, world.").unwrap();
    writeln!(p.screen, "Hello, world {:?}", 2).unwrap();
    loop {}
}
```
<!--
Move all applicable items out of the comment:
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
