### PR TITLE
chore: bump vexide and update vex-sdk dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,27 @@ Before releasing:
 - @new-contributor made their first contribution in #11!
 -->
 
+
 ## [Unreleased]
 
 ### Added
 
 ### Fixed
+
+### Changed
+
+### Removed
+
+### New Contributors
+
+
+## [0.4.1]
+
+### Added
+
+### Fixed
+
+- Fixed an issue where `vex-sdk` functions that return or take floating point values would not work correctly. (#todo)
 
 ### Changed
 
@@ -141,3 +157,4 @@ Before releasing:
 [0.2.1]: https://github.com/vexide/vexide/compare/v0.2.0...v0.2.1
 [0.3.0]: https://github.com/vexide/vexide/compare/v0.2.1...v0.3.0
 [0.4.0]: https://github.com/vexide/vexide/compare/v0.3.0...v0.4.0
+[0.4.1]: https://github.com/vexide/vexide/compare/v0.4.0...v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Before releasing:
 
 ### Fixed
 
-- Fixed an issue where `vex-sdk` functions that return or take floating point values would not work correctly. (#todo)
+- Fixed an issue where `vex-sdk` functions that return or take floating point values would not work correctly. (#156)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Before releasing:
 
 ### Fixed
 
-- Fixed an issue where `vex-sdk` functions that return or take floating point values would not work correctly. (#156)
+- Updated to vex-sdk 0.21.0, fixing ABI incompatibilities between the VEXos calling convention and the hard-float ABI introduced in vexide 0.4.0. This should fix broken functions that pass floats to the SDK. (#156)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",
     "unstable-core-error",
 ] }
-vexide-async = { version = "0.1.3", path = "packages/vexide-async", default-features = false }
-vexide-core = { version = "0.4.0", path = "packages/vexide-core", default-features = false }
-vexide-devices = { version = "0.4.0", path = "packages/vexide-devices", default-features = false }
-vexide-panic = { version = "0.1.3", path = "packages/vexide-panic", default-features = false }
-vexide-startup = { version = "0.3.0", path = "packages/vexide-startup", default-features = false }
-vexide-graphics = { version = "0.1.3", path = "packages/vexide-graphics", default-features = false }
+vexide-async = { version = "0.1.4", path = "packages/vexide-async", default-features = false }
+vexide-core = { version = "0.4.1", path = "packages/vexide-core", default-features = false }
+vexide-devices = { version = "0.4.1", path = "packages/vexide-devices", default-features = false }
+vexide-panic = { version = "0.1.4", path = "packages/vexide-panic", default-features = false }
+vexide-startup = { version = "0.3.1", path = "packages/vexide-startup", default-features = false }
+vexide-graphics = { version = "0.1.4", path = "packages/vexide-graphics", default-features = false }
 vexide-macro = { version = "0.3.0", path = "packages/vexide-macro", default-features = false }
-vex-sdk = "0.20.0"
+vex-sdk = "0.21.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 
 [workspace.lints.clippy]

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-async"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "The async executor at the core of vexide"

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 description = "Core functionality for vexide"

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-devices"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 description = "High level device bindings for vexide"

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-graphics"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "Graphics driver implementations for vexide"

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-panic"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "Panic handler for vexide"

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-startup"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT"
 description = "Support code for V5 Brain user program booting"


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR updates the vex-sdk dependency and all vexide crates.
The tag v0.4.1 will be created on merge.
## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
