### PR TITLE
feat: add IDE type checking for examples

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,10 +10,13 @@
         "opcontrol",
         "vexlink"
     ],
-    "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.cargo.allTargets": false,
     "rust-analyzer.check.targets": [
         "${workspaceFolder}/armv7a-vexos-eabi.json",
         "wasm32-unknown-unknown"
+    ],
+    "rust-analyzer.cargo.extraArgs": [
+        "--examples"
     ],
     "rust-analyzer.showUnlinkedFileNotification": false,
     "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Configures rust-analyzer to type-check examples.

## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
