### PR TITLE
feat: expose `lock_blocking` method on `Mutex` to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Before releasing:
 ### Added
 
 - Added support for the V5 GPS Sensor (#79)
+- Exposed `Mutex::lock_blocking` method to the public. (#126)
 
 ### Fixed
 

--- a/packages/vexide-core/src/sync/mutex.rs
+++ b/packages/vexide-core/src/sync/mutex.rs
@@ -107,9 +107,8 @@ impl<T> Mutex<T> {
         MutexLockFuture { mutex: self }
     }
 
-    /// Used internally to lock the mutex in a blocking fashion.
-    /// This is neccessary because a mutex may be created internally before the executor is ready to be initialized.
-    pub(crate) fn lock_blocking(&self) -> MutexGuard<'_, T> {
+    /// Lock the mutex in a blocking fashion.
+    pub fn lock_blocking(&self) -> MutexGuard<'_, T> {
         self.raw.lock();
         MutexGuard::new(self)
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This matches tokio's API (although they call it `blocking_lock` which is kind of dumb) and can be useful in cases where you just need extremely basic thread safety without worrying about colored functions.