### PR TITLE
feat: add must_use to Sleep struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Before releasing:
 
 - `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range.
 - Adjusted distance sensor status code errors to be more clear.
+- Marks many futures as `#[must_use]` to warn when futures are created without `await`ing them.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,9 @@ Before releasing:
 
 ### Changed
 
-- `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range.
-- Adjusted distance sensor status code errors to be more clear.
-- Marks many futures as `#[must_use]` to warn when futures are created without `await`ing them.
+- `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range. (#113) (**Breaking Change**)
+- Adjusted distance sensor status code errors to be more clear. (#113) (**Breaking Change**)
+- Marks many futures as `#[must_use]` to warn when futures are created without `await`ing them. (#112)
 
 ### Removed
 

--- a/packages/vexide-async/src/time.rs
+++ b/packages/vexide-async/src/time.rs
@@ -21,6 +21,7 @@ use crate::executor::EXECUTOR;
 
 /// A future that will complete after a certain instant is reached in time.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Sleep(Instant);
 
 impl Future for Sleep {

--- a/packages/vexide-core/src/sync/barrier.rs
+++ b/packages/vexide-core/src/sync/barrier.rs
@@ -7,6 +7,7 @@ use futures_core::Future;
 
 /// A future that resolves once all tasks have arrived at a [`Barrier`].
 /// This is created by [`Barrier::wait`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct BarrierWaitFuture<'a> {
     leader: bool,
     barrier: &'a Barrier,

--- a/packages/vexide-core/src/sync/condvar.rs
+++ b/packages/vexide-core/src/sync/condvar.rs
@@ -11,6 +11,7 @@ use replace_with::replace_with;
 use super::{MutexGuard, MutexLockFuture};
 
 /// A future that resolves once a condition variable is notified.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub enum CondvarWaitFuture<'a, T> {
     /// The future is waiting for a notification.
     WaitingForNotification {

--- a/packages/vexide-core/src/sync/mutex.rs
+++ b/packages/vexide-core/src/sync/mutex.rs
@@ -64,6 +64,7 @@ unsafe impl lock_api::RawMutex for RawMutex {
 }
 
 /// A future that resolves to a mutex guard.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct MutexLockFuture<'a, T> {
     mutex: &'a Mutex<T>,
 }

--- a/packages/vexide-core/src/sync/rwlock.rs
+++ b/packages/vexide-core/src/sync/rwlock.rs
@@ -75,6 +75,7 @@ impl<T> Drop for RwLockReadGuard<'_, T> {
 }
 
 /// A future that resolves to a read guard.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct RwLockReadFuture<'a, T> {
     lock: &'a RwLock<T>,
 }
@@ -117,6 +118,7 @@ impl<T> Drop for RwLockWriteGuard<'_, T> {
 }
 
 /// A future that resolves to a write guard.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct RwLockWriteFuture<'a, T> {
     lock: &'a RwLock<T>,
 }

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -336,6 +336,7 @@ pub enum CalibrationPhase {
 
 /// Future that calibrates an IMU
 /// created with [`InertialSensor::calibrate`].
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 #[derive(Debug, Clone, Copy)]
 pub enum InertialCalibrateFuture {
     /// Calibrate the IMU


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR adds a warning when `sleep()` futures are discarded without being used - this is likely unintentional as the function itself has no side-effects.

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
