### PR TITLE
feat: update distance sensor API to return none on a invalid distance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Before releasing:
 
 ### Changed
 
+- `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range.
+- Adjusted distance sensor status code errors to be more clear.
+
 ### Removed
 
 ### New Contributors

--- a/packages/vexide/examples/smart_devices.rs
+++ b/packages/vexide/examples/smart_devices.rs
@@ -43,7 +43,7 @@ async fn main(peripherals: Peripherals) {
         println!("IMU Euler angles: {:?}", imu.euler().unwrap());
         println!(
             "Distance: {}. Confidence: {}",
-            distance.distance().unwrap(),
+            distance.distance().unwrap().unwrap_or(9999),
             distance.distance_confidence().unwrap()
         );
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Updates the Distance Sensor API to return None on invalid distance and adds a more informative error code. 

Fixes: #94

## Additional Context
- I have tested these changes on a VEX V5 brain.
- These (might be) are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
