### PR TITLE
fix: use correct bit for IRQ status flag

### DIFF
--- a/packages/vexide-core/src/critical_section.rs
+++ b/packages/vexide-core/src/critical_section.rs
@@ -7,26 +7,28 @@ critical_section::set_impl!(ZynqCriticalSection);
 
 unsafe impl critical_section::Impl for ZynqCriticalSection {
     unsafe fn acquire() -> critical_section::RawRestoreState {
-        let mut state: u32;
         unsafe {
-            asm!("
-                    // Save the current state
-                    mrs {0}, cpsr
-                    // Disable IRQs
-                    cpsid i
-                    // Synchronization barriers
-                    dsb
-                    isb
-                ",
-                out(reg) state
-            )
+            let mut cpsr: u32;
+            asm!("mrs {0}, cpsr", out(reg) cpsr);
+            let masked = (cpsr & 0b10000000) == 0b10000000;
+
+            asm!(
+                "
+                // Disable IRQs
+                cpsid i
+                // Synchronization barriers
+                dsb
+                isb
+                "
+            );
+
+            masked
         }
-        (state & 0b1000000) == 0b1000000
     }
 
-    unsafe fn release(restore_state: critical_section::RawRestoreState) {
+    unsafe fn release(masked: critical_section::RawRestoreState) {
         // Don't enable IRQs if we are in a nested critical section
-        if restore_state {
+        if !masked {
             unsafe {
                 asm!(
                     "


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This fixes an issue where the critical-section implementation was looking at the wrong bit in CPSR as well as the release function not enabling interrupts at the correct time. 
## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
