### PR TITLE
refactor: consistent port numbering terminology, infallible `SmartPort::device_type`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Before releasing:
 
 - `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range.
 - Adjusted distance sensor status code errors to be more clear.
+- Renamed `SmartDevice::port_index` and `SmartPort::index` to `SmartDevice::port_number` and `SmartPort::port_number`.
+- Renamed `AdiDevice::port_index` and `AdiPort::index` to `AdiDevice::port_number` and `AdiDevice::port_number`.
+- `SmartPort::device_type` now no longer returns a `Result`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ Before releasing:
 
 - `DistanceSensor::distance` now returns an `Option` that will be `None` if the sensor is out of range.
 - Adjusted distance sensor status code errors to be more clear.
-- Renamed `SmartDevice::port_index` and `SmartPort::index` to `SmartDevice::port_number` and `SmartPort::port_number`.
-- Renamed `AdiDevice::port_index` and `AdiPort::index` to `AdiDevice::port_number` and `AdiDevice::port_number`.
-- `SmartPort::device_type` now no longer returns a `Result`.
+- Renamed `SmartDevice::port_index` and `SmartPort::index` to `SmartDevice::port_number` and `SmartPort::port_number`. (#121) (**Breaking Change**)
+- Renamed `AdiDevice::port_index` and `AdiPort::index` to `AdiDevice::port_number` and `AdiDevice::port_number`. (#121) (**Breaking Change**)
+- `SmartPort::device_type` now no longer returns a `Result`. (#121) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/adi/accelerometer.rs
+++ b/packages/vexide-devices/src/adi/accelerometer.rs
@@ -53,10 +53,7 @@ impl AdiAccelerometer {
         self.port.validate_expander()?;
         self.port.configure(self.device_type());
 
-        Ok(
-            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
-                as u16,
-        )
+        Ok(unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) } as u16)
     }
 }
 
@@ -87,14 +84,14 @@ impl Sensitivity {
 }
 
 impl AdiDevice for AdiAccelerometer {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -40,7 +40,7 @@ impl AdiAddrLed {
         unsafe {
             vexDeviceAdiAddrLedSet(
                 self.port.device_handle(),
-                self.port.internal_index(),
+                self.port.index(),
                 self.buf.as_mut_ptr(),
                 0,
                 self.buf.len() as u32,
@@ -92,14 +92,14 @@ impl AdiAddrLed {
 }
 
 impl AdiDevice for AdiAddrLed {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/analog.rs
+++ b/packages/vexide-devices/src/adi/analog.rs
@@ -43,10 +43,7 @@ impl AdiAnalogIn {
         self.port.validate_expander()?;
         self.port.configure(self.device_type());
 
-        Ok(
-            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
-                as u16,
-        )
+        Ok(unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) } as u16)
     }
 
     /// Reads an analog input channel and returns the calculated voltage input (0-5V).
@@ -66,14 +63,14 @@ impl AdiAnalogIn {
 }
 
 impl AdiDevice for AdiAnalogIn {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -72,8 +72,7 @@ impl AdiDigitalIn {
         self.port.configure(self.device_type());
 
         let value =
-            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
-                != 0;
+            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) } != 0;
 
         Ok(match value {
             true => LogicLevel::High,
@@ -93,14 +92,14 @@ impl AdiDigitalIn {
 }
 
 impl AdiDevice for AdiDigitalIn {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {
@@ -130,7 +129,7 @@ impl AdiDigitalOut {
         unsafe {
             vexDeviceAdiValueSet(
                 self.port.device_handle(),
-                self.port.internal_index(),
+                self.port.index(),
                 level.is_high() as i32,
             );
         }
@@ -152,14 +151,14 @@ impl AdiDigitalOut {
 }
 
 impl AdiDevice for AdiDigitalOut {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -102,7 +102,7 @@ impl AdiDevice for AdiEncoder {
 #[derive(Debug, Snafu)]
 /// Errors that can occur when interacting with an encoder range finder.
 pub enum EncoderError {
-    /// The index of the top wire must be on an odd numbered port (A, C, E, G).
+    /// The number of the top wire must be on an odd numbered port (A, C, E, G).
     BadTopPort,
 
     /// The bottom wire must be plugged in directly above the top wire.

--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -23,7 +23,7 @@ impl AdiEncoder {
         let bottom_port = ports.1;
 
         // Port error handling - two-wire devices are a little weird with this sort of thing.
-        if top_port.internal_expander_index() != bottom_port.internal_expander_index() {
+        if top_port.expander_index() != bottom_port.expander_index() {
             // Top and bottom must be plugged into the same ADI expander.
             return Err(EncoderError::ExpanderPortMismatch);
         } else if top_port.index() % 2 == 0 {
@@ -51,10 +51,7 @@ impl AdiEncoder {
 
         Ok(Position::from_ticks(
             unsafe {
-                vexDeviceAdiValueGet(
-                    self.top_port.device_handle(),
-                    self.top_port.internal_index(),
-                ) as i64
+                vexDeviceAdiValueGet(self.top_port.device_handle(), self.top_port.index()) as i64
             },
             360,
         ))
@@ -69,7 +66,7 @@ impl AdiEncoder {
         unsafe {
             vexDeviceAdiValueSet(
                 self.top_port.device_handle(),
-                self.top_port.internal_index(),
+                self.top_port.index(),
                 position.as_ticks(360) as i32,
             )
         }
@@ -87,14 +84,14 @@ impl AdiEncoder {
 }
 
 impl AdiDevice for AdiEncoder {
-    type PortIndexOutput = (u8, u8);
+    type PortNumberOutput = (u8, u8);
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        (self.top_port.index(), self.bottom_port.index())
+    fn port_number(&self) -> Self::PortNumberOutput {
+        (self.top_port.number(), self.bottom_port.number())
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.top_port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.top_port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/light_sensor.rs
+++ b/packages/vexide-devices/src/adi/light_sensor.rs
@@ -40,22 +40,19 @@ impl AdiLightSensor {
         self.port.validate_expander()?;
         self.port.configure(self.device_type());
 
-        Ok(
-            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
-                as u16,
-        )
+        Ok(unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) } as u16)
     }
 }
 
 impl AdiDevice for AdiLightSensor {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/line_tracker.rs
+++ b/packages/vexide-devices/src/adi/line_tracker.rs
@@ -62,22 +62,19 @@ impl AdiLineTracker {
         self.port.validate_expander()?;
         self.port.configure(self.device_type());
 
-        Ok(
-            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
-                as u16,
-        )
+        Ok(unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) } as u16)
     }
 }
 
 impl AdiDevice for AdiLineTracker {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -161,12 +161,12 @@ pub trait AdiDevice {
     /// occasionally `(u8, u8)` if the device has two ADI wires.
     type PortNumberOutput;
 
-    /// Get the number of the [`AdiPort`] this device is registered on.
+    /// Get the port number of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
     fn port_number(&self) -> Self::PortNumberOutput;
 
-    /// Get the number of the [`AdiPort`] this device is registered on.
+    /// Get the port number of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
     fn expander_port_number(&self) -> Option<u8>;

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -163,12 +163,12 @@ pub trait AdiDevice {
 
     /// Get the index of the [`AdiPort`] this device is registered on.
     ///
-    /// Ports are indexed starting from 1.
+    /// Ports are numbered starting from 1.
     fn port_number(&self) -> Self::PortNumberOutput;
 
     /// Get the index of the [`AdiPort`] this device is registered on.
     ///
-    /// Ports are indexed starting from 1.
+    /// Ports are numbered starting from 1.
     fn expander_port_number(&self) -> Option<u8>;
 
     /// Get the variant of [`AdiDeviceType`] that this device is associated with.

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -161,12 +161,12 @@ pub trait AdiDevice {
     /// occasionally `(u8, u8)` if the device has two ADI wires.
     type PortNumberOutput;
 
-    /// Get the index of the [`AdiPort`] this device is registered on.
+    /// Get the number of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
     fn port_number(&self) -> Self::PortNumberOutput;
 
-    /// Get the index of the [`AdiPort`] this device is registered on.
+    /// Get the number of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
     fn expander_port_number(&self) -> Option<u8>;

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -41,19 +41,19 @@ pub const ADI_UPDATE_INTERVAL: Duration = Duration::from_millis(10);
 /// Represents an ADI (three wire) port on a V5 Brain or V5 Three Wire Expander.
 #[derive(Debug, Eq, PartialEq)]
 pub struct AdiPort {
-    /// The index of the port (port number).
+    /// The number of the port.
     ///
-    /// Ports are indexed starting from 1.
-    index: u8,
+    /// Ports are numbered starting from 1.
+    number: u8,
 
     /// The index of this port's associated [`AdiExpander`](super::smart::AdiExpander).
     ///
     /// If this port is not associated with an [`AdiExpander`](super::smart::AdiExpander) it should be set to `None`.
-    expander_index: Option<u8>,
+    expander_number: Option<u8>,
 }
 
 impl AdiPort {
-    pub(crate) const INTERNAL_ADI_PORT_INDEX: u8 = 22;
+    pub(crate) const INTERNAL_ADI_PORT_NUMBER: u8 = 22;
 
     /// Create a new port.
     ///
@@ -62,49 +62,49 @@ impl AdiPort {
     /// Creating new `AdiPort`s is inherently unsafe due to the possibility of constructing
     /// more than one device on the same port index allowing multiple mutable references to
     /// the same hardware device. Prefer using [`Peripherals`](crate::peripherals::Peripherals) to register devices if possible.
-    pub const unsafe fn new(index: u8, expander_index: Option<u8>) -> Self {
+    pub const unsafe fn new(number: u8, expander_number: Option<u8>) -> Self {
         Self {
-            index,
-            expander_index,
+            number,
+            expander_number,
         }
     }
 
-    /// Get the index of the port (port number).
+    /// Get the number of the port.
     ///
-    /// Ports are indexed starting from 1.
-    pub const fn index(&self) -> u8 {
-        self.index
+    /// Ports are numbered starting from 1.
+    pub const fn number(&self) -> u8 {
+        self.number
     }
 
     /// Get the index of this port's associated [`AdiExpander`](super::smart::AdiExpander) smart port, or `None` if this port is not
     /// associated with an expander.
-    pub const fn expander_index(&self) -> Option<u8> {
-        self.expander_index
+    pub const fn expander_number(&self) -> Option<u8> {
+        self.expander_number
     }
 
-    pub(crate) const fn internal_index(&self) -> u32 {
-        (self.index() - 1) as u32
+    pub(crate) const fn index(&self) -> u32 {
+        (self.number - 1) as u32
     }
 
-    pub(crate) fn internal_expander_index(&self) -> u32 {
-        ((self.expander_index.unwrap_or(Self::INTERNAL_ADI_PORT_INDEX)) - 1) as u32
+    pub(crate) fn expander_index(&self) -> u32 {
+        ((self
+            .expander_number
+            .unwrap_or(Self::INTERNAL_ADI_PORT_NUMBER))
+            - 1) as u32
     }
 
     pub(crate) fn device_handle(&self) -> V5_DeviceT {
-        unsafe { vexDeviceGetByIndex(self.internal_expander_index()) }
+        unsafe { vexDeviceGetByIndex(self.expander_index()) }
     }
 
     pub(crate) fn validate_expander(&self) -> Result<(), PortError> {
-        validate_port(
-            self.internal_expander_index() as u8 + 1,
-            SmartDeviceType::Adi,
-        )
+        validate_port(self.expander_index() as u8 + 1, SmartDeviceType::Adi)
     }
 
     /// Configures the ADI port to a specific type if it wasn't already configured.
     pub(crate) fn configure(&self, config: AdiDeviceType) {
         unsafe {
-            vexDeviceAdiPortConfigSet(self.device_handle(), self.internal_index(), config.into());
+            vexDeviceAdiPortConfigSet(self.device_handle(), self.index(), config.into());
         }
     }
 
@@ -112,30 +112,27 @@ impl AdiPort {
     pub fn configured_type(&self) -> Result<AdiDeviceType, PortError> {
         self.validate_expander()?;
 
-        Ok(
-            unsafe { vexDeviceAdiPortConfigGet(self.device_handle(), self.internal_index()) }
-                .into(),
-        )
+        Ok(unsafe { vexDeviceAdiPortConfigGet(self.device_handle(), self.index()) }.into())
     }
 }
 
-impl<T: AdiDevice<PortIndexOutput = u8>> From<T> for AdiPort {
+impl<T: AdiDevice<PortNumberOutput = u8>> From<T> for AdiPort {
     fn from(device: T) -> Self {
         // SAFETY: We can do this, since we ensure that the old smartport was disposed of.
         // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_index(), device.expander_port_index()) }
+        unsafe { Self::new(device.port_number(), device.expander_port_number()) }
     }
 }
 
 impl From<AdiRangeFinder> for (AdiPort, AdiPort) {
     fn from(device: AdiRangeFinder) -> Self {
-        let indexes = device.port_index();
-        let expander_index = device.expander_port_index();
+        let numbers = device.port_number();
+        let expander_number = device.expander_port_number();
 
         unsafe {
             (
-                AdiPort::new(indexes.0, expander_index),
-                AdiPort::new(indexes.1, expander_index),
+                AdiPort::new(numbers.0, expander_number),
+                AdiPort::new(numbers.1, expander_number),
             )
         }
     }
@@ -143,13 +140,13 @@ impl From<AdiRangeFinder> for (AdiPort, AdiPort) {
 
 impl From<AdiEncoder> for (AdiPort, AdiPort) {
     fn from(device: AdiEncoder) -> Self {
-        let indexes = device.port_index();
-        let expander_index = device.expander_port_index();
+        let numbers = device.port_number();
+        let expander_number = device.expander_port_number();
 
         unsafe {
             (
-                AdiPort::new(indexes.0, expander_index),
-                AdiPort::new(indexes.1, expander_index),
+                AdiPort::new(numbers.0, expander_number),
+                AdiPort::new(numbers.1, expander_number),
             )
         }
     }
@@ -160,18 +157,19 @@ pub trait AdiDevice {
     /// Update rate of ADI devices.
     const UPDATE_INTERVAL: Duration = ADI_UPDATE_INTERVAL;
 
-    /// The type that port_index should return. This is usually `u8`, but occasionally `(u8, u8)`.
-    type PortIndexOutput;
+    /// The type that [`port_number`] should return. This is usually `u8`, but
+    /// occasionally `(u8, u8)` if the device has two ADI wires.
+    type PortNumberOutput;
 
     /// Get the index of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are indexed starting from 1.
-    fn port_index(&self) -> Self::PortIndexOutput;
+    fn port_number(&self) -> Self::PortNumberOutput;
 
     /// Get the index of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are indexed starting from 1.
-    fn expander_port_index(&self) -> Option<u8>;
+    fn expander_port_number(&self) -> Option<u8>;
 
     /// Get the variant of [`AdiDeviceType`] that this device is associated with.
     fn device_type(&self) -> AdiDeviceType;

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -37,11 +37,7 @@ impl AdiMotor {
         self.port.configure(self.device_type());
 
         unsafe {
-            vexDeviceAdiValueSet(
-                self.port.device_handle(),
-                self.port.internal_index(),
-                pwm as i32,
-            );
+            vexDeviceAdiValueSet(self.port.device_handle(), self.port.index(), pwm as i32);
         }
 
         Ok(())
@@ -65,7 +61,7 @@ impl AdiMotor {
             //
             // Presumably this happens because the legacy motor device types return out of 256 (u8)
             // in the getter, but have an i8 setter. This needs hardware testing, though.
-            (unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
+            (unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) }
                 - i8::MAX as i32) as i8,
         )
     }
@@ -77,14 +73,14 @@ impl AdiMotor {
 }
 
 impl AdiDevice for AdiMotor {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/potentiometer.rs
+++ b/packages/vexide-devices/src/adi/potentiometer.rs
@@ -50,8 +50,7 @@ impl AdiPotentiometer {
         self.port.configure(self.device_type());
 
         Ok(
-            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.internal_index()) }
-                as f64
+            unsafe { vexDeviceAdiValueGet(self.port.device_handle(), self.port.index()) } as f64
                 * self.potentiometer_type.max_angle()
                 / analog::ADC_MAX_VALUE as f64,
         )
@@ -86,14 +85,14 @@ impl PotentiometerType {
 }
 
 impl AdiDevice for AdiPotentiometer {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/pwm.rs
+++ b/packages/vexide-devices/src/adi/pwm.rs
@@ -27,11 +27,7 @@ impl AdiPwmOut {
         self.port.configure(self.device_type());
 
         unsafe {
-            vexDeviceAdiValueSet(
-                self.port.device_handle(),
-                self.port.internal_index(),
-                value as i32,
-            );
+            vexDeviceAdiValueSet(self.port.device_handle(), self.port.index(), value as i32);
         }
 
         Ok(())
@@ -39,14 +35,14 @@ impl AdiPwmOut {
 }
 
 impl AdiDevice for AdiPwmOut {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -80,7 +80,7 @@ pub enum RangeFinderError {
     /// The sensor is unable to return a valid reading.
     NoReading,
 
-    /// The index of the output wire must be on an odd numbered port (A, C, E, G).
+    /// The number of the output wire must be odd (A, C, E, G).
     BadOutputPort,
 
     /// The input  wire must be plugged in directly above the output wire.

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -80,7 +80,7 @@ pub enum RangeFinderError {
     /// The sensor is unable to return a valid reading.
     NoReading,
 
-    /// The number of the output wire must be odd (A, C, E, G).
+    /// The port number of the output wire must be odd (A, C, E, G).
     BadOutputPort,
 
     /// The input  wire must be plugged in directly above the output wire.

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -23,7 +23,7 @@ impl AdiRangeFinder {
         let input_port = ports.1;
 
         // Port error handling - two-wire devices are a little weird with this sort of thing.
-        if output_port.internal_expander_index() != input_port.internal_expander_index() {
+        if output_port.expander_index() != input_port.expander_index() {
             // Output and input must be plugged into the same ADI expander.
             return Err(RangeFinderError::ExpanderPortMismatch);
         } else if output_port.index() % 2 == 0 {
@@ -50,10 +50,7 @@ impl AdiRangeFinder {
         self.output_port.configure(self.device_type());
 
         match unsafe {
-            vexDeviceAdiValueGet(
-                self.output_port.device_handle(),
-                self.output_port.internal_index(),
-            )
+            vexDeviceAdiValueGet(self.output_port.device_handle(), self.output_port.index())
         } {
             -1 => Err(RangeFinderError::NoReading),
             val => Ok(val as u16),
@@ -62,14 +59,14 @@ impl AdiRangeFinder {
 }
 
 impl AdiDevice for AdiRangeFinder {
-    type PortIndexOutput = (u8, u8);
+    type PortNumberOutput = (u8, u8);
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        (self.output_port.index(), self.input_port.index())
+    fn port_number(&self) -> Self::PortNumberOutput {
+        (self.output_port.number(), self.input_port.number())
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.output_port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.output_port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/adi/solenoid.rs
+++ b/packages/vexide-devices/src/adi/solenoid.rs
@@ -32,7 +32,7 @@ impl AdiSolenoid {
         unsafe {
             vexDeviceAdiValueSet(
                 self.port.device_handle(),
-                self.port.internal_index(),
+                self.port.index(),
                 level.is_high() as i32,
             );
         }
@@ -77,14 +77,14 @@ impl AdiSolenoid {
 }
 
 impl AdiDevice for AdiSolenoid {
-    type PortIndexOutput = u8;
+    type PortNumberOutput = u8;
 
-    fn port_index(&self) -> Self::PortIndexOutput {
-        self.port.index()
+    fn port_number(&self) -> Self::PortNumberOutput {
+        self.port.number()
     }
 
-    fn expander_port_index(&self) -> Option<u8> {
-        self.port.expander_index()
+    fn expander_port_number(&self) -> Option<u8> {
+        self.port.expander_number()
     }
 
     fn device_type(&self) -> AdiDeviceType {

--- a/packages/vexide-devices/src/peripherals.rs
+++ b/packages/vexide-devices/src/peripherals.rs
@@ -213,13 +213,13 @@ impl DynamicPeripherals {
     ///
     /// This function panics if the provided port is outside the range 1-21.
     /// Ports outside of this range are invalid and cannot be created.
-    pub fn take_smart_port(&mut self, port_index: u8) -> Option<SmartPort> {
-        let port_index = port_index as usize - 1;
+    pub fn take_smart_port(&mut self, port_number: u8) -> Option<SmartPort> {
+        let port_index = port_number as usize - 1;
         if self.smart_ports[port_index] {
             return None;
         };
         self.smart_ports[port_index] = true;
-        Some(unsafe { SmartPort::new(port_index as u8 + 1) })
+        Some(unsafe { SmartPort::new(port_number) })
     }
 
     /// Creates an [`AdiPort`] only if one has not been created on the given slot before.
@@ -228,13 +228,13 @@ impl DynamicPeripherals {
     ///
     /// This function panics if the provided port is outside the range 1-8.
     /// Slots outside of this range are invalid and cannot be created.
-    pub fn take_adi_port(&mut self, port_index: u8) -> Option<AdiPort> {
-        let port_index = port_index as usize - 1;
-        if self.adi_slots[port_index] {
+    pub fn take_adi_port(&mut self, port_number: u8) -> Option<AdiPort> {
+        let port_number = port_number as usize - 1;
+        if self.adi_slots[port_number] {
             return None;
         }
-        self.smart_ports[port_index] = true;
-        Some(unsafe { AdiPort::new(port_index as u8 + 1, None) })
+        self.smart_ports[port_number] = true;
+        Some(unsafe { AdiPort::new(port_number as u8 + 1, None) })
     }
 
     /// Creates a [`Screen`] only if one has not been created before.

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -104,8 +104,8 @@ impl DistanceSensor {
 }
 
 impl SmartDevice for DistanceSensor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/expander.rs
+++ b/packages/vexide-devices/src/smart/expander.rs
@@ -41,14 +41,14 @@ impl AdiExpander {
     pub const fn new(port: SmartPort) -> Self {
         unsafe {
             Self {
-                adi_a: AdiPort::new(1, Some(port.index())),
-                adi_b: AdiPort::new(2, Some(port.index())),
-                adi_c: AdiPort::new(3, Some(port.index())),
-                adi_d: AdiPort::new(4, Some(port.index())),
-                adi_e: AdiPort::new(5, Some(port.index())),
-                adi_f: AdiPort::new(6, Some(port.index())),
-                adi_g: AdiPort::new(7, Some(port.index())),
-                adi_h: AdiPort::new(8, Some(port.index())),
+                adi_a: AdiPort::new(1, Some(port.number())),
+                adi_b: AdiPort::new(2, Some(port.number())),
+                adi_c: AdiPort::new(3, Some(port.number())),
+                adi_d: AdiPort::new(4, Some(port.number())),
+                adi_e: AdiPort::new(5, Some(port.number())),
+                adi_f: AdiPort::new(6, Some(port.number())),
+                adi_g: AdiPort::new(7, Some(port.number())),
+                adi_h: AdiPort::new(8, Some(port.number())),
                 port,
             }
         }
@@ -56,8 +56,8 @@ impl AdiExpander {
 }
 
 impl SmartDevice for AdiExpander {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -122,8 +122,8 @@ impl GpsSensor {
 }
 
 impl SmartDevice for GpsSensor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -103,7 +103,7 @@ impl InertialSensor {
     /// no longer calibrating.
     /// There a 3 second timeout that will return [`InertialError::CalibrationTimedOut`] if the timeout is exceeded.
     pub fn calibrate(&mut self) -> InertialCalibrateFuture {
-        InertialCalibrateFuture::Calibrate(self.port.index())
+        InertialCalibrateFuture::Calibrate(self.port.number())
     }
 
     /// Get the total number of degrees the Inertial Sensor has spun about the z-axis.
@@ -247,8 +247,8 @@ impl InertialSensor {
 }
 
 impl SmartDevice for InertialSensor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -193,8 +193,8 @@ impl io::Write for RadioLink {
 }
 
 impl SmartDevice for RadioLink {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -46,7 +46,7 @@ use crate::PortError;
 
 /// Defines common functionality shared by all smart port devices.
 pub trait SmartDevice {
-    /// Get the index of the [`SmartPort`] this device is registered on.
+    /// Get the number of the [`SmartPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
     ///
