### PR TITLE
fix(macro): wrap original function instead of re-writing

### DIFF
--- a/packages/vexide-macro/Cargo.toml
+++ b/packages/vexide-macro/Cargo.toml
@@ -14,6 +14,7 @@ authors = [
 repository = "https://github.com/vexide/vexide"
 
 [dependencies]
+proc-macro2 = "1.0.84"
 quote = "1.0.35"
 syn = { version = "^2.0.57", features = ["full"] }
 

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -1,16 +1,20 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, FnArg, ItemFn, Pat, Signature};
+use syn::{parse_macro_input, ItemFn, Signature};
+
+const NO_SYNC_ERR: &str = "The vexide entrypoint must be marked `async`.";
+const NO_UNSAFE_ERR: &str = "The vexide entrypoint must be not marked `unsafe`.";
+const WRONG_ARGS_ERR: &str = "The vexide entrypoint must take a single parameter of type `vexide_devices::peripherals::Peripherals`";
 
 fn verify_function_sig(sig: &Signature) -> Result<(), syn::Error> {
     let mut error = None;
 
     if sig.asyncness.is_none() {
-        let message = syn::Error::new_spanned(sig, "Function must be async");
+        let message = syn::Error::new_spanned(sig, NO_SYNC_ERR);
         error.replace(message);
     }
     if sig.unsafety.is_some() {
-        let message = syn::Error::new_spanned(sig, "Function must be safe");
+        let message = syn::Error::new_spanned(sig, NO_UNSAFE_ERR);
         match error {
             Some(ref mut e) => e.combine(message),
             None => {
@@ -19,10 +23,7 @@ fn verify_function_sig(sig: &Signature) -> Result<(), syn::Error> {
         };
     }
     if sig.inputs.len() != 1 {
-        let message = syn::Error::new_spanned(
-            sig,
-            "Function must take a `vexide_devices::peripherals::Peripherals`",
-        );
+        let message = syn::Error::new_spanned(sig, WRONG_ARGS_ERR);
         match error {
             Some(ref mut e) => e.combine(message),
             None => {
@@ -37,38 +38,36 @@ fn verify_function_sig(sig: &Signature) -> Result<(), syn::Error> {
     }
 }
 
-#[proc_macro_attribute]
-pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    let item = parse_macro_input!(item as ItemFn);
-    match verify_function_sig(&item.sig) {
+fn create_main_wrapper(inner: ItemFn) -> proc_macro2::TokenStream {
+    match verify_function_sig(&inner.sig) {
         Ok(_) => {}
-        Err(e) => return e.to_compile_error().into(),
+        Err(e) => return e.to_compile_error(),
     }
-    let err = syn::Error::new_spanned(&item.sig, "Function must take a `Peripherals`")
-        .to_compile_error()
-        .into();
-    let FnArg::Typed(peripherals_arg) = item.sig.inputs.first().unwrap() else {
-        return err;
-    };
-    let Pat::Ident(ref peripherals_pat) = *peripherals_arg.pat else {
-        return err;
-    };
-    let peripherals_ident = &peripherals_pat.ident;
-    let ret_type = match &item.sig.output {
+    let inner_ident = inner.sig.ident.clone();
+    let ret_type = match &inner.sig.output {
         syn::ReturnType::Default => quote! { () },
         syn::ReturnType::Type(_, ty) => quote! { #ty },
     };
 
-    let block = item.block;
-
     quote! {
         #[no_mangle]
         extern "Rust" fn main() {
-            let #peripherals_ident = ::vexide::devices::peripherals::Peripherals::take().unwrap();
-
-            let termination: #ret_type = ::vexide::async_runtime::block_on(async #block);
+            #inner
+            let termination: #ret_type = ::vexide::async_runtime::block_on(
+                #inner_ident(::vexide::devices::peripherals::Peripherals::take().unwrap())
+            );
             ::vexide::core::program::Termination::report(termination);
         }
+    }
+}
+
+#[proc_macro_attribute]
+pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item = parse_macro_input!(item as ItemFn);
+    let main_fn = create_main_wrapper(item);
+
+    quote! {
+        #main_fn
 
         #[no_mangle]
         #[link_section = ".boot"]
@@ -82,4 +81,84 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[used] // This is needed to prevent the linker from removing this object in release builds
         static COLD_HEADER: ::vexide::startup::ColdHeader = ::vexide::startup::ColdHeader::new(2, 0, 0);
     }.into()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn wraps_main_fn() {
+        let source = quote! {
+            async fn main(_peripherals: Peripherals) {
+                println!("Hello, world!");
+            }
+        };
+        let input = syn::parse2::<ItemFn>(source).unwrap();
+        let output = create_main_wrapper(input);
+        assert_eq!(
+            output.to_string(),
+            quote! {
+                #[no_mangle]
+                extern "Rust" fn main() {
+                    async fn main(_peripherals: Peripherals) {
+                        println!("Hello, world!");
+                    }
+                    let termination: () = ::vexide::async_runtime::block_on(
+                        main(::vexide::devices::peripherals::Peripherals::take().unwrap())
+                    );
+                    ::vexide::core::program::Termination::report(termination);
+                }
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn requires_async() {
+        let source = quote! {
+            fn main(_peripherals: Peripherals) {
+                println!("Hello, world!");
+            }
+        };
+        let input = syn::parse2::<ItemFn>(source).unwrap();
+        let output = create_main_wrapper(input);
+        assert!(output.to_string().contains(NO_SYNC_ERR));
+    }
+
+    #[test]
+    fn requires_safe() {
+        let source = quote! {
+            async unsafe fn main(_peripherals: Peripherals) {
+                println!("Hello, world!");
+            }
+        };
+        let input = syn::parse2::<ItemFn>(source).unwrap();
+        let output = create_main_wrapper(input);
+        assert!(output.to_string().contains(NO_UNSAFE_ERR));
+    }
+
+    #[test]
+    fn disallows_0_args() {
+        let source = quote! {
+            async fn main() {
+                println!("Hello, world!");
+            }
+        };
+        let input = syn::parse2::<ItemFn>(source).unwrap();
+        let output = create_main_wrapper(input);
+        assert!(output.to_string().contains(WRONG_ARGS_ERR));
+    }
+
+    #[test]
+    fn disallows_2_args() {
+        let source = quote! {
+            async fn main(_peripherals: Peripherals, _other: Peripherals) {
+                println!("Hello, world!");
+            }
+        };
+        let input = syn::parse2::<ItemFn>(source).unwrap();
+        let output = create_main_wrapper(input);
+        assert!(output.to_string().contains(WRONG_ARGS_ERR));
+    }
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR updates the vexide-macro crate's codegen to wrap the original function rather than rewriting it. This fixes #74 and simplifies some of the logic for code generation. It also adds some related tests to the crate.

## Additional Context

- I have tested these changes on a VEX V5 brain.
- See also: #74's example program
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
