### PR TITLE
refactor: switch to an all in one controller state getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,14 @@ Before releasing:
 
 ### Added
 
+- You can now detect controller release occurrences with `ButtonState::is_now_released`.
+
 ### Fixed
 
 ### Changed
 
 - Controller state is now returned all at once to reduce error checking. (#152) (**Breaking Change**)
+- `Button::was_pressed` has been renamed to `ButtonState::is_now_pressed`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Before releasing:
 
 ### Changed
 
+- Controller state is now returned all at once to reduce error checking. (#todo) (**Breaking Change**)
+
 ### Removed
 
 ### New Contributors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Before releasing:
 
 ### Changed
 
-- Controller state is now returned all at once to reduce error checking. (#todo) (**Breaking Change**)
+- Controller state is now returned all at once to reduce error checking. (#152) (**Breaking Change**)
 
 ### Removed
 

--- a/examples/clawbot.rs
+++ b/examples/clawbot.rs
@@ -55,31 +55,11 @@ impl Compete for ClawBot {
             // Limit Switch State
             let limit_switch_pressed = self.arm_limit_switch.is_high().unwrap_or_default();
 
-            // Controller Buttons
-            let r1_pressed = self
-                .controller
-                .right_trigger_1
-                .is_pressed()
-                .unwrap_or_default();
-            let r2_pressed = self
-                .controller
-                .right_trigger_2
-                .is_pressed()
-                .unwrap_or_default();
-            let l1_pressed = self
-                .controller
-                .left_trigger_1
-                .is_pressed()
-                .unwrap_or_default();
-            let l2_pressed = self
-                .controller
-                .left_trigger_2
-                .is_pressed()
-                .unwrap_or_default();
+            let c_state = self.controller.state().unwrap_or_default();
 
             // Simple arcade drive
-            let forward = self.controller.left_stick.y().unwrap_or_default();
-            let turn = self.controller.right_stick.x().unwrap_or_default();
+            let forward = c_state.right_stick.y();
+            let turn = c_state.right_stick.x();
             let mut left_voltage = (forward + turn) * Motor::MAX_VOLTAGE;
             let mut right_voltage = (forward - turn) * Motor::MAX_VOLTAGE;
 
@@ -94,18 +74,18 @@ impl Compete for ClawBot {
             self.right_motor.set_voltage(right_voltage).ok();
 
             // Arm control using the R1 and R2 buttons on the controller.
-            if r1_pressed {
+            if c_state.right_trigger_1.is_pressed() {
                 self.arm.set_voltage(12.0).ok();
-            } else if r2_pressed {
+            } else if c_state.right_trigger_2.is_pressed() {
                 self.arm.set_voltage(-12.0).ok();
             } else {
                 self.arm.brake(BrakeMode::Hold).ok();
             }
 
             // Claw control using the L1 and L2 buttons on the controller.
-            if l1_pressed {
+            if c_state.left_trigger_1.is_pressed() {
                 self.claw.set_voltage(12.0).ok();
-            } else if l2_pressed && !limit_switch_pressed {
+            } else if c_state.left_trigger_2.is_pressed() && !limit_switch_pressed {
                 self.claw.set_voltage(-12.0).ok();
             } else {
                 self.claw.brake(BrakeMode::Hold).ok();

--- a/examples/pneumatics.rs
+++ b/examples/pneumatics.rs
@@ -28,5 +28,7 @@ async fn main(peripherals: Peripherals) {
     Robot {
         controller: peripherals.primary_controller,
         solenoid: AdiSolenoid::new(peripherals.adi_a),
-    }.compete().await;
+    }
+    .compete()
+    .await;
 }

--- a/examples/pneumatics.rs
+++ b/examples/pneumatics.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+use vexide::prelude::*;
+
+struct Robot {
+    controller: Controller,
+    solenoid: AdiSolenoid,
+}
+
+impl Compete for Robot {
+    async fn driver(&mut self) {
+        loop {
+            let controller_state = self.controller.state().unwrap_or_default();
+
+            // Toggle the solenoid if button A got pressed.
+            if controller_state.button_a.is_now_pressed() {
+                self.solenoid.toggle().ok();
+            }
+
+            sleep(Controller::UPDATE_INTERVAL).await;
+        }
+    }
+}
+
+#[vexide::main]
+async fn main(peripherals: Peripherals) {
+    Robot {
+        controller: peripherals.primary_controller,
+        solenoid: AdiSolenoid::new(peripherals.adi_a),
+    }.compete().await;
+}

--- a/examples/smart_devices.rs
+++ b/examples/smart_devices.rs
@@ -34,14 +34,15 @@ async fn main(peripherals: Peripherals) {
     let distance = DistanceSensor::new(peripherals.port_16);
 
     loop {
+        let controller_state = controller.state().unwrap();
         // Simple tank drive
-        let left = controller.left_stick.y().unwrap();
-        let right = controller.right_stick.y().unwrap();
+        let left = controller_state.left_stick.y();
+        let right = controller_state.right_stick.y();
         left_motor.set_voltage(12.0 * left).unwrap();
         right_motor.set_voltage(12.0 * right).unwrap();
 
         println!("IMU Euler angles: {:?}", imu.euler().unwrap());
-        println!("Distance Sensor Object: {:?}", distance.object().unwrap(),);
+        println!("Distance Sensor Object: {:?}", distance.object().unwrap());
 
         // Don't hog the CPU
         sleep(Duration::from_millis(5)).await;

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -49,5 +49,7 @@ async fn main(peripherals: Peripherals) {
             Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
             Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
         ],
-    }.compete().await;
+    }
+    .compete()
+    .await;
 }

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -22,12 +22,16 @@ impl Compete for Robot {
 
             // Move left motors.
             for motor in self.left_motors.iter_mut() {
-                motor.set_voltage((forward + turn) * Motor::MAX_VOLTAGE).ok();
+                motor
+                    .set_voltage((forward + turn) * Motor::MAX_VOLTAGE)
+                    .ok();
             }
 
             // Move right motors.
             for motor in self.right_motors.iter_mut() {
-                motor.set_voltage((forward - turn) * Motor::MAX_VOLTAGE).ok();
+                motor
+                    .set_voltage((forward - turn) * Motor::MAX_VOLTAGE)
+                    .ok();
             }
 
             sleep(Controller::UPDATE_INTERVAL).await;

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -15,19 +15,19 @@ impl Compete for Robot {
         loop {
             let controller_state = self.controller.state().unwrap_or_default();
 
-            // - Right stick's vertical motion dictates the robot's forward power.
-            // - Left stick's sideways motion dictates the robot's turning power.
-            let fwd = controller_state.left_stick.x();
+            // - Right stick's vertical motion dictates the robot's forward voltage.
+            // - Left stick's sideways motion dictates the robot's turning voltage.
+            let forward = controller_state.right_stick.x();
             let turn = controller_state.left_stick.y();
 
             // Move left motors.
             for motor in self.left_motors.iter_mut() {
-                motor.set_voltage((fwd + turn) * Motor::MAX_VOLTAGE).ok();
+                motor.set_voltage((forward + turn) * Motor::MAX_VOLTAGE).ok();
             }
 
             // Move right motors.
             for motor in self.right_motors.iter_mut() {
-                motor.set_voltage((fwd - turn) * Motor::MAX_VOLTAGE).ok();
+                motor.set_voltage((forward - turn) * Motor::MAX_VOLTAGE).ok();
             }
 
             sleep(Controller::UPDATE_INTERVAL).await;

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -1,0 +1,53 @@
+#![no_std]
+#![no_main]
+
+use vexide::prelude::*;
+
+/// 6-motor drivetrain robot with split arcade controls.
+struct Robot {
+    controller: Controller,
+    left_motors: [Motor; 3],
+    right_motors: [Motor; 3],
+}
+
+impl Compete for Robot {
+    async fn driver(&mut self) {
+        loop {
+            let controller_state = self.controller.state().unwrap_or_default();
+
+            // - Right stick's vertical motion dictates the robot's forward power.
+            // - Left stick's sideways motion dictates the robot's turning power.
+            let fwd = controller_state.left_stick.x();
+            let turn = controller_state.left_stick.y();
+
+            // Move left motors.
+            for motor in self.left_motors.iter_mut() {
+                motor.set_voltage((fwd + turn) * Motor::MAX_VOLTAGE).ok();
+            }
+
+            // Move right motors.
+            for motor in self.right_motors.iter_mut() {
+                motor.set_voltage((fwd - turn) * Motor::MAX_VOLTAGE).ok();
+            }
+
+            sleep(Controller::UPDATE_INTERVAL).await;
+        }
+    }
+}
+
+#[vexide::main]
+async fn main(peripherals: Peripherals) {
+    Robot {
+        controller: peripherals.primary_controller,
+        left_motors: [
+            Motor::new(peripherals.port_1, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_2, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_3, Gearset::Blue, Direction::Forward),
+        ],
+        right_motors: [
+            Motor::new(peripherals.port_4, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
+        ],
+    }.compete().await;
+}

--- a/examples/tank_drive.rs
+++ b/examples/tank_drive.rs
@@ -1,0 +1,48 @@
+#![no_std]
+#![no_main]
+
+use vexide::prelude::*;
+
+/// 6-motor drivetrain robot with tank controls.
+struct Robot {
+    controller: Controller,
+    left_motors: [Motor; 3],
+    right_motors: [Motor; 3],
+}
+
+impl Compete for Robot {
+    async fn driver(&mut self) {
+        loop {
+            let controller_state = self.controller.state().unwrap_or_default();
+
+            // Move the left motors using the left stick's y-axis
+            for motor in self.left_motors.iter_mut() {
+                motor.set_voltage(controller_state.left_stick.y() * Motor::MAX_VOLTAGE).ok();
+            }
+
+            // Move the right motors using the left stick's y-axis
+            for motor in self.right_motors.iter_mut() {
+                motor.set_voltage(controller_state.right_stick.y() * Motor::MAX_VOLTAGE).ok();
+            }
+
+            sleep(Controller::UPDATE_INTERVAL).await;
+        }
+    }
+}
+
+#[vexide::main]
+async fn main(peripherals: Peripherals) {
+    Robot {
+        controller: peripherals.primary_controller,
+        left_motors: [
+            Motor::new(peripherals.port_1, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_2, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_3, Gearset::Blue, Direction::Forward),
+        ],
+        right_motors: [
+            Motor::new(peripherals.port_4, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
+        ],
+    }.compete().await;
+}

--- a/examples/tank_drive.rs
+++ b/examples/tank_drive.rs
@@ -17,12 +17,16 @@ impl Compete for Robot {
 
             // Move the left motors using the left stick's y-axis
             for motor in self.left_motors.iter_mut() {
-                motor.set_voltage(controller_state.left_stick.y() * Motor::MAX_VOLTAGE).ok();
+                motor
+                    .set_voltage(controller_state.left_stick.y() * Motor::MAX_VOLTAGE)
+                    .ok();
             }
 
             // Move the right motors using the left stick's y-axis
             for motor in self.right_motors.iter_mut() {
-                motor.set_voltage(controller_state.right_stick.y() * Motor::MAX_VOLTAGE).ok();
+                motor
+                    .set_voltage(controller_state.right_stick.y() * Motor::MAX_VOLTAGE)
+                    .ok();
             }
 
             sleep(Controller::UPDATE_INTERVAL).await;
@@ -44,5 +48,7 @@ async fn main(peripherals: Peripherals) {
             Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
             Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
         ],
-    }.compete().await;
+    }
+    .compete()
+    .await;
 }

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -1,4 +1,4 @@
-//! Controller support.
+//! V5 Controller
 //!
 //! This module allows you to read from the buttons and joysticks on the controller and write to the controller's display.
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR refactors the controller API so that all controller state is returned at once. A single controller channel cannot error without every other controller channel erroring, so this removes all unnecessary error handling.

Closes #131 

## Additional Context
- I have tested these changes on a VEX V5 brain.
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
