### PR TITLE
fix: stop double buffered rending from stopping panic message rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Before releasing:
 
 - Fixed an issue where the distance sensor relative_size returned a u32 when it can be negative. (#116)
 - Fixed an issue preventing the `Screen::draw_buffer` function from working properly. (#128)
-- Fixed an issue where panic messages would not be displayed even when the `display_panics` feature was enabled if the screens render mode was set to `DoubleBuffered`. (#todo)
+- Fixed an issue where panic messages would not be displayed even when the `display_panics` feature was enabled if the screens render mode was set to `DoubleBuffered`. (#134)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Before releasing:
 
 - Fixed an issue where the distance sensor relative_size returned a u32 when it can be negative. (#116)
 - Fixed an issue preventing the `Screen::draw_buffer` function from working properly. (#128)
+- Fixed an issue where panic messages would not be displayed even when the `display_panics` feature was enabled if the screens render mode was set to `DoubleBuffered`. (#todo)
 
 ### Changed
 

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -38,6 +38,8 @@ fn draw_error(screen: &mut Screen, msg: &str, backtrace: &Backtrace) {
     const LINE_HEIGHT: i16 = 20;
     const LINE_MAX_WIDTH: usize = 52;
 
+    screen.set_render_mode(vexide_devices::screen::RenderMode::Immediate);
+
     fn draw_text(screen: &mut Screen, buffer: &str, line: i16) {
         screen.fill(
             &Text::new(


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR fixes a bug where enabling screen double buffering would stop graphical panic messages from being displayed on the screen.

Closes #92 

## Additional Context
- I have tested these changes on a VEX V5 brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
