### PR TITLE
refactor: rename `Competition` trait to `Compete`

### DIFF
--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -559,7 +559,7 @@ impl<Shared, MkConnected, MkDisconnected, MkDisabled, MkAutonomous>
 
 /// A set of tasks to run when the competition is in a particular mode.
 #[allow(async_fn_in_trait)]
-pub trait Competition: Sized {
+pub trait Compete: Sized {
     /// Runs when the competition system is connected.
     ///
     /// See [`CompetitionBuilder::on_connect`] for more information.
@@ -588,7 +588,7 @@ pub trait Competition: Sized {
 
 /// Extension methods for [`Competition`].
 /// Automatically implemented for any type implementing [`Competition`].
-pub trait CompetitionExt: Competition {
+pub trait CompeteExt: Compete {
     /// Build a competition runtime that competes with this robot.
     fn compete(
         self,
@@ -610,4 +610,4 @@ pub trait CompetitionExt: Competition {
     }
 }
 
-impl<R: Competition> CompetitionExt for R {}
+impl<R: Compete> CompeteExt for R {}

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -226,7 +226,7 @@ pub struct CompetitionRuntime<
     ///         during task creation.
     shared: UnsafeCell<Shared>,
 
-    /// Keep `self.current` in place while `self.current` references it.
+    /// Keep `self.shared` in place while `self.task` references it.
     _pin: PhantomPinned,
 }
 

--- a/packages/vexide/examples/clawbot.rs
+++ b/packages/vexide/examples/clawbot.rs
@@ -25,7 +25,7 @@ struct ClawBot {
     controller: Controller,
 }
 
-impl Competition for ClawBot {
+impl Compete for ClawBot {
     async fn autonomous(&mut self) {
         // Basic example autonomous that moves the drivetrain 10 revolutions forwards.
         self.left_motor

--- a/packages/vexide/examples/competition.rs
+++ b/packages/vexide/examples/competition.rs
@@ -7,7 +7,7 @@ use vexide::prelude::*;
 
 struct Robot;
 
-impl Competition for Robot {
+impl Compete for Robot {
     async fn connected(&mut self) {
         println!("Connected");
     }

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -50,7 +50,7 @@ pub mod prelude {
     };
     #[cfg(feature = "core")]
     pub use vexide_core::{
-        competition::{Competition, CompetitionExt, CompetitionRuntime},
+        competition::{Compete, CompeteExt, CompetitionRuntime},
         dbg,
         float::Float,
         io::{BufRead, Read, Seek, Write},


### PR DESCRIPTION
- **docs: fix erroneous comment on `CompetitionRuntime._pin`**
- **refactor(competition): rename `Competition` to `Compete`**

## Describe the changes this PR makes. Why should it be merged?

Trait names typically take one of two forms:

1. Noun phrases describing something the type _is_ (e.g. an implementor of `SmartDevice` _is_ a smart device).
2. Verb phrases describing something the type can _do_ or something that can be _done to_ the type (e.g. an implementor of `Display` can be displayed).

With the recent merge of #87, the convenience trait for constructing a competition runtime, `Competition`, no longer follows this convention. Instead of describing competitions, `Competition` describes things (robots) which compete in competitions.

This PR renames the trait to `Compete` to maintain the brevity of `Competition`, but stick to established conventions for trait names.

I've also fixed an error in one of the doc-comments on `CompetitionRuntime`. Eventually its inner workings should be documented in the internals book but until then it's important to at least keep the comments informative.
