### PR TITLE
fix: rename Asynchronous category to asynchronous

### DIFF
--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 description = "The async executor at the core of vexide"
 keywords = ["Robotics", "bindings", "async", "vex", "v5"]
-categories = ["no-std", "science::robotics", "Asynchronous"]
+categories = ["no-std", "science::robotics", "asynchronous"]
 repository = "https://github.com/vexide/vexide"
 authors = [
     "vexide",


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR fixes an outdated category slug in vexide-async.
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).


-->
