### PR TITLE
fix: correctly place .boot after the cold header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,20 @@ Before releasing:
 
 ### New Contributors
 
+## [0.2.1]
+
+### Added
+
+### Fixed
+
+- Fixed debug builds causing data aborts. (#67)
+
+### Changed
+
+### Removed
+
+### New Contributors
+
 ## [0.2.0]
 
 ### Added
@@ -49,5 +63,6 @@ Before releasing:
 
 ### New Contributors
 
-[unreleased]: https://github.com/vexide/vexide/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/vexide/vexide/compare/v0.2.1...HEAD
+[0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...v0.2.0
+[0.2.1]: https://github.com/vexide/vexide/compare/v0.2.0...v0.2.1

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-startup"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 description = "Support code for V5 Brain user program booting"

--- a/packages/vexide-startup/link/v5.ld
+++ b/packages/vexide-startup/link/v5.ld
@@ -19,9 +19,10 @@ __heap_end = __cold_end - __stack_length - 0x100;
 
 SECTIONS {
     .text : {
+        __text_start = .;
         KEEP(*(.cold_magic))
         /* Size of cold header */
-        . += 0x20;
+        . = __text_start + 0x20;
         *(.boot)
         *(.text .text.*)
     } > COLD

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "async/await powered Rust library for VEX V5 Brains"
 keywords = ["Robotics", "bindings", "vex", "v5"]
@@ -24,7 +24,7 @@ vexide-devices = { version = "0.2.0", path = "../vexide-devices", optional = tru
 vexide-panic = { version = "0.1.1", path = "../vexide-panic", optional = true }
 vexide-core = { version = "0.2.0", path = "../vexide-core", optional = true }
 vexide-math = { version = "0.1.1", path = "../vexide-math", optional = true }
-vexide-startup = { version = "0.1.1", path = "../vexide-startup", optional = true }
+vexide-startup = { version = "0.1.2", path = "../vexide-startup", optional = true }
 vexide-graphics = { version = "0.1.1", path = "../vexide-graphics", optional = true }
 vexide-macro = { version = "0.1.0", path = "../vexide-macro", optional = true }
 vex-sdk = "0.14.0"


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR fixes and issue with the linker script that misplaced the .boot section. Somehow this caused release builds to function and debug builds to fail.
## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
