### PR TITLE
feat: add startup options to main macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,76 +3,83 @@ name: Rust
 on: [push, pull_request]
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@v2
+    # Check and lint are separated because linting doesn't seem to fail
+    # if there are errors are outside of the PR's changes.
+    check:
+        name: Check
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup | Checkout
+              uses: actions/checkout@v2
 
-      - name: Setup | Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-07
-          override: true
+            - name: Setup | Toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: nightly-2024-02-07
+                  override: true
 
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-  check-examples:
-    name: Check Examples
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@v2
+            - name: Check
+              uses: actions-rs/cargo@v1
+              with:
+                  command: check
+                  args: --lib --bins --examples --all-features
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: dtolnay/rust-toolchain@nightly
+              with:
+                  components: clippy
+            - uses: giraffate/clippy-action@v1
+              with:
+                  reporter: "github-pr-check"
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  clippy_flags: --lib --bins --examples --all-features
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup | Checkout
+              uses: actions/checkout@v2
 
-      - name: Setup | Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-07
-          override: true
+            - name: Setup | Toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: nightly-2024-02-07
+                  override: true
 
-      - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --examples
-  fmt:
-    name: Rustfmt
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@v2
+            # Currently other crates do not compile in test mode as
+            # `cargo test` doesn't work with our target. `vexide-macros`
+            # is an exception because it is a proc-macro crate.
+            # This isn't actually a big issue at the time of writing because
+            # those crates don't have tests.
+            - name: Test vexide-macros
+              uses: actions-rs/cargo@v1
+              with:
+                  command: test
+                  args: --lib --bins --examples --all-features
+    fmt:
+        name: Rustfmt
+        runs-on: ubuntu-latest
+        steps:
+            - name: Setup | Checkout
+              uses: actions/checkout@v2
 
-      - name: Setup | Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-02-07
-          override: true
+            - name: Setup | Toolchain
+              uses: actions-rs/toolchain@v1
+              with:
+                  profile: minimal
+                  toolchain: nightly-2024-02-07
+                  override: true
 
-      - name: Setup | Install Rustfmt
-        run: rustup component add rustfmt
+            - name: Setup | Install Rustfmt
+              run: rustup component add rustfmt
 
-      - name: Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@nightly
-      with:
-        components: clippy
-    - uses: giraffate/clippy-action@v1
-      with:
-        reporter: 'github-pr-check'
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        clippy_flags: --all-targets --all-features
+            - name: Format
+              uses: actions-rs/cargo@v1
+              with:
+                  command: fmt
+                  args: --all -- --check

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,9 @@
     "rust-analyzer.cargo.extraArgs": [
         "--examples",
         "--lib",
-        "--bins",
-        "--all-features"
+        "--bins"
     ],
+    "rust-analyzer.cargo.features": "all",
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.showUnlinkedFileNotification": false,
     "files.trimTrailingWhitespace": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "${workspaceFolder}/armv7a-vexos-eabi.json",
         "wasm32-unknown-unknown"
     ],
+    "rust-analyzer.check.command": "clippy",
     "rust-analyzer.showUnlinkedFileNotification": false,
     "files.trimTrailingWhitespace": true,
     "files.trimFinalNewlines": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,15 @@ Before releasing:
 
 ### Added
 
