### PR TITLE
chore: bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ Before releasing:
 
 ### Added
 
+### Fixed
+
+### Changed
+
+### Removed
+
+### New Contributors
+
+## [0.4.0]
+
+### Added
+
 - Added support for the V5 GPS Sensor (#79)
 - Added support for custom banner themes configurable through the `vexide::main` macro (#127)
 
@@ -128,3 +140,4 @@ Before releasing:
 [0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...v0.2.0
 [0.2.1]: https://github.com/vexide/vexide/compare/v0.2.0...v0.2.1
 [0.3.0]: https://github.com/vexide/vexide/compare/v0.2.1...v0.3.0
+[0.4.0]: https://github.com/vexide/vexide/compare/v0.3.0...v0.4.0

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-async"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "The async executor at the core of vexide"
@@ -18,7 +18,7 @@ authors = [
 
 [dependencies]
 async-task = { version = "4.5.0", default-features = false }
-vexide-core = { version = "0.3.0", path = "../vexide-core" }
+vexide-core = { version = "0.4.0", path = "../vexide-core" }
 waker-fn = "1.1.1"
 vex-sdk = "0.20.0"
 

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "Core functionality for vexide"

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-devices"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "High level device bindings for vexide"
@@ -17,7 +17,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vexide-core = { version = "0.3.0", path = "../vexide-core" }
+vexide-core = { version = "0.4.0", path = "../vexide-core" }
 vex-sdk = "0.20.0"
 snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -22,7 +22,7 @@ slint = { version = "1.5.1", default-features = false, optional = true, features
     "renderer-software",
 ] }
 vex-sdk = "0.20.0"
-vexide-async = { version = "0.1.2", path = "../vexide-async" }
+vexide-async = { version = "0.1.3", path = "../vexide-async" }
 vexide-core = { version = "0.4.0", path = "../vexide-core" }
 vexide-devices = { version = "0.4.0", path = "../vexide-devices" }
 

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-graphics"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "Graphics driver implementations for vexide"
@@ -23,8 +23,8 @@ slint = { version = "1.5.1", default-features = false, optional = true, features
 ] }
 vex-sdk = "0.20.0"
 vexide-async = { version = "0.1.2", path = "../vexide-async" }
-vexide-core = { version = "0.3.0", path = "../vexide-core" }
-vexide-devices = { version = "0.3.0", path = "../vexide-devices" }
+vexide-core = { version = "0.4.0", path = "../vexide-core" }
+vexide-devices = { version = "0.4.0", path = "../vexide-devices" }
 
 [lints]
 workspace = true

--- a/packages/vexide-macro/Cargo.toml
+++ b/packages/vexide-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-macro"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Proc macros for vexide"

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-panic"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "Panic handler for vexide"
@@ -17,8 +17,8 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vexide-core = { version = "0.3.0", path = "../vexide-core" }
-vexide-devices = { version = "0.3.0", path = "../vexide-devices", optional = true }
+vexide-core = { version = "0.4.0", path = "../vexide-core" }
+vexide-devices = { version = "0.4.0", path = "../vexide-devices", optional = true }
 vex-sdk = "0.20.0"
 snafu = { version = "0.8.4", default-features = false, features = [
     "unstable-core-error",

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-startup"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Support code for V5 Brain user program booting"
@@ -17,7 +17,7 @@ authors = [
 [dependencies]
 bitflags = "2.4.2"
 vex-sdk = "0.20.0"
-vexide-core = { version = "0.3.0", path = "../vexide-core" }
+vexide-core = { version = "0.4.0", path = "../vexide-core" }
 compile-time = "0.2.0"
 
 [lints]

--- a/packages/vexide-startup/src/banner/mod.rs
+++ b/packages/vexide-startup/src/banner/mod.rs
@@ -21,7 +21,7 @@ pub mod themes;
 /// This function is used internally in the [`startup`](crate::startup) function to print the banner.
 #[inline]
 pub fn print(theme: BannerTheme) {
-    const VEXIDE_VERSION: &str = "0.3.0";
+    const VEXIDE_VERSION: &str = "0.4.0";
 
     let system_version = unsafe { vexSystemVersion() }.to_be_bytes();
     let competition_status = unsafe { vexCompetitionStatus() };

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "async/await powered Rust library for VEX V5 Brains"
 keywords = ["Robotics", "bindings", "vex", "v5"]
@@ -25,12 +25,12 @@ compress = true
 
 [dependencies]
 vexide-async = { version = "0.1.2", path = "../vexide-async", optional = true, default-features = false }
-vexide-devices = { version = "0.3.0", path = "../vexide-devices", optional = true, default-features = false }
+vexide-devices = { version = "0.4.0", path = "../vexide-devices", optional = true, default-features = false }
 vexide-panic = { version = "0.1.2", path = "../vexide-panic", optional = true, default-features = false }
-vexide-core = { version = "0.3.0", path = "../vexide-core", optional = true, default-features = false }
-vexide-startup = { version = "0.2.0", path = "../vexide-startup", optional = true, default-features = false }
+vexide-core = { version = "0.4.0", path = "../vexide-core", optional = true, default-features = false }
+vexide-startup = { version = "0.3.0", path = "../vexide-startup", optional = true, default-features = false }
 vexide-graphics = { version = "0.1.2", path = "../vexide-graphics", optional = true, default-features = false }
-vexide-macro = { version = "0.2.0", path = "../vexide-macro", optional = true, default-features = false }
+vexide-macro = { version = "0.3.0", path = "../vexide-macro", optional = true, default-features = false }
 vex-sdk = "0.20.0"
 
 [features]

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -24,12 +24,12 @@ compress = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-vexide-async = { version = "0.1.2", path = "../vexide-async", optional = true, default-features = false }
+vexide-async = { version = "0.1.3", path = "../vexide-async", optional = true, default-features = false }
 vexide-devices = { version = "0.4.0", path = "../vexide-devices", optional = true, default-features = false }
-vexide-panic = { version = "0.1.2", path = "../vexide-panic", optional = true, default-features = false }
+vexide-panic = { version = "0.1.3", path = "../vexide-panic", optional = true, default-features = false }
 vexide-core = { version = "0.4.0", path = "../vexide-core", optional = true, default-features = false }
 vexide-startup = { version = "0.3.0", path = "../vexide-startup", optional = true, default-features = false }
-vexide-graphics = { version = "0.1.2", path = "../vexide-graphics", optional = true, default-features = false }
+vexide-graphics = { version = "0.1.3", path = "../vexide-graphics", optional = true, default-features = false }
 vexide-macro = { version = "0.3.0", path = "../vexide-macro", optional = true, default-features = false }
 vex-sdk = "0.20.0"
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Updates vexide versions to 0.4.0 for the upcoming release. The tag v0.4.0 will be created on merge.
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).

- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
