### PR TITLE
feat: add more Point2 conversions

### DIFF
--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -5,17 +5,13 @@ edition = "2021"
 license = "MIT"
 description = "High level device bindings for vexide"
 keywords = ["Robotics", "bindings", "vex", "v5"]
-categories = [
-    "api-bindings",
-    "no-std",
-    "science::robotics",
-]
+categories = ["api-bindings", "no-std", "science::robotics"]
 repository = "https://github.com/vexide/vexide"
 authors = [
     "vexide",
     "Gavin Niederman <gavinniederman@gmail.com>",
     "doinkythederp <doinkythederp@icloud.com>",
-    "Tropical"
+    "Tropical",
 ]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -31,6 +27,9 @@ mint = "0.5.9"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 bitflags = "2.4.2"
 smart-leds-trait = { version = "0.3.0", optional = true }
+nalgebra = { version = "0.32", default-features = false, optional = true, features = [
+    "convert-mint",
+] }
 
 [lints]
 workspace = true
@@ -38,3 +37,4 @@ workspace = true
 [features]
 dangerous_motor_tuning = []
 smart_leds_trait = ["dep:smart-leds-trait"]
+nalgebra = ["dep:nalgebra"]

--- a/packages/vexide-devices/src/geometry/mod.rs
+++ b/packages/vexide-devices/src/geometry/mod.rs
@@ -7,6 +7,9 @@ use core::{
 
 pub use mint::{EulerAngles, Quaternion, Vector3};
 
+#[cfg(feature = "nalgebra")]
+mod nalgebra;
+
 /// A point in 2D cartesian space.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Point2<T> {
@@ -19,7 +22,7 @@ pub struct Point2<T> {
 
 impl<T> Point2<T> {
     /// Creates a new point.
-    pub fn new(x: T, y: T) -> Self {
+    pub const fn new(x: T, y: T) -> Self {
         Self { x, y }
     }
 
@@ -36,12 +39,12 @@ impl<T> Point2<T> {
 
 impl<T: Copy> Point2<T> {
     /// Gets the point's x component.
-    pub fn x(&self) -> T {
+    pub const fn x(&self) -> T {
         self.x
     }
 
     /// Gets the point's y component.
-    pub fn y(&self) -> T {
+    pub const fn y(&self) -> T {
         self.y
     }
 }
@@ -185,6 +188,10 @@ impl<T: Neg<Output = T>> Neg for Point2<T> {
 
 // Mint conversions
 
+impl<T> mint::IntoMint for Point2<T> {
+    type MintType = mint::Point2<T>;
+}
+
 impl<T> From<mint::Point2<T>> for Point2<T> {
     fn from(mint: mint::Point2<T>) -> Self {
         Self {
@@ -193,6 +200,7 @@ impl<T> From<mint::Point2<T>> for Point2<T> {
         }
     }
 }
+
 impl<T> From<Point2<T>> for mint::Point2<T> {
     fn from(point: Point2<T>) -> Self {
         Self {

--- a/packages/vexide-devices/src/geometry/nalgebra.rs
+++ b/packages/vexide-devices/src/geometry/nalgebra.rs
@@ -1,0 +1,18 @@
+use super::Point2;
+
+impl<T: nalgebra::Scalar> From<nalgebra::Point2<T>> for Point2<T> {
+    fn from(na_point: nalgebra::Point2<T>) -> Self {
+        // nalgebra appears to have a highly optimized conversion to mint.
+        let coords: mint::Point2<T> = na_point.into();
+        Self {
+            x: coords.x,
+            y: coords.y,
+        }
+    }
+}
+
+impl<T: nalgebra::Scalar> From<Point2<T>> for nalgebra::Point2<T> {
+    fn from(point: Point2<T>) -> Self {
+        Self::new(point.x, point.y)
+    }
+}


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Adds an optional feature for converting Point2 to its corresponding `nalgebra` type. Also makes a few Point2 functions `const` and implements `IntoMint`.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
-->
