### PR TITLE
fix: competition API while disconnected

### DIFF
--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -236,7 +236,7 @@ pub struct Competition<
     _pin: PhantomPinned,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompetitionRuntimePhase {
     Initial,
     Disconnected,
@@ -270,14 +270,17 @@ where
             Poll::Ready(Some(new_status)) => {
                 let old_status = *this.status;
 
-                // Decide which phase we're in based on the status update.
-                *this.phase = if !old_status.is_connected() && new_status.is_connected() {
-                    CompetitionRuntimePhase::Connected
-                } else if old_status.is_connected() && !new_status.is_connected() {
-                    CompetitionRuntimePhase::Disconnected
-                } else {
-                    CompetitionRuntimePhase::Mode(new_status.mode())
-                };
+                // Connected and Disconnected should not be interrupted by other changes.
+                if *this.phase != CompetitionRuntimePhase::Connected && *this.phase != CompetitionRuntimePhase::Disconnected {
+                    // Decide which phase we're in based on the status update.
+                    *this.phase = if !old_status.is_connected() && new_status.is_connected() {
+                        CompetitionRuntimePhase::Connected
+                    } else if old_status.is_connected() && !new_status.is_connected() {
+                        CompetitionRuntimePhase::Disconnected
+                    } else {
+                        CompetitionRuntimePhase::Mode(new_status.mode())
+                    };
+                }
 
                 *this.status = new_status;
             }

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -271,7 +271,9 @@ where
                 let old_status = *this.status;
 
                 // Connected and Disconnected should not be interrupted by other changes.
-                if *this.phase != CompetitionRuntimePhase::Connected && *this.phase != CompetitionRuntimePhase::Disconnected {
+                if *this.phase != CompetitionRuntimePhase::Connected
+                    && *this.phase != CompetitionRuntimePhase::Disconnected
+                {
                     // Decide which phase we're in based on the status update.
                     *this.phase = if !old_status.is_connected() && new_status.is_connected() {
                         CompetitionRuntimePhase::Connected


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Refactors the way that competition tasks are created to support running in driver mode while not connected to a competition controller.

## Additional Context
Closes #29