### PR TITLE
refactor: :recycle: improve controller screen API

### DIFF
--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -184,9 +184,9 @@ impl ControllerScreen {
     pub fn get_update_duration(&self) -> Option<Duration> {
         let connection = unsafe { Controller::new(self.id).connection() };
         match connection {
-            ControllerConnection::Offline => None
-            ControllerConnection::Tethered => Some(Duration::from_millis(10))
-            ControllerConnection::VexNet => Some(Duration::from_millis(50))
+            ControllerConnection::Offline => None,
+            ControllerConnection::Tethered => Some(Duration::from_millis(10)),
+            ControllerConnection::VexNet => Some(Duration::from_millis(50)),
         }
     }
 

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -233,8 +233,9 @@ impl ControllerScreen {
         if text.as_bytes().len() > Self::MAX_LINE_LENGTH {
             return Err(ControllerError::TextTooLong);
         }
+        let text = text.into_raw();
         unsafe {
-            vexControllerTextSet(id.0 as _, (line + 1) as _, (col + 1) as _, text.into_raw() as *const _);
+            vexControllerTextSet(id.0 as _, (line + 1) as _, (col + 1) as _, text as *const _);
         }
 
         // stop rust from leaking the CString
@@ -260,9 +261,9 @@ impl ControllerScreen {
         if text.as_bytes().len() > Self::MAX_RUMBLE_LENGTH {
             return Err(ControllerError::TextTooLong);
         }
-
+        let text = text.into_raw();
         unsafe {
-            vexControllerTextSet(id.0 as _, 3 as _, 0 as _, text.into_raw() as *const _);
+            vexControllerTextSet(id.0 as _, 3 as _, 0 as _, text as *const _);
         }
 
         // stop rust from leaking the CString

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -177,8 +177,7 @@ impl ControllerScreen {
     /// Maximum number of lines that text can be drawn at after clearing the screen.
     pub const MAX_LINES: usize = 3;
 
-    /// Returns the update duration of the screen in ms. Consecutive updates that are not
-    /// this duration apart will be ignored.
+    /// Returns the update duration of the screen.
     pub fn get_update_duration(&self) -> Option<Duration> {
         let connection = unsafe { Controller::new(self.id).connection() };
         match connection {

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -304,7 +304,7 @@ impl Controller {
     /// Creating new `Controller`s is inherently unsafe due to the possibility of constructing
     /// more than one screen at once allowing multiple mutable references to the same
     /// hardware device. Prefer using [`Peripherals`](crate::peripherals::Peripherals) to register devices if possible.
-    pub const unsafe fn new(id: ControllerId) -> Self {
+    pub unsafe fn new(id: ControllerId) -> Self {
         Self {
             id,
             screen: ControllerScreen {


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR updates the controller screen interface to move rumbles there, adds more error handling, and fixes some incorrect/suboptimal implementations of the controller screen functions.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
-->
