### PR TITLE
fix: build docs to target supporting vex-sdk calling convention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ vexide-panic = { version = "0.1.4", path = "packages/vexide-panic", default-feat
 vexide-startup = { version = "0.3.1", path = "packages/vexide-startup", default-features = false }
 vexide-graphics = { version = "0.1.4", path = "packages/vexide-graphics", default-features = false }
 vexide-macro = { version = "0.3.0", path = "packages/vexide-macro", default-features = false }
-vex-sdk = "0.21.0"
+vex-sdk = "0.22.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 
 [workspace.lints.clippy]

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -24,3 +24,6 @@ vex-sdk = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -44,3 +44,6 @@ workspace = true
 default = ["backtraces"]
 force_rust_libm = ["dep:libm"]
 backtraces = ["dep:vex-libunwind"]
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -35,3 +35,6 @@ workspace = true
 dangerous_motor_tuning = []
 smart_leds_trait = ["dep:smart-leds-trait"]
 nalgebra = ["dep:nalgebra"]
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -34,3 +34,6 @@ default = []
 
 embedded-graphics = ["dep:embedded-graphics-core"]
 slint = ["dep:slint"]
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide-macro/Cargo.toml
+++ b/packages/vexide-macro/Cargo.toml
@@ -23,3 +23,6 @@ proc-macro = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -30,3 +30,6 @@ backtraces = ["vexide-core/backtraces"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -25,3 +25,6 @@ workspace = true
 
 [features]
 default = []
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -65,3 +65,6 @@ embedded-graphics = ["vexide-graphics/embedded-graphics", "graphics"]
 
 panic = ["dep:vexide-panic"]
 display_panics = ["panic", "vexide-panic/display_panics"]
+
+[package.metadata.docs.rs]
+targets = [ "armv7a-none-eabi" ]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR should fix any possible issues with pros.rs docs builds.

should close #162 
 
## Additional Context
- These are *only* non-code changes (e.g. documentation, README.md).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).

- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
