### PR TITLE
refactor: new simplified startup routine

### DIFF
--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -26,10 +26,7 @@ impl<T: Termination, E: Debug> Termination for Result<T, E> {
     fn report(self) {
         match self {
             Ok(t) => t.report(),
-            Err(e) => {
-                io::println!("Error: {e:?}");
-                exit();
-            }
+            Err(e) => io::println!("Error: {e:?}"),
         }
     }
 }

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -43,7 +43,23 @@ fn verify_function_sig(sig: &Signature) -> Result<(), syn::Error> {
     }
 }
 
-fn create_main_wrapper(inner: ItemFn) -> proc_macro2::TokenStream {
+fn make_code_sig(opts: MacroOpts) -> proc_macro2::TokenStream {
+    let sig = if let Some(code_sig) = opts.code_sig {
+        quote! { #code_sig }
+    } else {
+        quote! {  ::vexide::startup::CodeSignature::new(
+            ::vexide::startup::ProgramType::User,
+            ::vexide::startup::ProgramOwner::Partner,
+            ::vexide::startup::ProgramFlags::empty(),
+        ) }
+    };
+
+    quote! {
+        static CODE_SIGNATURE: ::vexide::startup::CodeSignature = #sig;
+    }
+}
+
+fn make_entrypoint(inner: ItemFn, opts: MacroOpts) -> proc_macro2::TokenStream {
     match verify_function_sig(&inner.sig) {
         Ok(_) => {}
         Err(e) => return e.to_compile_error(),
@@ -54,53 +70,33 @@ fn create_main_wrapper(inner: ItemFn) -> proc_macro2::TokenStream {
         syn::ReturnType::Type(_, ty) => quote! { #ty },
     };
 
+    let banner_print = if opts.banner_enabled {
+        let theme = if let Some(theme) = opts.banner_theme {
+            quote! { #theme }
+        } else {
+            quote! { ::vexide::startup::banner::themes::THEME_DEFAULT }
+        };
+        Some(quote! { ::vexide::startup::banner::print(#theme); })
+    } else {
+        None
+    };
+
     quote! {
         #[no_mangle]
-        extern "Rust" fn main() {
+        unsafe extern "C" fn _start() -> ! {
+            #[cfg(target_arch = "arm")]
+            ::vexide::core::allocator::vexos::init_heap();
+
+            #banner_print
+
             #inner
             let termination: #ret_type = ::vexide::async_runtime::block_on(
                 #inner_ident(::vexide::devices::peripherals::Peripherals::take().unwrap())
             );
             ::vexide::core::program::Termination::report(termination);
+
+            vexide_core::program::exit();
         }
-    }
-}
-
-fn make_entrypoint(opts: MacroOpts) -> proc_macro2::TokenStream {
-    let banner_arg = if opts.banner_enabled {
-        quote! { true }
-    } else {
-        quote! { false }
-    };
-    let code_signature = if let Some(code_sig) = opts.code_sig {
-        quote! { #code_sig }
-    } else {
-        quote! {  ::vexide::startup::CodeSignature::new(
-            ::vexide::startup::ProgramType::User,
-            ::vexide::startup::ProgramOwner::Partner,
-            ::vexide::startup::ProgramFlags::empty(),
-        ) }
-    };
-    let theme = if let Some(theme) = opts.banner_theme {
-        quote! { #theme }
-    } else {
-        quote! { ::vexide::startup::banner::themes::THEME_DEFAULT }
-    };
-
-    quote! {
-        const _: () = {
-            #[no_mangle]
-            #[link_section = ".boot"]
-            unsafe extern "C" fn _start() {
-                unsafe {
-                    ::vexide::startup::program_entry::<#banner_arg>(#theme)
-                }
-            }
-
-            #[link_section = ".code_signature"]
-            #[used] // This is needed to prevent the linker from removing this object in release builds
-            static __CODE_SIGNATURE: ::vexide::startup::CodeSignature = #code_signature;
-        };
     }
 }
 
@@ -179,16 +175,18 @@ fn make_entrypoint(opts: MacroOpts) -> proc_macro2::TokenStream {
 #[proc_macro_attribute]
 pub fn main(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let item = parse_macro_input!(item as ItemFn);
-    let attrs = parse_macro_input!(attrs as Attrs);
-    let opts = MacroOpts::from(attrs);
-    let main_fn = create_main_wrapper(item);
-    let entrypoint = make_entrypoint(opts);
+    let opts = MacroOpts::from(parse_macro_input!(attrs as Attrs));
+
+    let entrypoint = make_entrypoint(item, opts.clone());
+    let code_signature = make_code_sig(opts);
 
     quote! {
-        #main_fn
-        #entrypoint
-    }
-    .into()
+        const _: () = {
+            #code_signature
+
+            #entrypoint
+        };
+    }.into()
 }
 
 #[cfg(test)]
@@ -204,20 +202,28 @@ mod test {
                 println!("Hello, world!");
             }
         };
-        let input = syn::parse2::<ItemFn>(source).unwrap();
-        let output = create_main_wrapper(input);
+
+        let input = syn::parse2::<ItemFn>(source.clone()).unwrap();
+        let output = make_entrypoint(input, MacroOpts::default());
+
         assert_eq!(
             output.to_string(),
             quote! {
                 #[no_mangle]
-                extern "Rust" fn main() {
-                    async fn main(_peripherals: Peripherals) {
-                        println!("Hello, world!");
-                    }
+                unsafe extern "C" fn _start() -> ! {
+                    #[cfg(target_arch = "arm")]
+                    ::vexide::core::allocator::vexos::init_heap();
+
+                    ::vexide::startup::banner::print(::vexide::startup::banner::themes::THEME_DEFAULT);
+
+                    #source
+
                     let termination: () = ::vexide::async_runtime::block_on(
                         main(::vexide::devices::peripherals::Peripherals::take().unwrap())
                     );
                     ::vexide::core::program::Termination::report(termination);
+
+                    vexide_core::program::exit();
                 }
             }
             .to_string()
@@ -226,25 +232,30 @@ mod test {
 
     #[test]
     fn toggles_banner_using_parsed_opts() {
-        let entrypoint = make_entrypoint(MacroOpts {
+        let source = quote! {
+            async fn main(_peripherals: Peripherals) {
+                println!("Hello, world!");
+            }
+        };
+        let input = syn::parse2::<ItemFn>(source.clone()).unwrap();
+        let entrypoint = make_entrypoint(input.clone(), MacroOpts {
             banner_enabled: false,
             banner_theme: None,
             code_sig: None,
         });
-        assert!(entrypoint.to_string().contains("false"));
-        assert!(!entrypoint.to_string().contains("true"));
-        let entrypoint = make_entrypoint(MacroOpts {
+        assert!(!entrypoint.to_string().contains(":: vexide :: startup :: banner :: print"));
+
+        let entrypoint = make_entrypoint(input, MacroOpts {
             banner_enabled: true,
             banner_theme: None,
             code_sig: None,
         });
-        assert!(entrypoint.to_string().contains("true"));
-        assert!(!entrypoint.to_string().contains("false"));
+        assert!(entrypoint.to_string().contains(":: vexide :: startup :: banner :: print"));
     }
 
     #[test]
     fn uses_custom_code_sig_from_parsed_opts() {
-        let entrypoint = make_entrypoint(MacroOpts {
+        let code_sig = make_code_sig(MacroOpts {
             banner_enabled: false,
             banner_theme: None,
             code_sig: Some(Ident::new(
@@ -252,9 +263,10 @@ mod test {
                 proc_macro2::Span::call_site(),
             )),
         });
-        println!("{}", entrypoint);
-        assert!(entrypoint.to_string().contains(
-            "static __CODE_SIGNATURE : :: vexide :: startup :: CodeSignature = __custom_code_sig_ident__ ;"
+
+        println!("{}", code_sig.to_string());
+        assert!(code_sig.to_string().contains(
+            "static CODE_SIGNATURE : :: vexide :: startup :: CodeSignature = __custom_code_sig_ident__ ;"
         ));
     }
 
@@ -265,8 +277,10 @@ mod test {
                 println!("Hello, world!");
             }
         };
-        let input = syn::parse2::<ItemFn>(source).unwrap();
-        let output = create_main_wrapper(input);
+
+        let input = syn::parse2::<ItemFn>(source.clone()).unwrap();
+        let output = make_entrypoint(input, MacroOpts::default());
+
         assert!(output.to_string().contains(NO_SYNC_ERR));
     }
 
@@ -277,8 +291,10 @@ mod test {
                 println!("Hello, world!");
             }
         };
-        let input = syn::parse2::<ItemFn>(source).unwrap();
-        let output = create_main_wrapper(input);
+
+        let input = syn::parse2::<ItemFn>(source.clone()).unwrap();
+        let output = make_entrypoint(input, MacroOpts::default());
+
         assert!(output.to_string().contains(NO_UNSAFE_ERR));
     }
 
@@ -289,8 +305,10 @@ mod test {
                 println!("Hello, world!");
             }
         };
-        let input = syn::parse2::<ItemFn>(source).unwrap();
-        let output = create_main_wrapper(input);
+
+        let input = syn::parse2::<ItemFn>(source.clone()).unwrap();
+        let output = make_entrypoint(input, MacroOpts::default());
+
         assert!(output.to_string().contains(WRONG_ARGS_ERR));
     }
 
@@ -301,8 +319,10 @@ mod test {
                 println!("Hello, world!");
             }
         };
-        let input = syn::parse2::<ItemFn>(source).unwrap();
-        let output = create_main_wrapper(input);
+
+        let input = syn::parse2::<ItemFn>(source.clone()).unwrap();
+        let output = make_entrypoint(input, MacroOpts::default());
+
         assert!(output.to_string().contains(WRONG_ARGS_ERR));
     }
 }

--- a/packages/vexide-macro/src/parse.rs
+++ b/packages/vexide-macro/src/parse.rs
@@ -18,6 +18,7 @@ mod kw {
     custom_keyword!(code_sig);
 }
 
+#[derive(Clone)]
 pub struct MacroOpts {
     pub banner_enabled: bool,
     pub banner_theme: Option<Ident>,

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -18,8 +18,6 @@ authors = [
 bitflags = "2.4.2"
 vex-sdk = "0.19.0"
 vexide-core = { version = "0.3.0", path = "../vexide-core" }
-vexide-async = { version = "0.1.2", path = "../vexide-async" }
-vexide-devices = { version = "0.3.0", path = "../vexide-devices" }
 compile-time = "0.2.0"
 
 [lints]

--- a/packages/vexide-startup/examples/booting.rs
+++ b/packages/vexide-startup/examples/booting.rs
@@ -8,18 +8,15 @@ use alloc::boxed::Box;
 
 use vex_sdk::vexTasksRun;
 use vexide_core::println;
-use vexide_startup::{CodeSignature, ProgramFlags, ProgramOwner, ProgramType};
+use vexide_startup::{
+    banner::themes::THEME_DEFAULT, CodeSignature, ProgramFlags, ProgramOwner, ProgramType,
+};
 
 #[no_mangle]
 unsafe extern "C" fn _start() -> ! {
-    #[cfg(target_arch = "arm")]
     unsafe {
-        // Setup the global heap allocator if we're on ARM.
-        // If we're on wasm32, vexide_core will have already set this up for us.
-        vexide_core::allocator::vexos::init_heap();
-    }
+        vexide_startup::startup::<true>(THEME_DEFAULT);
 
-    unsafe {
         // Write something to the screen to test if the program is running
         let test_box = Box::new(100);
         vex_sdk::vexDisplayRectFill(0, 0, *test_box, 200);

--- a/packages/vexide-startup/src/banner/mod.rs
+++ b/packages/vexide-startup/src/banner/mod.rs
@@ -20,7 +20,7 @@ pub mod themes;
 ///
 /// This function is used internally in [`program_entry`](crate::program_entry) to print the banner.
 #[inline]
-pub fn print(theme: &BannerTheme) {
+pub fn print(theme: BannerTheme) {
     const VEXIDE_VERSION: &str = "0.3.0";
 
     let system_version = unsafe { vexSystemVersion() }.to_be_bytes();

--- a/packages/vexide-startup/src/banner/themes.rs
+++ b/packages/vexide-startup/src/banner/themes.rs
@@ -47,7 +47,7 @@ macro_rules! ansi_rgb_bold {
     };
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 /// Banner display options
 pub struct BannerTheme {
     /// The emoji to be displayed nex to the vexide version


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR simplifies vexide's boot/startup process.

1. Startup now begins at the assembly level, where `.boot` contains some `global_asm` that sets up the stack and then jumps to the `_start` symbol.
2. The `_start` symbol is generated by our macro, which calls the `startup` function in `vexide_startup`.
3. `startup` initializes the heap allocator and zeroes bss if on ARM, then prints the banner.
4. `_start` then calls `main` in the executor and handles any exits/return values using `Termination`.

## Additional Context
This fixes memory errors due to stack corruption on debug builds.