+- The startup banner and code signature may now be configured using parameters passed to `vexide::main`. (#102)
+
 ### Fixed
 
 ### Changed
 
 ### Removed
+
+- The `no-banner` feature has been removed from `vexide-startup` and must now be toggled through the `vexide:main` attribute. (#102)
 
 ### New Contributors
 

--- a/packages/vexide-macro/Cargo.toml
+++ b/packages/vexide-macro/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "vexide",
     "Gavin Niederman <gavinniederman@gmail.com>",
     "doinkythederp <doinkythederp@icloud.com>",
-    "Tropical"
+    "Tropical",
 ]
 repository = "https://github.com/vexide/vexide"
 
@@ -20,3 +20,6 @@ syn = { version = "^2.0.57", features = ["full"] }
 
 [lib]
 proc-macro = true
+
+[lints]
+workspace = true

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -146,7 +146,7 @@ fn make_entrypoint(opts: MacroOpts) -> proc_macro2::TokenStream {
 /// static CODE_SIG: ColdHeader = ColdHeader::new(2, 0, 0);
 /// #[vexide::main(code_sig = CODE_SIG)]
 /// async fn main(_p: Peripherals) {
-///    println!("This is the only serial output from this program!")
+///    println!("Hello world!")
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -1,3 +1,5 @@
+//! This crate provides a procedural macro for marking the entrypoint of a [vexide](https://vexide.dev) program.
+
 use parse::{Attrs, MacroOpts};
 use proc_macro::TokenStream;
 use quote::quote;

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -93,6 +93,62 @@ fn make_entrypoint(opts: MacroOpts) -> proc_macro2::TokenStream {
     }
 }
 
+/// Marks a function as the entrypoint for a vexide program. When the program is started,
+/// the `main` function will be called with a single argument of type `Peripherals` which
+/// allows access to device peripherals like motors, sensors, and the display.
+///
+/// The `main` function must be marked `async` and must not be marked `unsafe`. It may
+/// return any type that implements `Termination`, which includes `()`, `!`, and `Result`.
+///
+/// # Parameters
+///
+/// The `main` attribute can be provided with parameters that alter the behavior of the program.
+///
+/// - `banner`: A boolean value that toggles the vexide startup banner printed over serial.
+///   When `false`, the banner will be not displayed.
+/// - `code_sig`: Allows using a custom `ColdHeader` struct to configure program behavior.
+///
+/// # Examples
+///
+/// The most basic usage of the `main` attribute is to mark an async function as the entrypoint
+/// for a vexide program. The function must take a single argument of type `Peripherals`.
+///
+/// ```ignore
+/// # #![no_std]
+/// # #![no_main]
+/// # use vexide::prelude::*;
+/// # use core::fmt::Write;
+/// #[vexide::main]
+/// async fn main(mut peripherals: Peripherals) {
+///     write!(peripherals.screen, "Hello, vexide!").unwrap();
+/// }
+/// ```
+///
+/// The `main` attribute can also be provided with parameters to customize the behavior of the program.
+///
+/// ```ignore
+/// # #![no_std]
+/// # #![no_main]
+/// # use vexide::prelude::*;
+/// #[vexide::main(banner = false)]
+/// async fn main(_p: Peripherals) {
+///    println!("This is the only serial output from this program!")
+/// }
+/// ```
+///
+/// A custom code signature may be used to further configure the behavior of the program.
+///
+/// ```ignore
+/// # #![no_std]
+/// # #![no_main]
+/// # use vexide::prelude::*;
+/// # use vexide::startup::ColdHeader;
+/// static CODE_SIG: ColdHeader = ColdHeader::new(2, 0, 0);
+/// #[vexide::main(code_sig = CODE_SIG)]
+/// async fn main(_p: Peripherals) {
+///    println!("This is the only serial output from this program!")
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn main(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);

--- a/packages/vexide-macro/src/parse.rs
+++ b/packages/vexide-macro/src/parse.rs
@@ -45,7 +45,7 @@ pub struct Attrs {
 }
 
 impl Parse for Attrs {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         Ok(Self {
             attr_list: Punctuated::parse_terminated(input)?,
         })
@@ -58,7 +58,7 @@ pub enum Attribute {
 }
 
 impl Parse for Attribute {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         let lookahead = input.lookahead1();
         if lookahead.peek(kw::banner) {
             input.parse().map(Attribute::Banner)
@@ -77,13 +77,13 @@ pub struct Banner {
 }
 
 impl Banner {
-    pub fn as_bool(&self) -> bool {
+    pub const fn as_bool(&self) -> bool {
         self.arg.value
     }
 }
 
 impl Parse for Banner {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         Ok(Self {
             token: input.parse()?,
             eq: input.parse()?,
@@ -113,7 +113,7 @@ impl CodeSig {
 }
 
 impl Parse for CodeSig {
-    fn parse(input: ParseStream) -> Result<Self> {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
         Ok(Self {
             token: input.parse()?,
             eq: input.parse()?,

--- a/packages/vexide-macro/src/parse.rs
+++ b/packages/vexide-macro/src/parse.rs
@@ -1,0 +1,204 @@
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    Ident, Result, Token,
+};
+
+mod kw {
+    use syn::custom_keyword;
+
+    custom_keyword!(banner);
+    custom_keyword!(code_sig);
+}
+
+pub struct MacroOpts {
+    pub banner: bool,
+    pub code_sig: Option<Ident>,
+}
+
+impl Default for MacroOpts {
+    fn default() -> Self {
+        Self {
+            banner: true,
+            code_sig: None,
+        }
+    }
+}
+
+impl From<Attrs> for MacroOpts {
+    fn from(value: Attrs) -> Self {
+        let mut opts = Self::default();
+        for attr in value.attr_list {
+            match attr {
+                Attribute::Banner(banner) => opts.banner = banner.as_bool(),
+                Attribute::CodeSig(code_sig) => opts.code_sig = Some(code_sig.into_ident()),
+            }
+        }
+        opts
+    }
+}
+
+pub struct Attrs {
+    attr_list: Punctuated<Attribute, Token![,]>,
+}
+
+impl Parse for Attrs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            attr_list: Punctuated::parse_terminated(input)?,
+        })
+    }
+}
+
+pub enum Attribute {
+    Banner(Banner),
+    CodeSig(CodeSig),
+}
+
+impl Parse for Attribute {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(kw::banner) {
+            input.parse().map(Attribute::Banner)
+        } else if lookahead.peek(kw::code_sig) {
+            input.parse().map(Attribute::CodeSig)
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+pub struct Banner {
+    token: kw::banner,
+    eq: Token![=],
+    arg: syn::LitBool,
+}
+
+impl Banner {
+    pub fn as_bool(&self) -> bool {
+        self.arg.value
+    }
+}
+
+impl Parse for Banner {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            token: input.parse()?,
+            eq: input.parse()?,
+            arg: input.parse()?,
+        })
+    }
+}
+
+impl ToTokens for Banner {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.token.to_tokens(tokens);
+        self.eq.to_tokens(tokens);
+        self.arg.to_tokens(tokens);
+    }
+}
+
+pub struct CodeSig {
+    token: kw::code_sig,
+    eq: Token![=],
+    ident: Ident,
+}
+
+impl CodeSig {
+    pub fn into_ident(self) -> Ident {
+        self.ident
+    }
+}
+
+impl Parse for CodeSig {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            token: input.parse()?,
+            eq: input.parse()?,
+            ident: input.parse()?,
+        })
+    }
+}
+
+impl ToTokens for CodeSig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.token.to_tokens(tokens);
+        self.eq.to_tokens(tokens);
+        self.ident.to_tokens(tokens);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use quote::quote;
+    use syn::Ident;
+
+    use super::*;
+
+    #[test]
+    fn parses_banner_attribute() {
+        let source = quote! {
+            banner = true
+        };
+        let input = syn::parse2::<Banner>(source).unwrap();
+        assert_eq!(input.as_bool(), true);
+    }
+
+    #[test]
+    fn parses_code_sig_attribute() {
+        let ident = Ident::new("my_code_sig", proc_macro2::Span::call_site());
+        let source = quote! {
+            code_sig = #ident
+        };
+        let input = syn::parse2::<CodeSig>(source).unwrap();
+        assert_eq!(input.into_ident(), ident);
+    }
+
+    #[test]
+    fn parses_attrs_into_macro_opts() {
+        let source = quote! {
+            banner = true, code_sig = my_code_sig
+        };
+        let input = syn::parse2::<Attrs>(source).unwrap();
+        assert_eq!(input.attr_list.len(), 2);
+        let opts = MacroOpts::from(input);
+        assert_eq!(opts.banner, true);
+        assert_eq!(opts.code_sig.unwrap().to_string(), "my_code_sig");
+    }
+
+    #[test]
+    fn macro_opts_defaults_when_n_opts_missing() {
+        fn macro_opts_from(source: TokenStream) -> MacroOpts {
+            let input = syn::parse2::<Attrs>(source).unwrap();
+            MacroOpts::from(input)
+        }
+
+        let source = quote! {};
+        let opts = macro_opts_from(source);
+        assert_eq!(opts.banner, true);
+        assert_eq!(opts.code_sig, None);
+
+        let source = quote! {
+            banner = false
+        };
+        let opts = macro_opts_from(source);
+        assert_eq!(opts.banner, false);
+        assert_eq!(opts.code_sig, None);
+
+        let source = quote! {
+            code_sig = my_code_sig
+        };
+        let opts = macro_opts_from(source);
+        assert_eq!(opts.banner, true);
+        assert_eq!(opts.code_sig.unwrap().to_string(), "my_code_sig");
+
+        let source = quote! {
+            banner = false, code_sig = my_code_sig
+        };
+        let opts = macro_opts_from(source);
+        assert_eq!(opts.banner, false);
+        assert_eq!(opts.code_sig.unwrap().to_string(), "my_code_sig");
+    }
+}

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -5,21 +5,18 @@ edition = "2021"
 license = "MIT"
 description = "Support code for V5 Brain user program booting"
 keywords = ["Robotics", "startup", "vex", "v5"]
-categories = [
-    "no-std",
-    "science::robotics",
-]
+categories = ["no-std", "science::robotics"]
 repository = "https://github.com/vexide/vexide"
 authors = [
     "vexide",
     "Gavin Niederman <gavinniederman@gmail.com>",
     "doinkythederp <doinkythederp@icloud.com>",
-    "Tropical"
+    "Tropical",
 ]
 
 [dependencies]
 vex-sdk = "0.14.0"
-vexide-core = { version = "0.2.0", path = "../vexide-core"}
+vexide-core = { version = "0.2.0", path = "../vexide-core" }
 vexide-async = { version = "0.1.1", path = "../vexide-async" }
 vexide-devices = { version = "0.2.0", path = "../vexide-devices" }
 
@@ -28,5 +25,3 @@ workspace = true
 
 [features]
 default = []
-
-no-banner = []

--- a/packages/vexide-startup/examples/booting.rs
+++ b/packages/vexide-startup/examples/booting.rs
@@ -21,7 +21,7 @@ extern "Rust" fn main() {
 #[no_mangle]
 #[link_section = ".boot"]
 unsafe extern "C" fn _entry() {
-    unsafe { vexide_startup::program_entry() }
+    unsafe { vexide_startup::program_entry::<true>() }
 }
 
 #[link_section = ".cold_magic"]

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -21,7 +21,7 @@ extern "C" {
     static mut __bss_end: u32;
 }
 
-/// The cold header is a structure that is placed at the beginning of cold memory and tells VexOS details about the program.
+/// The cold header is a structure that is placed at the beginning of cold memory and tells VEXos details about the program.
 #[repr(C, packed)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ColdHeader {

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -22,7 +22,7 @@ extern "C" {
 }
 
 #[repr(C, packed)]
-/// The cold header is a structure that is placed at the beginning of cold memory and tells VexOS details abuot the program.
+/// The cold header is a structure that is placed at the beginning of cold memory and tells VexOS details about the program.
 pub struct ColdHeader {
     /// The magic number for the cold header. This should always be "XVX5".
     pub magic: [u8; 4],
@@ -55,11 +55,15 @@ extern "Rust" {
 /// Sets up the user stack, zeroes the BSS section, and calls the user code.
 /// This function is designed to be used as an entrypoint for programs on the VEX V5 Brain.
 ///
+/// # Const Parameters
+///
+/// - `BANNER`: Enables the vexide startup banner, which prints the vexide logo ASCII art and a startup message.
+///
 /// # Safety
 ///
 /// This function MUST only be called once and should only be called at the very start of program initialization.
 /// Calling this function more than one time will seriously mess up both your stack and your heap.
-pub unsafe fn program_entry() {
+pub unsafe fn program_entry<const BANNER: bool>() {
     #[cfg(target_arch = "arm")]
     unsafe {
         use core::arch::asm;
@@ -90,9 +94,9 @@ pub unsafe fn program_entry() {
         #[cfg(target_arch = "arm")]
         vexide_core::allocator::vexos::init_heap();
         // Print the banner
-        #[cfg(not(feature = "no-banner"))]
-        print!(
-            "
+        if BANNER {
+            print!(
+                "
 \x1B[1;38;5;196m=%%%%%#-  \x1B[38;5;254m-#%%%%-\x1B[1;38;5;196m  :*%%%%%+.
 \x1B[38;5;208m  -#%%%%#-  \x1B[38;5;254m:%-\x1B[1;38;5;208m  -*%%%%#
 \x1B[38;5;226m    *%%%%#=   -#%%%%%+
@@ -103,7 +107,8 @@ pub unsafe fn program_entry() {
 vexide startup successful!
 Running user code...
 "
-        );
+            );
+        }
         // Run vexos background processing at a regular 2ms interval.
         // This is necessary for serial and devices to work properly.
         vexide_async::task::spawn(async {

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -21,8 +21,9 @@ extern "C" {
     static mut __bss_end: u32;
 }
 
-#[repr(C, packed)]
 /// The cold header is a structure that is placed at the beginning of cold memory and tells VexOS details about the program.
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ColdHeader {
     /// The magic number for the cold header. This should always be "XVX5".
     pub magic: [u8; 4],

--- a/packages/vexide/examples/bannerless.rs
+++ b/packages/vexide/examples/bannerless.rs
@@ -1,0 +1,9 @@
+#![no_main]
+#![no_std]
+
+use vexide::prelude::*;
+
+#[vexide::main(banner = true)]
+async fn main(_peripherals: Peripherals) {
+    println!("This is the program's only output.");
+}

--- a/packages/vexide/examples/bannerless.rs
+++ b/packages/vexide/examples/bannerless.rs
@@ -3,7 +3,7 @@
 
 use vexide::prelude::*;
 
-#[vexide::main(banner = true)]
+#[vexide::main(banner = false)]
 async fn main(_peripherals: Peripherals) {
     println!("This is the program's only output.");
 }

--- a/packages/vexide/examples/custom_code_sig.rs
+++ b/packages/vexide/examples/custom_code_sig.rs
@@ -1,0 +1,12 @@
+#![no_main]
+#![no_std]
+
+use vexide::{prelude::*, startup::ColdHeader};
+
+// The custom code signature can be used to configure program behavior.
+static CODE_SIG: ColdHeader = ColdHeader::new(2, 0, 0);
+
+#[vexide::main(code_sig = CODE_SIG)]
+async fn main(_peripherals: Peripherals) {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR moves the option for toggling the vexide ASCII art banner into the parameters of the main macro to make it easier to disable. It fixes #97. It also adds a way to use a custom code signature.

This likely does not come at a code size cost compared to disabling the banner with the feature because it uses const generics to toggle the banner, but I haven't gotten to profiling yet.

## Additional Context
- These are breaking changes (semver: major).
- I have tested these changes on a VEX V5 brain.
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).

-->
