### PR TITLE
feat: add exit status to Termination

### DIFF
--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -7,54 +7,70 @@ use vex_sdk::{vexSerialWriteFree, vexSystemExitRequest, vexTasksRun};
 
 use crate::{io, time::Instant};
 
-/// A that can be implemented for arbitrary return types in the main function.
+/// This type represents the result of a program as a whole.
+/// It should not be used in place of a [`Result`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(u32)]
+pub enum ExitCode {
+    /// The program exited successfully.
+    #[default]
+    Success = 0,
+    /// The program exited due to a failure.
+    Failure = 1,
+}
+
+/// A trait that can be implemented to allow an arbitrary return type from the main function.
 pub trait Termination {
-    /// Run specific termination logic.
-    /// Unlike in the standard library, this function does not return a status code.
-    fn report(self);
+    /// Converts the type to an [`ExitCode`], printing any failure messages over serial.
+    fn report(self) -> ExitCode;
 }
 impl Termination for () {
-    fn report(self) {}
+    fn report(self) -> ExitCode {
+        ExitCode::Success
+    }
 }
 impl Termination for ! {
-    fn report(self) {}
+    fn report(self) -> ExitCode {
+        ExitCode::Success
+    }
 }
 impl Termination for Infallible {
-    fn report(self) {}
+    fn report(self) -> ExitCode {
+        ExitCode::Success
+    }
 }
 impl<T: Termination, E: Debug> Termination for Result<T, E> {
-    fn report(self) {
+    fn report(self) -> ExitCode {
         match self {
             Ok(t) => t.report(),
             Err(e) => {
                 io::println!("Error: {e:?}");
-                exit();
+                ExitCode::Failure
             }
         }
     }
 }
 
-/// Exits the program using vexSystemExitRequest.
-/// This function will not instantly exit the program,
-/// but will instead wait 3ms to force the serial buffer to flush.
+/// Exits the program, preventing execution from continuing.
+/// This function may block up to 15ms before exiting to allow the serial buffer to flush.
 pub fn exit() -> ! {
     let exit_time = Instant::now();
     const FLUSH_TIMEOUT: Duration = Duration::from_millis(15);
     unsafe {
-        // Force the serial buffer to flush
+        // Force the serial buffer to flush.
         while exit_time.elapsed() < FLUSH_TIMEOUT {
-            // If the buffer has been fully flushed, exit the loop
+            // If the buffer has been fully flushed, exit the loop.
             if vexSerialWriteFree(io::STDIO_CHANNEL) == (io::Stdout::INTERNAL_BUFFER_SIZE as i32) {
                 break;
             }
             vexTasksRun();
         }
-        // Exit the program
-        // Everything after this point is unreachable.
+
+        // Exit the program.
         vexSystemExitRequest();
     }
 
-    // unreachable.
+    // Wait for the system to finish stopping the program.
     loop {
         core::hint::spin_loop();
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR adds an `ExitStatus` enum which is returned by `Termination` to represent whether the program was successful, similar to how the standard library's `Termination` returns an `ExitStatus` struct. This would make it easier to implement unit testing because the runner can decide if a test was successful or a failure based on the output of `Termination::report`, like how the builtin `test` crate does.

## Additional Context
- I have tested these changes on a VEX V5 brain.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
-->
