### PR TITLE
fix: implement `Send` and `Sync` for smart devices

### DIFF
--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -20,7 +20,7 @@ pub struct DistanceSensor {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for DistanceSensor {}
 unsafe impl Sync for DistanceSensor {}
 

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -19,6 +19,11 @@ pub struct DistanceSensor {
     device: V5_DeviceT,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for DistanceSensor {}
+unsafe impl Sync for DistanceSensor {}
+
 impl DistanceSensor {
     /// Create a new distance sensor from a smart port index.
     pub fn new(port: SmartPort) -> Self {

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -29,6 +29,11 @@ pub struct InertialSensor {
     heading_offset: f64,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for InertialSensor {}
+unsafe impl Sync for InertialSensor {}
+
 impl InertialSensor {
     /// The time limit used by the PROS kernel for bailing out of calibration. In theory, this
     /// could be as low as 2s, but is kept at 3s for margin-of-error.

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -30,7 +30,7 @@ pub struct InertialSensor {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for InertialSensor {}
 unsafe impl Sync for InertialSensor {}
 

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -26,7 +26,7 @@ pub struct RadioLink {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for RadioLink {}
 unsafe impl Sync for RadioLink {}
 

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -25,6 +25,11 @@ pub struct RadioLink {
     device: V5_DeviceT,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for RadioLink {}
+unsafe impl Sync for RadioLink {}
+
 impl RadioLink {
     /// Opens a radio link from a VEXNet radio plugged into a smart port. Once
     /// opened, other VEXNet functionality such as controller tethering on this

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -31,7 +31,7 @@ pub struct Motor {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for Motor {}
 unsafe impl Sync for Motor {}
 

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -30,6 +30,11 @@ pub struct Motor {
     device: V5_DeviceT,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for Motor {}
+unsafe impl Sync for Motor {}
+
 /// Represents a possible target for a [`Motor`].
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MotorControl {

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -21,6 +21,11 @@ pub struct OpticalSensor {
     device: V5_DeviceT,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for OpticalSensor {}
+unsafe impl Sync for OpticalSensor {}
+
 impl OpticalSensor {
     /// The smallest integration time you can set on an optical sensor.
     ///

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -22,7 +22,7 @@ pub struct OpticalSensor {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for OpticalSensor {}
 unsafe impl Sync for OpticalSensor {}
 

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -31,6 +31,11 @@ pub struct RotationSensor {
     raw_direction_offset: i32,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for RotationSensor {}
+unsafe impl Sync for RotationSensor {}
+
 impl RotationSensor {
     /// The minimum data rate that you can set a rotation sensor to.
     pub const MIN_DATA_RATE: Duration = Duration::from_millis(5);

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -32,7 +32,7 @@ pub struct RotationSensor {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for RotationSensor {}
 unsafe impl Sync for RotationSensor {}
 

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -22,7 +22,7 @@ pub struct SerialPort {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for SerialPort {}
 unsafe impl Sync for SerialPort {}
 

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -21,6 +21,11 @@ pub struct SerialPort {
     device: V5_DeviceT,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for SerialPort {}
+unsafe impl Sync for SerialPort {}
+
 impl SerialPort {
     /// The maximum allowed baud rate that generic serial can be configured to
     /// use by user programs.

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -51,7 +51,7 @@ pub struct VisionSensor {
 }
 
 // SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
-// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+// SDK each device function. Simply sharing a raw pointer across threads is not inherently unsafe.
 unsafe impl Send for VisionSensor {}
 unsafe impl Sync for VisionSensor {}
 

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -50,6 +50,11 @@ pub struct VisionSensor {
     device: V5_DeviceT,
 }
 
+// SAFETY: Required because we store a raw pointer to the device handle to avoid it getting from the
+// SDK each device function. Simply sharing a raw pointer across threads is not inherent unsafe.
+unsafe impl Send for VisionSensor {}
+unsafe impl Sync for VisionSensor {}
+
 impl VisionSensor {
     /// The horizontal resolution of the vision sensor.
     ///


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Smart devices are currently not `Send` or `Sync`, which makes them not shareable between async tasks. This is because we store a raw device handle `V5_DeviceT` for convenience when interacting with the SDK. Sending raw pointers across threads isn't inherently unsound, and the lack of `Send + Sync` on raw pointers exists more as a lint.
