### PR TITLE
fix(core): use correct file/line macro in dbg!()

### DIFF
--- a/packages/vexide-core/src/io/stdio.rs
+++ b/packages/vexide-core/src/io/stdio.rs
@@ -180,7 +180,7 @@ pub use print;
 /// Prints and returns the value of a given expression for quick and dirty debugging.
 macro_rules! dbg {
     () => {
-        $crate::println!("[{}:{}]", $file!(), $line!())
+        $crate::println!("[{}:{}]", file!(), line!())
     };
     ($val:expr $(,)?) => {
         match $val {


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR uses the `file!` and `line!` macros correctly in the `dbg!` macro's empty arm.

## Additional Context

Fixes #173.

- I _haven't_ tested these changes on a VEX V5 brain. (My school is on break and I don't have access to the hardware now)
