### PR TITLE
fix: check for negative relative_size results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Before releasing:
 
 ### Fixed
 
+- Fixed an issue where the distance sensor relative_size returned a u32 when it can be negative. (#116)
+
 ### Changed
 
 - `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range.

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -69,7 +69,7 @@ impl DistanceSensor {
     /// Get the current guess at relative "object size".
     ///
     /// This is a value that has a range of 0 to 400. A 18" x 30" grey card will return
-    /// a value of approximately 75 in typical room lighting.
+    /// a value of approximately 75 in typical room lighting. If the sensor is not able to detect an object, None is returned.
     ///
     /// This sensor reading is unusual, as it is entirely unitless with the seemingly arbitrary
     /// range of 0-400 existing due to VEXCode's [`vex::sizeType`] enum having four variants. It's
@@ -77,10 +77,15 @@ impl DistanceSensor {
     /// of salt.
     ///
     /// [`vex::sizeType`]: https://api.vexcode.cloud/v5/search/sizeType/sizeType/enum
-    pub fn relative_size(&self) -> Result<u32, DistanceError> {
+    pub fn relative_size(&self) -> Result<Option<u32>, DistanceError> {
         self.validate()?;
 
-        Ok(unsafe { vexDeviceDistanceObjectSizeGet(self.device) as u32 })
+        let size = unsafe { vexDeviceDistanceObjectSizeGet(self.device) as i32 };
+        if size >= 0 {
+            Ok(Some(size as u32))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Returns the confidence in the distance measurement from 0.0 to 1.0.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR accounts for invalid relative size values in the Distance Sensor API.
Needs testing.
## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
