### PR TITLE
docs: update advantages over PROS to eliminate duplicate and inaccurate points

### DIFF
--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -6,8 +6,6 @@
 //! Advantages over similar libraries like PROS include:
 //! - vexide is a real crate on crates.io instead of a template, or similar. This allows for dependency management with cargo.
 //! - vexide has an [`Async executor`](async_runtime) which allows for easy and performant asynchronous code.
-//! - Active development. vexide is actively developed and maintained.
-//! - vexide is a real crate on crates.io instead of a template, or similar. This allows for dependency management with cargo.
 //! - vexide has no external dependencies. It's 100% Rust and every line of code is yours to see.
 //! - vexide produces tiny and fast binaries.
 //!


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Minor fixes in lib.rs docs to remove some inaccurate/duplicated advantages over PROS.
* PROS is also actively developed, so that is not an advantage here
* vexide being a crate was mentioned twice

## Additional Context

- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
