### PR TITLE
docs: bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Before releasing:
 
 ### Fixed
 
-- Removed unintentional re-exports from `vexide-core` program module.
+- Removed unintentional re-exports from `vexide-core` program module. (**Breaking Change**)
 - Fixed vision panicking after getting garbage data from vex-sdk.
 - Corrected incorrect axis getters in the `Controller` API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,23 @@ Before releasing:
 
 ### New Contributors
 
-[unreleased]: https://github.com/vexide/vexide/compare/HEAD...HEAD
+## [0.2.0]
+
+### Added
+
+- Added `TICKS_PER_ROTATION` constant to `AdiEncoder` for use with `Position`.
+
+### Fixed
+
+- Removed unintentional re-exports from `vexide-core` program module.
+- Fixed vision panicking after getting garbage data from vex-sdk.
+- Corrected incorrect axis getters in the `Controller` API.
+
+### Changed
+
+### Removed
+
+### New Contributors
+
+[unreleased]: https://github.com/vexide/vexide/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...HEAD

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-async"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "The async executor at the core of vexide"
@@ -22,7 +22,7 @@ authors = [
 
 [dependencies]
 async-task = { version = "4.5.0", default-features = false }
-vexide-core = { version = "0.1.0", path = "../vexide-core" }
+vexide-core = { version = "0.2.0", path = "../vexide-core" }
 waker-fn = "1.1.1"
 vex-sdk = "0.14.0"
 critical-section = { version = "1.1.2", features = ["restore-state-bool"] }

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Core functionality for vexide"

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-devices"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "High level device bindings for vexide"
@@ -21,7 +21,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vexide-core = { version = "0.1.0", path = "../vexide-core" }
+vexide-core = { version = "0.2.0", path = "../vexide-core" }
 vex-sdk = "0.14.0"
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-graphics"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Graphics driver implementations for vexide"
@@ -17,9 +17,9 @@ repository = "https://github.com/vexide/vexide"
 embedded-graphics-core = { version = "0.4.0", optional = true }
 slint = { version = "1.5.1", default-features = false, optional = true, features = ["compat-1-2", "unsafe-single-threaded", "libm", "renderer-software"] }
 vex-sdk = "0.14.0"
-vexide-async = { version = "0.1.0", path = "../vexide-async" }
-vexide-core = { version = "0.1.0", path = "../vexide-core" }
-vexide-devices = { version = "0.1.0", path = "../vexide-devices" }
+vexide-async = { version = "0.1.1", path = "../vexide-async" }
+vexide-core = { version = "0.2.0", path = "../vexide-core" }
+vexide-devices = { version = "0.2.0", path = "../vexide-devices" }
 
 [lints]
 workspace = true

--- a/packages/vexide-math/Cargo.toml
+++ b/packages/vexide-math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-math"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Commonly used mathematical formulas for vexide"
@@ -20,7 +20,7 @@ authors = [
 
 [dependencies]
 num = { version = "0.4.1", default-features = false }
-vexide-core = { version = "0.1.0", path = "../vexide-core" }
+vexide-core = { version = "0.2.0", path = "../vexide-core" }
 
 [lints]
 workspace = true

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-panic"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Panic handler for vexide"
@@ -20,8 +20,8 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vexide-core = { version = "0.1.0", path = "../vexide-core" }
-vexide-devices = { version = "0.1.0", path = "../vexide-devices", optional = true }
+vexide-core = { version = "0.2.0", path = "../vexide-core" }
+vexide-devices = { version = "0.2.0", path = "../vexide-devices", optional = true }
 vex-sdk = "0.14.0"
 
 [features]

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-startup"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 description = "Support code for V5 Brain user program booting"
@@ -19,9 +19,9 @@ authors = [
 
 [dependencies]
 vex-sdk = "0.14.0"
-vexide-core = { version = "0.1.0", path = "../vexide-core"}
-vexide-async = { version = "0.1.0", path = "../vexide-async" }
-vexide-devices = { version = "0.1.0", path = "../vexide-devices" }
+vexide-core = { version = "0.2.0", path = "../vexide-core"}
+vexide-async = { version = "0.1.1", path = "../vexide-async" }
+vexide-devices = { version = "0.2.0", path = "../vexide-devices" }
 
 [lints]
 workspace = true

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "async/await powered Rust library for VEX V5 Brains"
 keywords = ["Robotics", "bindings", "vex", "v5"]
@@ -19,13 +19,13 @@ rust-version = "1.75.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vexide-async = { version = "0.1.0", path = "../vexide-async", optional = true }
-vexide-devices = { version = "0.1.0", path = "../vexide-devices", optional = true }
-vexide-panic = { version = "0.1.0", path = "../vexide-panic", optional = true }
-vexide-core = { version = "0.1.0", path = "../vexide-core", optional = true }
-vexide-math = { version = "0.1.0", path = "../vexide-math", optional = true }
-vexide-startup = { version = "0.1.0", path = "../vexide-startup", optional = true }
-vexide-graphics = { version = "0.1.0", path = "../vexide-graphics", optional = true }
+vexide-async = { version = "0.1.1", path = "../vexide-async", optional = true }
+vexide-devices = { version = "0.2.0", path = "../vexide-devices", optional = true }
+vexide-panic = { version = "0.1.1", path = "../vexide-panic", optional = true }
+vexide-core = { version = "0.2.0", path = "../vexide-core", optional = true }
+vexide-math = { version = "0.1.1", path = "../vexide-math", optional = true }
+vexide-startup = { version = "0.1.1", path = "../vexide-startup", optional = true }
+vexide-graphics = { version = "0.1.1", path = "../vexide-graphics", optional = true }
 vexide-macro = { version = "0.1.0", path = "../vexide-macro", optional = true }
 vex-sdk = "0.14.0"
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR bumps vexide to version 0.2.0
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).

- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
