### PR TITLE
fix(clawbot): enable arm usage when claw is not in use

### DIFF
--- a/packages/vexide/examples/clawbot.rs
+++ b/packages/vexide/examples/clawbot.rs
@@ -108,7 +108,7 @@ impl Competition for ClawBot {
             } else if l2_pressed && !limit_switch_pressed {
                 self.claw.set_voltage(-12.0).ok();
             } else {
-                self.arm.brake(BrakeMode::Hold).ok();
+                self.claw.brake(BrakeMode::Hold).ok();
             }
 
             // Sleep some time, since we're limited by how fast the controller updates.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR fixes a bug in the clawbot example that prevents the arm from moving while the claw is not being controlled.

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
