### PR TITLE
fix(screen): correct vexDisplayCopyRect region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Before releasing:
 ### Fixed
 
 - Fixed an issue where the distance sensor relative_size returned a u32 when it can be negative. (#116)
+- Fixed an issue preventing the `Screen::draw_buffer` function from working properly. (#128)
 
 ### Changed
 

--- a/packages/vexide-devices/src/screen.rs
+++ b/packages/vexide-devices/src/screen.rs
@@ -620,7 +620,7 @@ impl Screen {
                 region.start.x as _,
                 (region.start.y + Self::HEADER_HEIGHT) as _,
                 region.end.x as _,
-                (region.start.y + Self::HEADER_HEIGHT) as _,
+                (region.end.y + Self::HEADER_HEIGHT) as _,
                 raw_buf.as_mut_ptr(),
                 src_stride,
             );


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Fixes the region passed to vexDisplayCopyRect in the Screen struct.

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
