### PR TITLE
fix: implement into smartport seperately for every smart device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Before releasing:
 - `battery::current` is now returned in amps rather than milliamps.
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
 - Renamed `Motor::MAX_VOLTAGE` to `Motor::V5_MAX_VOLTAGE` and added `Motor::EXP_MAX_VOLTAGE`. (#167) (**Breaking Change**)
+- Moved the ability to convert Smart devices to `SmartPorts` out of the `SmartDevice` trait and into the devices themselves. (#171) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -82,6 +82,13 @@ impl SmartDevice for DistanceSensor {
         SmartDeviceType::Distance
     }
 }
+impl From<DistanceSensor> for SmartPort {
+    fn from(device: DistanceSensor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// Readings from a phyiscal object detected by a Distance Sensor.
 #[derive(Default, Debug, Clone, PartialEq, PartialOrd)]

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -84,9 +84,7 @@ impl SmartDevice for DistanceSensor {
 }
 impl From<DistanceSensor> for SmartPort {
     fn from(device: DistanceSensor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/expander.rs
+++ b/packages/vexide-devices/src/smart/expander.rs
@@ -64,3 +64,10 @@ impl SmartDevice for AdiExpander {
         SmartDeviceType::Adi
     }
 }
+impl From<AdiExpander> for SmartPort {
+    fn from(device: AdiExpander) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}

--- a/packages/vexide-devices/src/smart/expander.rs
+++ b/packages/vexide-devices/src/smart/expander.rs
@@ -66,8 +66,6 @@ impl SmartDevice for AdiExpander {
 }
 impl From<AdiExpander> for SmartPort {
     fn from(device: AdiExpander) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -133,9 +133,7 @@ impl SmartDevice for GpsSensor {
 }
 impl From<GpsSensor> for SmartPort {
     fn from(device: GpsSensor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -131,6 +131,13 @@ impl SmartDevice for GpsSensor {
         SmartDeviceType::Gps
     }
 }
+impl From<GpsSensor> for SmartPort {
+    fn from(device: GpsSensor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// GPS Sensor Internal IMU
 #[derive(Debug, PartialEq)]

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -255,6 +255,13 @@ impl SmartDevice for InertialSensor {
         SmartDeviceType::Imu
     }
 }
+impl From<InertialSensor> for SmartPort {
+    fn from(device: InertialSensor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// Represents one of six possible physical IMU orientations relative
 /// to the earth's center of gravity.

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -257,9 +257,7 @@ impl SmartDevice for InertialSensor {
 }
 impl From<InertialSensor> for SmartPort {
     fn from(device: InertialSensor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -201,6 +201,13 @@ impl SmartDevice for RadioLink {
         SmartDeviceType::GenericSerial
     }
 }
+impl From<RadioLink> for SmartPort {
+    fn from(device: RadioLink) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// The type of a radio link being established.
 ///

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -203,9 +203,7 @@ impl SmartDevice for RadioLink {
 }
 impl From<RadioLink> for SmartPort {
     fn from(device: RadioLink) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/mod.rs
+++ b/packages/vexide-devices/src/smart/mod.rs
@@ -108,14 +108,6 @@ pub trait SmartDevice {
     }
 }
 
-impl<T: SmartDevice> From<T> for SmartPort {
-    fn from(device: T) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
-    }
-}
-
 /// Verify that the device type is currently plugged into this port.
 ///
 /// This function provides the internal implementations of [`SmartDevice::validate_port`], [`SmartPort::validate_type`],

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -560,6 +560,13 @@ impl SmartDevice for Motor {
         SmartDeviceType::Motor
     }
 }
+impl From<Motor> for SmartPort {
+    fn from(device: Motor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// Determines how a motor should act when braking.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -562,9 +562,7 @@ impl SmartDevice for Motor {
 }
 impl From<Motor> for SmartPort {
     fn from(device: Motor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -194,9 +194,7 @@ impl SmartDevice for OpticalSensor {
 }
 impl From<OpticalSensor> for SmartPort {
     fn from(device: OpticalSensor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -192,6 +192,13 @@ impl SmartDevice for OpticalSensor {
         SmartDeviceType::Optical
     }
 }
+impl From<OpticalSensor> for SmartPort {
+    fn from(device: OpticalSensor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// Represents a gesture and its direction.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -204,3 +204,10 @@ impl SmartDevice for RotationSensor {
         SmartDeviceType::Rotation
     }
 }
+impl From<RotationSensor> for SmartPort {
+    fn from(device: RotationSensor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -206,8 +206,6 @@ impl SmartDevice for RotationSensor {
 }
 impl From<RotationSensor> for SmartPort {
     fn from(device: RotationSensor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -288,9 +288,7 @@ impl SmartDevice for SerialPort {
 }
 impl From<SerialPort> for SmartPort {
     fn from(device: SerialPort) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -286,6 +286,13 @@ impl SmartDevice for SerialPort {
         SmartDeviceType::GenericSerial
     }
 }
+impl From<SerialPort> for SmartPort {
+    fn from(device: SerialPort) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// Errors that can occur when interacting with a [`SerialPort`].
 #[derive(Debug, Snafu)]

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -428,9 +428,7 @@ impl SmartDevice for VisionSensor {
 }
 impl From<VisionSensor> for SmartPort {
     fn from(device: VisionSensor) -> Self {
-        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
-        // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number()) }
+        device.port
     }
 }
 

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -426,6 +426,13 @@ impl SmartDevice for VisionSensor {
         SmartDeviceType::Vision
     }
 }
+impl From<VisionSensor> for SmartPort {
+    fn from(device: VisionSensor) -> Self {
+        // SAFETY: We can do this, since we ensure that the old smart port was disposed of.
+        // This can effectively be thought as a move out of the device's private `port` field.
+        unsafe { Self::new(device.port_number()) }
+    }
+}
 
 /// A vision detection color signature.
 ///


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Fixes an issue where `SmartPort`s could be duplicated through a bad from implementation on any type implementing `SmartDevice`.
Closes #170 
## Additional Context
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
