### PR TITLE
feat: add text metrics getter

### DIFF
--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -276,7 +276,7 @@ impl Text {
     }
 
     /// Get the height of the text widget in pixels
-    pub fn height(&self) -> i32 {
+    pub fn height(&self) -> u16 {
         unsafe {
             // Display blank string(no-op function) to set last used text size
             // vexDisplayString(Height/Width)Get uses the last text size to determine text size
@@ -292,12 +292,12 @@ impl Text {
                 }
             }
 
-            vexDisplayStringHeightGet(self.text.as_ptr())
+            vexDisplayStringHeightGet(self.text.as_ptr()) as _
         }
     }
 
     /// Get the width of the text widget in pixels
-    pub fn width(&self) -> i32 {
+    pub fn width(&self) -> u16 {
         unsafe {
             match self.size {
                 // Display blank string(no-op function) to set last used text size
@@ -313,7 +313,7 @@ impl Text {
                 }
             }
 
-            vexDisplayStringWidthGet(self.text.as_ptr())
+            vexDisplayStringWidthGet(self.text.as_ptr()) as _
         }
     }
 }

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -5,7 +5,7 @@
 //! and the [`Stroke`] trait can be used to draw the outlines of shapes.
 
 use alloc::{ffi::CString, string::String, vec::Vec};
-use core::{ffi::VaList, mem, time::Duration};
+use core::{mem, time::Duration};
 
 use snafu::Snafu;
 use vex_sdk::{
@@ -13,8 +13,8 @@ use vex_sdk::{
     vexDisplayCopyRect, vexDisplayErase, vexDisplayForegroundColor, vexDisplayLineDraw,
     vexDisplayPixelSet, vexDisplayRectDraw, vexDisplayRectFill, vexDisplayScroll,
     vexDisplayScrollRect, vexDisplaySmallStringAt, vexDisplayString, vexDisplayStringAt,
-    vexDisplayStringHeightGet, vexDisplayStringWidthGet, vexDisplayVBigStringAt,
-    vexDisplayVSmallStringAt, vexDisplayVStringAt, vexTouchDataGet, V5_TouchEvent, V5_TouchStatus,
+    vexDisplayStringHeightGet, vexDisplayStringWidthGet, vexTouchDataGet, V5_TouchEvent,
+    V5_TouchStatus,
 };
 
 use crate::{color::IntoRgb, geometry::Point2};

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -5,7 +5,7 @@
 //! and the [`Stroke`] trait can be used to draw the outlines of shapes.
 
 use alloc::{ffi::CString, string::String, vec::Vec};
-use core::{mem, time::Duration};
+use core::{ffi::VaList, mem, time::Duration};
 
 use snafu::Snafu;
 use vex_sdk::{
@@ -13,7 +13,8 @@ use vex_sdk::{
     vexDisplayCopyRect, vexDisplayErase, vexDisplayForegroundColor, vexDisplayLineDraw,
     vexDisplayPixelSet, vexDisplayRectDraw, vexDisplayRectFill, vexDisplayScroll,
     vexDisplayScrollRect, vexDisplaySmallStringAt, vexDisplayString, vexDisplayStringAt,
-    vexTouchDataGet, V5_TouchEvent, V5_TouchStatus,
+    vexDisplayStringHeightGet, vexDisplayStringWidthGet, vexDisplayVBigStringAt,
+    vexDisplayVSmallStringAt, vexDisplayVStringAt, vexTouchDataGet, V5_TouchEvent, V5_TouchStatus,
 };
 
 use crate::{color::IntoRgb, geometry::Point2};
@@ -271,6 +272,42 @@ impl Text {
                 .expect("CString::new encountered NUL (U+0000) byte in non-terminating position."),
             position: position.into(),
             size,
+        }
+    }
+
+    pub fn height(&self) -> i32 {
+        unsafe {
+            match self.size {
+                TextSize::Small => {
+                    vexDisplaySmallStringAt(0, 0, c"".as_ptr());
+                }
+                TextSize::Medium => {
+                    vexDisplayStringAt(0, 0, c"".as_ptr());
+                }
+                TextSize::Large => {
+                    vexDisplayBigStringAt(0, 0, c"".as_ptr());
+                }
+            }
+
+            vexDisplayStringHeightGet(self.text.as_ptr())
+        }
+    }
+
+    pub fn width(&self) -> i32 {
+        unsafe {
+            match self.size {
+                TextSize::Small => {
+                    vexDisplaySmallStringAt(0, 0, c"".as_ptr());
+                }
+                TextSize::Medium => {
+                    vexDisplayStringAt(0, 0, c"".as_ptr());
+                }
+                TextSize::Large => {
+                    vexDisplayBigStringAt(0, 0, c"".as_ptr());
+                }
+            }
+
+            vexDisplayStringWidthGet(self.text.as_ptr())
         }
     }
 }

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -275,8 +275,11 @@ impl Text {
         }
     }
 
+    /// Get the height of the text widget in pixels
     pub fn height(&self) -> i32 {
         unsafe {
+            // Display blank string(no-op function) to set last used text size
+            // vexDisplayString(Height/Width)Get uses the last text size to determine text size
             match self.size {
                 TextSize::Small => {
                     vexDisplaySmallStringAt(0, 0, c"".as_ptr());
@@ -293,9 +296,12 @@ impl Text {
         }
     }
 
+    /// Get the width of the text widget in pixels
     pub fn width(&self) -> i32 {
         unsafe {
             match self.size {
+                // Display blank string(no-op function) to set last used text size
+                // vexDisplayString(Height/Width)Get uses the last text size to determine text size
                 TextSize::Small => {
                     vexDisplaySmallStringAt(0, 0, c"".as_ptr());
                 }


### PR DESCRIPTION
This PR adds metrics getters for text widgets using the vexDisplayString(Width/Height)Get

I haven't tested these changes, but @doinkythederp tested it and it worked