### PR TITLE
fix: add missing llvm-tools component to rust toolchain in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
         devShell = pkgs.mkShell {
           buildInputs = with pkgs; [
             (rust-bin.nightly.latest.default.override {
-              extensions = [ "rust-src" ];
+              extensions = [ "rust-src" "llvm-tools" ];
             })
             cargo-binutils
             cargo-pros'


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR adds the `llvm-tools` component to the Rust toolchain in our flake. This lets you use cargo-pros with the flake's toolchain.
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
- I have tested this.
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).

- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
