### PR TITLE
fix(controller): use correct axes for left and right sticks

### DIFF
--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -250,13 +250,13 @@ impl Controller {
             screen: ControllerScreen { id },
             left_stick: Joystick {
                 id,
-                x_channel: V5_ControllerIndex::Axis1,
-                y_channel: V5_ControllerIndex::Axis2,
+                x_channel: V5_ControllerIndex::Axis3,
+                y_channel: V5_ControllerIndex::Axis4,
             },
             right_stick: Joystick {
                 id,
-                x_channel: V5_ControllerIndex::Axis3,
-                y_channel: V5_ControllerIndex::Axis4,
+                x_channel: V5_ControllerIndex::Axis2,
+                y_channel: V5_ControllerIndex::Axis1,
             },
             button_a: Button {
                 id,

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -250,13 +250,13 @@ impl Controller {
             screen: ControllerScreen { id },
             left_stick: Joystick {
                 id,
-                x_channel: V5_ControllerIndex::Axis3,
-                y_channel: V5_ControllerIndex::Axis4,
+                x_channel: V5_ControllerIndex::Axis4,
+                y_channel: V5_ControllerIndex::Axis3,
             },
             right_stick: Joystick {
                 id,
-                x_channel: V5_ControllerIndex::Axis2,
-                y_channel: V5_ControllerIndex::Axis1,
+                x_channel: V5_ControllerIndex::Axis1,
+                y_channel: V5_ControllerIndex::Axis2,
             },
             button_a: Button {
                 id,


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR updates the controller struct to use the correct axes so that the correct values will be returned when calling Joystick methods.

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
