### PR TITLE
feat: add ticks per revolution constant to `AdiEncoder`

### DIFF
--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -14,6 +14,9 @@ pub struct AdiEncoder {
 }
 
 impl AdiEncoder {
+    /// Number of encoder ticks (unique sensor readings) per revolution for the encoder.
+    pub const TICKS_PER_REVOLUTION: u32 = 360;
+
     /// Create a new encoder sensor from a top and bottom [`AdiPort`].
     pub fn new(ports: (AdiPort, AdiPort)) -> Result<Self, EncoderError> {
         let top_port = ports.0;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Brings it inline with other devices returning `Position`.