### PR TITLE
feat: Add text alignment to Text widget

### DIFF
--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -5,7 +5,7 @@
 //! and the [`Stroke`] trait can be used to draw the outlines of shapes.
 
 use alloc::{ffi::CString, string::String, vec::Vec};
-use core::{default, mem, time::Duration};
+use core::{mem, time::Duration};
 
 use snafu::Snafu;
 use vex_sdk::{
@@ -367,21 +367,18 @@ impl Text {
 
 impl Fill for Text {
     fn fill(&self, _screen: &mut Screen, color: impl IntoRgb) {
-        let width = self.width();
-        let height = self.height();
-
         // Horizontally align text
         let x = match self.horizontal_align {
             HAlign::Left => self.position.x,
-            HAlign::Center => self.position.x - (width / 2) as i16,
-            HAlign::Right => self.position.x - width as i16,
+            HAlign::Center => self.position.x - (self.width() / 2) as i16,
+            HAlign::Right => self.position.x - self.width() as i16,
         };
 
         // Vertically align text
         let y = match self.vertical_align {
             VAlign::Top => self.position.y,
-            VAlign::Center => self.position.y - (height / 2) as i16,
-            VAlign::Bottom => self.position.y - height as i16,
+            VAlign::Center => self.position.y - (self.height() / 2) as i16,
+            VAlign::Bottom => self.position.y - self.height() as i16,
         };
 
         // This implementation is technically broken because it doesn't account errno.

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -5,7 +5,7 @@
 //! and the [`Stroke`] trait can be used to draw the outlines of shapes.
 
 use alloc::{ffi::CString, string::String, vec::Vec};
-use core::{mem, time::Duration};
+use core::{default, mem, time::Duration};
 
 use snafu::Snafu;
 use vex_sdk::{
@@ -254,9 +254,10 @@ pub enum TextSize {
 }
 
 /// Horizontal alignment for text on the screen
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum HAlign {
-    /// Input coordinate is at the left of the text box; default for text displaying
+    /// Input coordinate is at the left of the text box
+    #[default]
     Left,
     /// Input coordinate is at the center of the text box
     Center,
@@ -265,9 +266,10 @@ pub enum HAlign {
 }
 
 /// Vertical alignment for text on the screen
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub enum VAlign {
-    /// Input coordinate is at the top of the text box; default for text displaying
+    /// Input coordinate is at the top of the text box
+    #[default]
     Top,
     /// Input coordinate is at the center of the text box
     Center,
@@ -291,16 +293,9 @@ pub struct Text {
 }
 
 impl Text {
-    /// Create a new text with a given position(top left corner) and format
+    /// Create a new text with a given position(defaults to top left corner alignment) and format
     pub fn new(text: &str, size: TextSize, position: impl Into<Point2<i16>>) -> Self {
-        Self {
-            text: CString::new(text)
-                .expect("CString::new encountered NUL (U+0000) byte in non-terminating position."),
-            position: position.into(),
-            size,
-            horizontal_align: HAlign::Left,
-            vertical_align: VAlign::Top,
-        }
+        Self::new_aligned(text, size, position, HAlign::default(), VAlign::default())
     }
 
     /// Create a new text with a given position(based on alignment) and format


### PR DESCRIPTION
This pr adds a text alignment feature to Text widgets using the .width and .height methods

Can't test this today, but I can tomorrow
