### PR TITLE
feat: add support for 5.5W motors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Before releasing:
 - `battery::voltage` is now returned in volts rather than millivolts.
 - `battery::current` is now returned in amps rather than milliamps.
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
-- Renamed `Motor::MAX_VOLTAGE` to `Motor::MAX_VOLTAGE_V5` and added `Motor::MAX_VOLTAGE_EXP`. (#167) (**Breaking Change**)
+- Renamed `Motor::MAX_VOLTAGE` to `Motor::V5_MAX_VOLTAGE` and added `Motor::EXP_MAX_VOLTAGE`. (#167) (**Breaking Change**)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Before releasing:
 ### Added
 
 - You can now detect controller release occurrences with `ButtonState::is_now_released`.
-- Added support for 5.5W motors with two new constructors (`Motor::new_v5` and `Motor::new_exp`) and three new getters (`Motor::motor_type`, `Motor::is_v5`, and `Motor::is_exp`) for `Motor`. (#167)
+- Added support for 5.5W motors with a new constructor (`Motor::new_exp`) and three new getters (`Motor::motor_type`, `Motor::is_v5`, and `Motor::is_exp`) for `Motor`. (#167)
 
 ### Fixed
 
@@ -37,7 +37,6 @@ Before releasing:
 - `battery::voltage` is now returned in volts rather than millivolts.
 - `battery::current` is now returned in amps rather than milliamps.
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
-- Reworked `Motor::new` to take a enum with a variant for each motor type. (#167) (**Breaking Change**)
 - Renamed `Motor::MAX_VOLTAGE` to `Motor::MAX_VOLTAGE_V5` and added `Motor::MAX_VOLTAGE_EXP`. (#167) (**Breaking Change**)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Before releasing:
 ### Added
 
 - You can now detect controller release occurrences with `ButtonState::is_now_released`.
-- Added support for 5.5W motors with a new constructor (`Motor::new_exp`) and three new getters (`Motor::motor_type`, `Motor::is_v5`, and `Motor::is_exp`) for `Motor`. (#167)
+- Added support for 5.5W motors with a new constructor (`Motor::new_exp`) and four new getters (`Motor::max_voltage`, `Motor::motor_type`, `Motor::is_v5`, and `Motor::is_exp`) for `Motor`. (#167)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Before releasing:
 - `battery::current` is now returned in amps rather than milliamps.
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
 - Reworked `Motor::new` to take a enum with a variant for each motor type. (#167) (**Breaking Change**)
+- Renamed `Motor::MAX_VOLTAGE` to `Motor::MAX_VOLTAGE_V5` and added `Motor::MAX_VOLTAGE_EXP`. (#167) (**Breaking Change**)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Before releasing:
 ### Added
 
 - You can now detect controller release occurrences with `ButtonState::is_now_released`.
+- Added support for 5.5W motors with two new constructors (`Motor::new_v5` and `Motor::new_exp`) and three new getters (`Motor::motor_type`, `Motor::is_v5`, and `Motor::is_exp`) for `Motor`. (#167)
 
 ### Fixed
 
@@ -36,6 +37,7 @@ Before releasing:
 - `battery::voltage` is now returned in volts rather than millivolts.
 - `battery::current` is now returned in amps rather than milliamps.
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
+- Reworked `Motor::new` to take a enum with a variant for each motor type. (#167) (**Breaking Change**)
 
 ### Removed
 

--- a/examples/clawbot.rs
+++ b/examples/clawbot.rs
@@ -60,8 +60,8 @@ impl Compete for ClawBot {
             // Simple arcade drive
             let forward = c_state.right_stick.y();
             let turn = c_state.right_stick.x();
-            let mut left_voltage = (forward + turn) * Motor::MAX_VOLTAGE;
-            let mut right_voltage = (forward - turn) * Motor::MAX_VOLTAGE;
+            let mut left_voltage = (forward + turn) * Motor::MAX_VOLTAGE_V5;
+            let mut right_voltage = (forward - turn) * Motor::MAX_VOLTAGE_V5;
 
             // If we are pressing the bumpers, don't allow the motors to go in reverse
             if left_bumper_pressed || right_bumper_pressed {

--- a/examples/clawbot.rs
+++ b/examples/clawbot.rs
@@ -103,10 +103,10 @@ impl Compete for ClawBot {
 async fn main(peripherals: Peripherals) {
     // Configuring devices and handing off control to the [`Competition`] API.
     ClawBot {
-        left_motor: Motor::new_v5(peripherals.port_1, Gearset::Green, Direction::Forward),
-        right_motor: Motor::new_v5(peripherals.port_10, Gearset::Green, Direction::Reverse),
-        claw: Motor::new_v5(peripherals.port_3, Gearset::Green, Direction::Forward),
-        arm: Motor::new_v5(peripherals.port_8, Gearset::Green, Direction::Forward),
+        left_motor: Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward),
+        right_motor: Motor::new(peripherals.port_10, Gearset::Green, Direction::Reverse),
+        claw: Motor::new(peripherals.port_3, Gearset::Green, Direction::Forward),
+        arm: Motor::new(peripherals.port_8, Gearset::Green, Direction::Forward),
         left_bumper: AdiDigitalIn::new(peripherals.adi_a),
         right_bumper: AdiDigitalIn::new(peripherals.adi_b),
         arm_limit_switch: AdiDigitalIn::new(peripherals.adi_h),

--- a/examples/clawbot.rs
+++ b/examples/clawbot.rs
@@ -60,8 +60,8 @@ impl Compete for ClawBot {
             // Simple arcade drive
             let forward = c_state.right_stick.y();
             let turn = c_state.right_stick.x();
-            let mut left_voltage = (forward + turn) * Motor::MAX_VOLTAGE_V5;
-            let mut right_voltage = (forward - turn) * Motor::MAX_VOLTAGE_V5;
+            let mut left_voltage = (forward + turn) * Motor::V5_MAX_VOLTAGE;
+            let mut right_voltage = (forward - turn) * Motor::V5_MAX_VOLTAGE;
 
             // If we are pressing the bumpers, don't allow the motors to go in reverse
             if left_bumper_pressed || right_bumper_pressed {

--- a/examples/clawbot.rs
+++ b/examples/clawbot.rs
@@ -103,10 +103,10 @@ impl Compete for ClawBot {
 async fn main(peripherals: Peripherals) {
     // Configuring devices and handing off control to the [`Competition`] API.
     ClawBot {
-        left_motor: Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward),
-        right_motor: Motor::new(peripherals.port_10, Gearset::Green, Direction::Reverse),
-        claw: Motor::new(peripherals.port_3, Gearset::Green, Direction::Forward),
-        arm: Motor::new(peripherals.port_8, Gearset::Green, Direction::Forward),
+        left_motor: Motor::new_v5(peripherals.port_1, Gearset::Green, Direction::Forward),
+        right_motor: Motor::new_v5(peripherals.port_10, Gearset::Green, Direction::Reverse),
+        claw: Motor::new_v5(peripherals.port_3, Gearset::Green, Direction::Forward),
+        arm: Motor::new_v5(peripherals.port_8, Gearset::Green, Direction::Forward),
         left_bumper: AdiDigitalIn::new(peripherals.adi_a),
         right_bumper: AdiDigitalIn::new(peripherals.adi_b),
         arm_limit_switch: AdiDigitalIn::new(peripherals.adi_h),

--- a/examples/smart_devices.rs
+++ b/examples/smart_devices.rs
@@ -9,8 +9,8 @@ use vexide::prelude::*;
 async fn main(peripherals: Peripherals) {
     let controller = peripherals.primary_controller;
     // Create two new motors on smart ports 1 and 10.
-    let mut left_motor = Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward);
-    let mut right_motor = Motor::new(peripherals.port_10, Gearset::Green, Direction::Forward);
+    let mut left_motor = Motor::new_v5(peripherals.port_1, Gearset::Green, Direction::Forward);
+    let mut right_motor = Motor::new_v5(peripherals.port_10, Gearset::Green, Direction::Forward);
 
     // Create a new inertial sensor (IMU) on smart port 6.
     // We don't have to handle a result because this constructor is infallible.

--- a/examples/smart_devices.rs
+++ b/examples/smart_devices.rs
@@ -9,8 +9,8 @@ use vexide::prelude::*;
 async fn main(peripherals: Peripherals) {
     let controller = peripherals.primary_controller;
     // Create two new motors on smart ports 1 and 10.
-    let mut left_motor = Motor::new_v5(peripherals.port_1, Gearset::Green, Direction::Forward);
-    let mut right_motor = Motor::new_v5(peripherals.port_10, Gearset::Green, Direction::Forward);
+    let mut left_motor = Motor::new(peripherals.port_1, Gearset::Green, Direction::Forward);
+    let mut right_motor = Motor::new(peripherals.port_10, Gearset::Green, Direction::Forward);
 
     // Create a new inertial sensor (IMU) on smart port 6.
     // We don't have to handle a result because this constructor is infallible.

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -23,14 +23,14 @@ impl Compete for Robot {
             // Move left motors.
             for motor in self.left_motors.iter_mut() {
                 motor
-                    .set_voltage((forward + turn) * Motor::MAX_VOLTAGE_V5)
+                    .set_voltage((forward + turn) * Motor::V5_MAX_VOLTAGE)
                     .ok();
             }
 
             // Move right motors.
             for motor in self.right_motors.iter_mut() {
                 motor
-                    .set_voltage((forward - turn) * Motor::MAX_VOLTAGE_V5)
+                    .set_voltage((forward - turn) * Motor::V5_MAX_VOLTAGE)
                     .ok();
             }
 

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -23,14 +23,14 @@ impl Compete for Robot {
             // Move left motors.
             for motor in self.left_motors.iter_mut() {
                 motor
-                    .set_voltage((forward + turn) * Motor::MAX_VOLTAGE)
+                    .set_voltage((forward + turn) * Motor::MAX_VOLTAGE_V5)
                     .ok();
             }
 
             // Move right motors.
             for motor in self.right_motors.iter_mut() {
                 motor
-                    .set_voltage((forward - turn) * Motor::MAX_VOLTAGE)
+                    .set_voltage((forward - turn) * Motor::MAX_VOLTAGE_V5)
                     .ok();
             }
 

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -44,14 +44,14 @@ async fn main(peripherals: Peripherals) {
     Robot {
         controller: peripherals.primary_controller,
         left_motors: [
-            Motor::new(peripherals.port_1, Gearset::Blue, Direction::Reverse),
-            Motor::new(peripherals.port_2, Gearset::Blue, Direction::Reverse),
-            Motor::new(peripherals.port_3, Gearset::Blue, Direction::Forward),
+            Motor::new_v5(peripherals.port_1, Gearset::Blue, Direction::Reverse),
+            Motor::new_v5(peripherals.port_2, Gearset::Blue, Direction::Reverse),
+            Motor::new_v5(peripherals.port_3, Gearset::Blue, Direction::Forward),
         ],
         right_motors: [
-            Motor::new(peripherals.port_4, Gearset::Blue, Direction::Forward),
-            Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
-            Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
+            Motor::new_v5(peripherals.port_4, Gearset::Blue, Direction::Forward),
+            Motor::new_v5(peripherals.port_5, Gearset::Blue, Direction::Forward),
+            Motor::new_v5(peripherals.port_6, Gearset::Blue, Direction::Reverse),
         ],
     }
     .compete()

--- a/examples/split_arcade_drive.rs
+++ b/examples/split_arcade_drive.rs
@@ -44,14 +44,14 @@ async fn main(peripherals: Peripherals) {
     Robot {
         controller: peripherals.primary_controller,
         left_motors: [
-            Motor::new_v5(peripherals.port_1, Gearset::Blue, Direction::Reverse),
-            Motor::new_v5(peripherals.port_2, Gearset::Blue, Direction::Reverse),
-            Motor::new_v5(peripherals.port_3, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_1, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_2, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_3, Gearset::Blue, Direction::Forward),
         ],
         right_motors: [
-            Motor::new_v5(peripherals.port_4, Gearset::Blue, Direction::Forward),
-            Motor::new_v5(peripherals.port_5, Gearset::Blue, Direction::Forward),
-            Motor::new_v5(peripherals.port_6, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_4, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
         ],
     }
     .compete()

--- a/examples/tank_drive.rs
+++ b/examples/tank_drive.rs
@@ -18,14 +18,14 @@ impl Compete for Robot {
             // Move the left motors using the left stick's y-axis
             for motor in self.left_motors.iter_mut() {
                 motor
-                    .set_voltage(controller_state.left_stick.y() * Motor::MAX_VOLTAGE)
+                    .set_voltage(controller_state.left_stick.y() * Motor::MAX_VOLTAGE_V5)
                     .ok();
             }
 
             // Move the right motors using the left stick's y-axis
             for motor in self.right_motors.iter_mut() {
                 motor
-                    .set_voltage(controller_state.right_stick.y() * Motor::MAX_VOLTAGE)
+                    .set_voltage(controller_state.right_stick.y() * Motor::MAX_VOLTAGE_V5)
                     .ok();
             }
 

--- a/examples/tank_drive.rs
+++ b/examples/tank_drive.rs
@@ -18,14 +18,14 @@ impl Compete for Robot {
             // Move the left motors using the left stick's y-axis
             for motor in self.left_motors.iter_mut() {
                 motor
-                    .set_voltage(controller_state.left_stick.y() * Motor::MAX_VOLTAGE_V5)
+                    .set_voltage(controller_state.left_stick.y() * Motor::V5_MAX_VOLTAGE)
                     .ok();
             }
 
             // Move the right motors using the left stick's y-axis
             for motor in self.right_motors.iter_mut() {
                 motor
-                    .set_voltage(controller_state.right_stick.y() * Motor::MAX_VOLTAGE_V5)
+                    .set_voltage(controller_state.right_stick.y() * Motor::V5_MAX_VOLTAGE)
                     .ok();
             }
 

--- a/examples/tank_drive.rs
+++ b/examples/tank_drive.rs
@@ -39,14 +39,14 @@ async fn main(peripherals: Peripherals) {
     Robot {
         controller: peripherals.primary_controller,
         left_motors: [
-            Motor::new_v5(peripherals.port_1, Gearset::Blue, Direction::Reverse),
-            Motor::new_v5(peripherals.port_2, Gearset::Blue, Direction::Reverse),
-            Motor::new_v5(peripherals.port_3, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_1, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_2, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_3, Gearset::Blue, Direction::Forward),
         ],
         right_motors: [
-            Motor::new_v5(peripherals.port_4, Gearset::Blue, Direction::Forward),
-            Motor::new_v5(peripherals.port_5, Gearset::Blue, Direction::Forward),
-            Motor::new_v5(peripherals.port_6, Gearset::Blue, Direction::Reverse),
+            Motor::new(peripherals.port_4, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
+            Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
         ],
     }
     .compete()

--- a/examples/tank_drive.rs
+++ b/examples/tank_drive.rs
@@ -39,14 +39,14 @@ async fn main(peripherals: Peripherals) {
     Robot {
         controller: peripherals.primary_controller,
         left_motors: [
-            Motor::new(peripherals.port_1, Gearset::Blue, Direction::Reverse),
-            Motor::new(peripherals.port_2, Gearset::Blue, Direction::Reverse),
-            Motor::new(peripherals.port_3, Gearset::Blue, Direction::Forward),
+            Motor::new_v5(peripherals.port_1, Gearset::Blue, Direction::Reverse),
+            Motor::new_v5(peripherals.port_2, Gearset::Blue, Direction::Reverse),
+            Motor::new_v5(peripherals.port_3, Gearset::Blue, Direction::Forward),
         ],
         right_motors: [
-            Motor::new(peripherals.port_4, Gearset::Blue, Direction::Forward),
-            Motor::new(peripherals.port_5, Gearset::Blue, Direction::Forward),
-            Motor::new(peripherals.port_6, Gearset::Blue, Direction::Reverse),
+            Motor::new_v5(peripherals.port_4, Gearset::Blue, Direction::Forward),
+            Motor::new_v5(peripherals.port_5, Gearset::Blue, Direction::Forward),
+            Motor::new_v5(peripherals.port_6, Gearset::Blue, Direction::Reverse),
         ],
     }
     .compete()

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -138,9 +138,13 @@ impl Motor {
     /// The rate at which data can be written to a [`Motor`].
     pub const DATA_WRITE_INTERVAL: Duration = Duration::from_millis(5);
 
-
     /// Create a new V5 or EXP motor.
-    fn new_with_type(port: SmartPort, gearset: Gearset, direction: Direction, motor_type: MotorType) -> Self {
+    fn new_with_type(
+        port: SmartPort,
+        gearset: Gearset,
+        direction: Direction,
+        motor_type: MotorType,
+    ) -> Self {
         let device = unsafe { port.device_handle() }; // SAFETY: This function is only called once on this port.
 
         // NOTE: SDK properly stores device state when unplugged, meaning that we can safely
@@ -332,7 +336,7 @@ impl Motor {
 
     /// Returns the current position of the motor.
     pub fn position(&self) -> Result<Position, MotorError> {
-        let gearset =  self.gearset()?;
+        let gearset = self.gearset()?;
         Ok(Position::from_ticks(
             unsafe { vexDeviceMotorPositionGet(self.device) } as i64,
             gearset.ticks_per_revolution(),

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -144,8 +144,10 @@ pub enum MotorOptions {
 }
 
 impl Motor {
-    /// The maximum voltage value that can be sent to a [`Motor`].
-    pub const MAX_VOLTAGE: f64 = 12.0;
+    /// The maximum voltage value that can be sent to a V5 [`Motor`].
+    pub const MAX_VOLTAGE_V5: f64 = 12.0;
+    /// The maximum voltage value that can be sent to a EXP [`Motor`].
+    pub const MAX_VOLTAGE_EXP: f64 = 10.0;
 
     /// The rate at which data can be read from a [`Motor`].
     pub const DATA_READ_INTERVAL: Duration = Duration::from_millis(10);
@@ -514,6 +516,14 @@ impl Motor {
             false => Direction::Forward,
             true => Direction::Reverse,
         })
+    }
+
+    /// Gets the maximum voltage for the motor based off of its [motor type](Motor::motor_type).
+    pub const fn max_voltage(&self) -> f64 {
+        match self.motor_type {
+            MotorType::Exp => Self::MAX_VOLTAGE_EXP,
+            MotorType::V5 => Self::MAX_VOLTAGE_V5,
+        }
     }
 
     /// Adjusts the internal tuning constants of the motor when using velocity control.

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -153,7 +153,7 @@ impl Motor {
     /// The rate at which data can be written to a [`Motor`].
     pub const DATA_WRITE_INTERVAL: Duration = Duration::from_millis(5);
 
-    /// Create a new motor from a smart port index.
+    /// Create a new V5 or EXP motor.
     pub fn new(port: SmartPort, options: MotorOptions) -> Self {
         let device = unsafe { port.device_handle() }; // SAFETY: This function is only called once on this port.
 
@@ -187,6 +187,15 @@ impl Motor {
             device,
             motor_type,
         }
+    }
+
+    /// Creates a new 11W (V5) Smart Motor.
+    pub fn new_v5(port: SmartPort, gearset: Gearset, direction: Direction) -> Self {
+        Self::new(port, MotorOptions::V5 { gearset, direction })
+    }
+    /// Creates a new 5.5W (EXP) Smart Motor.
+    pub fn new_exp(port: SmartPort, direction: Direction) -> Self {
+        Self::new(port, MotorOptions::Exp { direction })
     }
 
     /// Sets the target that the motor should attempt to reach.

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -309,6 +309,14 @@ impl Motor {
     pub const fn motor_type(&self) -> MotorType {
         self.motor_type
     }
+    /// Returns `true` if the motor is a 5.5W (EXP) Smart Motor.
+    pub const fn is_exp(&self) -> bool {
+        self.motor_type.is_exp()
+    }
+    /// Returns `true` if the motor is an 11W (V5) Smart Motor.
+    pub const fn is_v5(&self) -> bool {
+        self.motor_type.is_v5()
+    }
 
     /// Gets the estimated angular velocity (RPM) of the motor.
     pub fn velocity(&self) -> Result<i32, MotorError> {

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -124,13 +124,21 @@ impl MotorType {
     pub const fn is_v5(&self) -> bool {
         matches!(self, Self::V5)
     }
+
+    /// Gets the maximum voltage for a motor of this type.
+    pub const fn max_voltage(&self) -> f64 {
+        match self {
+            MotorType::Exp => Motor::V5_MAX_VOLTAGE,
+            MotorType::V5 => Motor::EXP_MAX_VOLTAGE,
+        }
+    }
 }
 
 impl Motor {
     /// The maximum voltage value that can be sent to a V5 [`Motor`].
-    pub const MAX_VOLTAGE_V5: f64 = 12.0;
+    pub const V5_MAX_VOLTAGE: f64 = 12.0;
     /// The maximum voltage value that can be sent to a EXP [`Motor`].
-    pub const MAX_VOLTAGE_EXP: f64 = 10.0;
+    pub const EXP_MAX_VOLTAGE: f64 = 10.0;
 
     /// The rate at which data can be read from a [`Motor`].
     pub const DATA_READ_INTERVAL: Duration = Duration::from_millis(10);
@@ -310,6 +318,11 @@ impl Motor {
         self.motor_type.is_v5()
     }
 
+    /// Gets the maximum voltage for the motor based off of its [motor type](Motor::motor_type).
+    pub const fn max_voltage(&self) -> f64 {
+        self.motor_type.max_voltage()
+    }
+
     /// Gets the estimated angular velocity (RPM) of the motor.
     pub fn velocity(&self) -> Result<i32, MotorError> {
         self.validate_port()?;
@@ -487,14 +500,6 @@ impl Motor {
             false => Direction::Forward,
             true => Direction::Reverse,
         })
-    }
-
-    /// Gets the maximum voltage for the motor based off of its [motor type](Motor::motor_type).
-    pub const fn max_voltage(&self) -> f64 {
-        match self.motor_type {
-            MotorType::Exp => Self::MAX_VOLTAGE_EXP,
-            MotorType::V5 => Self::MAX_VOLTAGE_V5,
-        }
     }
 
     /// Adjusts the internal tuning constants of the motor when using velocity control.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR adds support for 5.5W Smart motors. This entails:
- a new constructor for `Motor`:`Motor::new_exp`.
- new motor type getters: `Motor::motor_type`, `Motor::is_v5`, `Motor::is_exp`.
- split `Motor::MAX_VOLTAGE` into `Motor::MAX_VOLTAGE_V5` and `Motor::MAX_VOLTAGE_EXP`.

Closes #140.
## Additional Context
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
