### PR TITLE
refactor: rename `OpticalSensor::rgb` -> `color` and `raw` -> `raw_color`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Before releasing:
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
 - Renamed `Motor::MAX_VOLTAGE` to `Motor::V5_MAX_VOLTAGE` and added `Motor::EXP_MAX_VOLTAGE`. (#167) (**Breaking Change**)
 - Moved the ability to convert Smart devices to `SmartPorts` out of the `SmartDevice` trait and into the devices themselves. (#171) (**Breaking Change**)
+- Renamed `OpticalSensor::rgb` to `OpticalSensor::color` and `OpticalSensor::raw` to `OpticalSensor::raw_color` (#179) (**Breaking Change**).
 
 ### Removed
 

--- a/packages/vexide-devices/src/smart/optical.rs
+++ b/packages/vexide-devices/src/smart/optical.rs
@@ -130,7 +130,7 @@ impl OpticalSensor {
     }
 
     /// Get the processed RGB data from the sensor
-    pub fn rgb(&self) -> Result<OpticalRgb, PortError> {
+    pub fn color(&self) -> Result<OpticalRgb, PortError> {
         self.validate_port()?;
 
         let mut data = V5_DeviceOpticalRgb::default();
@@ -140,7 +140,7 @@ impl OpticalSensor {
     }
 
     /// Get the raw, unprocessed RGBC data from the sensor
-    pub fn raw(&self) -> Result<OpticalRaw, PortError> {
+    pub fn raw_color(&self) -> Result<OpticalRaw, PortError> {
         self.validate_port()?;
 
         let mut data = V5_DeviceOpticalRaw::default();


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This is a bit of a bikeshed, but I think these method names are a lot more clear in what they do. They also line up better with the naming of other methods with `raw` counterparts.