### PR TITLE
refactor: avoid dereferencing `V5_DeviceT` at all cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Before releasing:
 - Fixed an issue where the distance sensor relative_size returned a u32 when it can be negative. (#116)
 - Fixed an issue preventing the `Screen::draw_buffer` function from working properly. (#128)
 - Fixed an issue where panic messages would not be displayed even when the `display_panics` feature was enabled if the screens render mode was set to `DoubleBuffered`. (#134)
+- `GpsImu` should now validate on the correct port. (#141)
 
 ### Changed
 

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 async-task = { version = "4.5.0", default-features = false }
 vexide-core = { version = "0.3.0", path = "../vexide-core" }
 waker-fn = "1.1.1"
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 critical-section = { version = "1.1.2", features = ["restore-state-bool"] }
 
 [lints]

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -17,7 +17,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 
 [dependencies]
 vexide-core = { version = "0.3.0", path = "../vexide-core" }
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",
     "unstable-core-error",

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -54,12 +54,13 @@ impl GpsSensor {
 
         Ok(Self {
             device,
-            port,
             imu: GpsImu {
                 device,
+                port_number: port.number(),
                 rotation_offset: Default::default(),
                 heading_offset: Default::default(),
             },
+            port,
         })
     }
 
@@ -134,6 +135,7 @@ impl SmartDevice for GpsSensor {
 /// GPS Sensor Internal IMU
 #[derive(Debug, PartialEq)]
 pub struct GpsImu {
+    port_number: u8,
     device: V5_DeviceT,
     rotation_offset: f64,
     heading_offset: f64,
@@ -149,7 +151,7 @@ impl GpsImu {
 
     fn validate_port(&self) -> Result<(), PortError> {
         validate_port(
-            unsafe { (*self.device).zero_indexed_port },
+            self.port_number,
             SmartDeviceType::Gps,
         )
     }

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -150,10 +150,7 @@ impl GpsImu {
     pub const MAX_HEADING: f64 = 360.0;
 
     fn validate_port(&self) -> Result<(), PortError> {
-        validate_port(
-            self.port_number,
-            SmartDeviceType::Gps,
-        )
+        validate_port(self.port_number, SmartDeviceType::Gps)
     }
 
     /// Returns the IMU's yaw angle bounded by [0, 360) degrees.

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -39,7 +39,10 @@ pub use motor::Motor;
 pub use optical::OpticalSensor;
 pub use rotation::RotationSensor;
 pub use serial::SerialPort;
-use vex_sdk::{vexDeviceGetByIndex, vexDeviceGetTimestamp, V5_DeviceT, V5_DeviceType};
+use vex_sdk::{
+    vexDeviceGetByIndex, vexDeviceGetStatus, vexDeviceGetTimestamp, V5_DeviceT, V5_DeviceType,
+    V5_MAX_DEVICE_PORTS,
+};
 pub use vision::VisionSensor;
 
 use crate::PortError;
@@ -83,12 +86,12 @@ pub trait SmartDevice {
     /// }
     /// ```
     fn is_connected(&self) -> bool {
-        let connected_type: SmartDeviceType =
-            unsafe { *vexDeviceGetByIndex((self.port_number() - 1) as u32) }
-                .device_type
-                .into();
+        let mut device_types: [V5_DeviceType; V5_MAX_DEVICE_PORTS] = unsafe { core::mem::zeroed() };
+        unsafe {
+            vexDeviceGetStatus(device_types.as_mut_ptr());
+        }
 
-        connected_type == self.device_type()
+        SmartDeviceType::from(device_types[(self.port_number() - 1) as usize]) == self.device_type()
     }
 
     /// Get the timestamp recorded by this device's internal clock.
@@ -118,13 +121,17 @@ impl<T: SmartDevice> From<T> for SmartPort {
 /// This function provides the internal implementations of [`SmartDevice::validate_port`], [`SmartPort::validate_type`],
 /// and [`AdiPort::validate_expander`].
 pub(crate) fn validate_port(number: u8, device_type: SmartDeviceType) -> Result<(), PortError> {
-    let device = unsafe { *vexDeviceGetByIndex((number - 1) as u32) };
-    let plugged_type: SmartDeviceType = device.device_type.into();
+    let mut device_types: [V5_DeviceType; V5_MAX_DEVICE_PORTS] = unsafe { core::mem::zeroed() };
+    unsafe {
+        vexDeviceGetStatus(device_types.as_mut_ptr());
+    }
 
-    if !device.installed {
+    let connected_type: SmartDeviceType = device_types[(number - 1) as usize].into();
+
+    if connected_type == SmartDeviceType::None {
         // No device is plugged into the port.
         return Err(PortError::Disconnected);
-    } else if plugged_type != device_type {
+    } else if connected_type != device_type {
         // The connected device doesn't match the requested type.
         return Err(PortError::IncorrectDevice);
     }
@@ -192,9 +199,12 @@ impl SmartPort {
     /// println!("Type of device connected to port 1: {:?}", my_port.device_type());
     /// ```
     pub fn device_type(&self) -> SmartDeviceType {
-        unsafe { *vexDeviceGetByIndex(self.index()) }
-            .device_type
-            .into()
+        let mut device_types: [V5_DeviceType; V5_MAX_DEVICE_PORTS] = unsafe { core::mem::zeroed() };
+        unsafe {
+            vexDeviceGetStatus(device_types.as_mut_ptr());
+        }
+
+        device_types[self.index() as usize].into()
     }
 
     /// Verify that a device type is currently plugged into this port, returning an appropriate

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -21,7 +21,7 @@ slint = { version = "1.5.1", default-features = false, optional = true, features
     "libm",
     "renderer-software",
 ] }
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 vexide-async = { version = "0.1.2", path = "../vexide-async" }
 vexide-core = { version = "0.3.0", path = "../vexide-core" }
 vexide-devices = { version = "0.3.0", path = "../vexide-devices" }

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -19,7 +19,7 @@ authors = [
 [dependencies]
 vexide-core = { version = "0.3.0", path = "../vexide-core" }
 vexide-devices = { version = "0.3.0", path = "../vexide-devices", optional = true }
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 snafu = { version = "0.8.4", default-features = false, features = [
     "unstable-core-error",
 ] }

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 
 [dependencies]
 bitflags = "2.4.2"
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 vexide-core = { version = "0.3.0", path = "../vexide-core" }
 vexide-async = { version = "0.1.2", path = "../vexide-async" }
 vexide-devices = { version = "0.3.0", path = "../vexide-devices" }

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -31,7 +31,7 @@ vexide-core = { version = "0.3.0", path = "../vexide-core", optional = true, def
 vexide-startup = { version = "0.2.0", path = "../vexide-startup", optional = true, default-features = false }
 vexide-graphics = { version = "0.1.2", path = "../vexide-graphics", optional = true, default-features = false }
 vexide-macro = { version = "0.2.0", path = "../vexide-macro", optional = true, default-features = false }
-vex-sdk = "0.19.0"
+vex-sdk = "0.20.0"
 
 [features]
 default = [


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

As of `vex_sdk` 0.20.0, `V5_Device` is now an entirely opaque type, due to possible incorrectness regarding the memory layout of the reverse-engineered fields on that struct and due to possible instability of that internal struct across firmware updates. This PR removes any dereferences of `V5_Device` to try to read one of those fields with a public SDK function. The most common occurance of this was when trying to get a device handle's type, which has been replaced by a call to `vexDeviceGetStatus` - a function that returns the connection type of every port on the brain. This is the same method used by VDML in PROS, meaning it should be more theoretically sound than what we were doing before.

This also caused me to find an off-by-one error in `GpsImu` which has also been fixed.

## Additional Context
- Bumps to `vex_sdk` 0.20.0
- Untested