### PR TITLE
fix: rust-analyzer LSP from zed

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,15 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "check": {
+          "allTargets": false,
+          "targets": [
+            "../armv7a-vexos-eabi.json",
+            "wasm32-unknown-unknown"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Adds the necessary configuration files to get rust-analyzer LSP working on the [zed editor](https://zed.dev/). This is analgous to `.vscode/settings.json`.