@@ -135,7 +135,7 @@ pub(crate) fn validate_port(number: u8, device_type: SmartDeviceType) -> Result<
 /// Represents a smart port on a V5 Brain
 #[derive(Debug, Eq, PartialEq)]
 pub struct SmartPort {
-    /// The index of the port (port number).
+    /// The number of the port (port number).
     ///
     /// Ports are numbered starting from 1.
     number: u8,

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -46,7 +46,7 @@ use crate::PortError;
 
 /// Defines common functionality shared by all smart port devices.
 pub trait SmartDevice {
-    /// Get the number of the [`SmartPort`] this device is registered on.
+    /// Get the port number of the [`SmartPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
     ///

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -48,7 +48,7 @@ use crate::PortError;
 pub trait SmartDevice {
     /// Get the index of the [`SmartPort`] this device is registered on.
     ///
-    /// Ports are indexed starting from 1.
+    /// Ports are numbered starting from 1.
     ///
     /// # Examples
     ///
@@ -137,7 +137,7 @@ pub(crate) fn validate_port(number: u8, device_type: SmartDeviceType) -> Result<
 pub struct SmartPort {
     /// The index of the port (port number).
     ///
-    /// Ports are indexed starting from 1.
+    /// Ports are numbered starting from 1.
     number: u8,
 }
 

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -54,9 +54,9 @@ pub trait SmartDevice {
     ///
     /// ```
     /// let sensor = InertialSensor::new(peripherals.port_1)?;
-    /// assert_eq!(sensor.port_index(), 1);
+    /// assert_eq!(sensor.port_number(), 1);
     /// ```
-    fn port_index(&self) -> u8;
+    fn port_number(&self) -> u8;
 
     /// Get the variant of [`SmartDeviceType`] that this device is associated with.
     ///
@@ -84,7 +84,7 @@ pub trait SmartDevice {
     /// ```
     fn is_connected(&self) -> bool {
         let connected_type: SmartDeviceType =
-            unsafe { *vexDeviceGetByIndex((self.port_index() - 1) as u32) }
+            unsafe { *vexDeviceGetByIndex((self.port_number() - 1) as u32) }
                 .device_type
                 .into();
 
@@ -94,14 +94,14 @@ pub trait SmartDevice {
     /// Get the timestamp recorded by this device's internal clock.
     fn timestamp(&self) -> Result<SmartDeviceTimestamp, PortError> {
         Ok(SmartDeviceTimestamp(unsafe {
-            vexDeviceGetTimestamp(vexDeviceGetByIndex((self.port_index() - 1) as u32))
+            vexDeviceGetTimestamp(vexDeviceGetByIndex((self.port_number() - 1) as u32))
         }))
     }
 
     /// Verify that the device type is currently plugged into this port, returning an appropriate
     /// [`PortError`] if not available.
     fn validate_port(&self) -> Result<(), PortError> {
-        validate_port(self.port_index(), self.device_type())
+        validate_port(self.port_number(), self.device_type())
     }
 }
 
@@ -109,7 +109,7 @@ impl<T: SmartDevice> From<T> for SmartPort {
     fn from(device: T) -> Self {
         // SAFETY: We can do this, since we ensure that the old smartport was disposed of.
         // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_index()) }
+        unsafe { Self::new(device.port_number()) }
     }
 }
 
@@ -117,8 +117,8 @@ impl<T: SmartDevice> From<T> for SmartPort {
 ///
 /// This function provides the internal implementations of [`SmartDevice::validate_port`], [`SmartPort::validate_type`],
 /// and [`AdiPort::validate_expander`].
-pub(crate) fn validate_port(index: u8, device_type: SmartDeviceType) -> Result<(), PortError> {
-    let device = unsafe { *vexDeviceGetByIndex((index - 1) as u32) };
+pub(crate) fn validate_port(number: u8, device_type: SmartDeviceType) -> Result<(), PortError> {
+    let device = unsafe { *vexDeviceGetByIndex((number - 1) as u32) };
     let plugged_type: SmartDeviceType = device.device_type.into();
 
     if !device.installed {
@@ -138,7 +138,7 @@ pub struct SmartPort {
     /// The index of the port (port number).
     ///
     /// Ports are indexed starting from 1.
-    index: u8,
+    number: u8,
 }
 
 impl SmartPort {
@@ -159,23 +159,27 @@ impl SmartPort {
     /// // single port index.
     /// let my_port = unsafe { SmartPort::new(1) };
     /// ```
-    pub const unsafe fn new(index: u8) -> Self {
-        Self { index }
+    pub const unsafe fn new(number: u8) -> Self {
+        Self { number }
     }
 
-    /// Get the index of the port (port number).
+    /// Get the number of the port.
     ///
-    /// Ports are indexed starting from 1.
+    /// Ports are numbered starting from 1.
     ///
     /// # Examples
     ///
     /// ```
     /// let my_port = unsafe { SmartPort::new(1) };
     ///
-    /// assert_eq!(my_port.index(), 1);
+    /// assert_eq!(my_port.number(), 1);
     /// ```
-    pub const fn index(&self) -> u8 {
-        self.index
+    pub const fn number(&self) -> u8 {
+        self.number
+    }
+
+    pub(crate) const fn index(&self) -> u32 {
+        (self.number - 1) as u32
     }
 
     /// Get the type of device currently connected to this port.
@@ -185,23 +189,23 @@ impl SmartPort {
     /// ```
     /// let my_port = unsafe { SmartPort::new(1) };
     ///
-    /// println!("Type of device connected to port 1: {:?}", my_port.connected_type()?);
+    /// println!("Type of device connected to port 1: {:?}", my_port.device_type());
     /// ```
-    pub fn device_type(&self) -> Result<SmartDeviceType, PortError> {
-        Ok(unsafe { *vexDeviceGetByIndex((self.index() - 1) as u32) }
+    pub fn device_type(&self) -> SmartDeviceType {
+        unsafe { *vexDeviceGetByIndex(self.index()) }
             .device_type
-            .into())
+            .into()
     }
 
     /// Verify that a device type is currently plugged into this port, returning an appropriate
     /// [`PortError`] if not available.
     pub fn validate_type(&self, device_type: SmartDeviceType) -> Result<(), PortError> {
-        validate_port(self.index(), device_type)
+        validate_port(self.number(), device_type)
     }
 
     /// Get the raw handle of the underlying smart device connected to this port.
     pub(crate) unsafe fn device_handle(&self) -> V5_DeviceT {
-        unsafe { vexDeviceGetByIndex((self.index() - 1) as u32) }
+        unsafe { vexDeviceGetByIndex(self.index()) }
     }
 }
 

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -464,8 +464,8 @@ impl Motor {
 }
 
 impl SmartDevice for Motor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -184,8 +184,8 @@ impl OpticalSensor {
 }
 
 impl SmartDevice for OpticalSensor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -196,8 +196,8 @@ impl RotationSensor {
 }
 
 impl SmartDevice for RotationSensor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -278,8 +278,8 @@ impl io::Write for SerialPort {
 }
 
 impl SmartDevice for SerialPort {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -418,8 +418,8 @@ impl VisionSensor {
 }
 
 impl SmartDevice for VisionSensor {
-    fn port_index(&self) -> u8 {
-        self.port.index()
+    fn port_number(&self) -> u8 {
+        self.port.number()
     }
 
     fn device_type(&self) -> SmartDeviceType {


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- For historical reasons, `SmartPort::device_type` returned `Result` even though it could never fail (`SmartDeviceType` -> `V5_DeviceType` used to be `TryFrom`). This PR fixes that.
- Renames all terminology of 1-indexed port numbers to be `number` rather than index, and renames all 0-index terminology to be `index`. This matches up terminology with recent simulator APIs (which more heavily lean to use `index` than number due to being SDK-internal).