### PR TITLE
refactor(ControllerScreen): use as_ptr instead of into_raw

### DIFF
--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -177,16 +177,16 @@ impl ControllerScreen {
         }
 
         let id: V5_ControllerId = self.id.into();
-        let text = CString::new(text)
-            .map_err(|_| ControllerError::NonTerminatingNul)?
-            .into_raw();
+        let text = CString::new(text).map_err(|_| ControllerError::NonTerminatingNul)?;
 
         unsafe {
-            vexControllerTextSet(id.0 as _, (line + 1) as _, (col + 1) as _, text as *const _);
+            vexControllerTextSet(
+                id.0 as _,
+                (line + 1) as _,
+                (col + 1) as _,
+                text.as_ptr() as *const u8,
+            );
         }
-
-        // stop rust from leaking the CString
-        drop(unsafe { CString::from_raw(text) });
 
         Ok(())
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Removes an unsafe block by using `as_ptr()` instead of `into_raw()`.