### PR TITLE
fix: heap allocation memory errors

### DIFF
--- a/packages/vexide-startup/link/v5.ld
+++ b/packages/vexide-startup/link/v5.ld
@@ -28,7 +28,6 @@ SECTIONS {
     } > USER_RAM
 
     .rodata : {
-        *(.rodata .rodata.*)
         *(.rodata1 .rodata1.*)
     } > USER_RAM
 

--- a/packages/vexide-startup/link/v5.ld
+++ b/packages/vexide-startup/link/v5.ld
@@ -27,7 +27,7 @@ SECTIONS {
         *(.text .text.*)
     } > USER_RAM
 
-    .rodata : {
+    .rodata1 : {
         *(.rodata1 .rodata1.*)
     } > USER_RAM
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Fixes a memory error in the new linkerscript that triggers during heap allocation. 

## Additional Context
No idea why that happened, but only including `rodata1` in our sections fixes it.