### PR TITLE
fix: make getters that do not access hardware infallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Before releasing:
 - Changed the incorrect return types of `AdiSolenoid::is_open` and `AdiSolenoid::is_closed` from `LogicLevel` to `bool`. (#164) (**Breaking Change**)
 - Renamed `Motor::MAX_VOLTAGE` to `Motor::V5_MAX_VOLTAGE` and added `Motor::EXP_MAX_VOLTAGE`. (#167) (**Breaking Change**)
 - Moved the ability to convert Smart devices to `SmartPorts` out of the `SmartDevice` trait and into the devices themselves. (#171) (**Breaking Change**)
+- Made the following functions infallible: `AdiAccelerometer::sensitivity`, `AdiAccelerometer::max_acceleration`, `AdiPotentiometer::potentiometer_type`, `AdiPotentiometer::max_angle`, `Motor::target`, and `RotationSensor::direction`. (#182) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/adi/accelerometer.rs
+++ b/packages/vexide-devices/src/adi/accelerometer.rs
@@ -28,7 +28,7 @@ impl AdiAccelerometer {
     /// Get the maximum acceleration measurement supported by the current [`Sensitivity`] jumper
     /// configuration.
     pub const fn max_acceleration(&self) -> f64 {
-       self.sensitivity().max_acceleration()
+        self.sensitivity().max_acceleration()
     }
 
     /// Gets the current acceleration measurement for this axis in g (~9.8 m/s/s).

--- a/packages/vexide-devices/src/adi/accelerometer.rs
+++ b/packages/vexide-devices/src/adi/accelerometer.rs
@@ -21,17 +21,14 @@ impl AdiAccelerometer {
     }
 
     /// Get the type of ADI accelerometer device.
-    pub fn sensitivity(&self) -> Result<Sensitivity, PortError> {
-        // Configuration check not required here since we don't access the SDK.
-        self.port.validate_expander()?;
-
-        Ok(self.sensitivity)
+    pub const fn sensitivity(&self) -> Sensitivity {
+        self.sensitivity
     }
 
     /// Get the maximum acceleration measurement supported by the current [`Sensitivity`] jumper
     /// configuration.
-    pub fn max_acceleration(&self) -> Result<f64, PortError> {
-        Ok(self.sensitivity()?.max_acceleration())
+    pub const fn max_acceleration(&self) -> f64 {
+       self.sensitivity().max_acceleration()
     }
 
     /// Gets the current acceleration measurement for this axis in g (~9.8 m/s/s).

--- a/packages/vexide-devices/src/adi/potentiometer.rs
+++ b/packages/vexide-devices/src/adi/potentiometer.rs
@@ -27,16 +27,13 @@ impl AdiPotentiometer {
     }
 
     /// Get the type of ADI potentiometer device.
-    pub fn potentiometer_type(&self) -> Result<PotentiometerType, PortError> {
-        // Configuration check not necessary since we don't fetch from the SDK.
-        self.port.validate_expander()?;
-
-        Ok(self.potentiometer_type)
+    pub const fn potentiometer_type(&self) -> PotentiometerType {
+        self.potentiometer_type
     }
 
     /// Get the maximum angle measurement (in degrees) for the given [`PotentiometerType`].
-    pub fn max_angle(&self) -> Result<f64, PortError> {
-        Ok(self.potentiometer_type()?.max_angle())
+    pub const fn max_angle(&self) -> f64 {
+        self.potentiometer_type().max_angle()
     }
 
     /// Gets the current potentiometer angle in degrees.

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -279,9 +279,8 @@ impl Motor {
     }
 
     /// Get the current [`MotorControl`] value that the motor is attempting to use.
-    pub fn target(&self) -> Result<MotorControl, MotorError> {
-        self.validate_port()?;
-        Ok(self.target)
+    pub const fn target(&self) -> MotorControl {
+        self.target
     }
 
     /// Sets the gearset of the motor.

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -105,7 +105,7 @@ impl RotationSensor {
         // behavior on our end without ever touching the status code.
         //
         // For more information: <https://www.vexforum.com/t/rotation-sensor-bug-workaround-on-vexos-1-1-0/96577/2>
-        if new_direction != self.direction()? {
+        if new_direction != self.direction() {
             self.direction_offset = self.position()?;
             self.raw_direction_offset = Position::from_ticks(
                 unsafe { vexDeviceAbsEncPositionGet(self.device) } as i64,
@@ -134,7 +134,7 @@ impl RotationSensor {
     }
 
     /// Gets whether or not the rotation sensor should be reversed.
-    pub fn direction(&self) -> Direction {
+    pub const fn direction(&self) -> Direction {
         self.direction
     }
 

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -133,11 +133,9 @@ impl RotationSensor {
         Ok(())
     }
 
-    /// Sets whether or not the rotation sensor should be reversed.
-    pub fn direction(&self) -> Result<Direction, PortError> {
-        self.validate_port()?;
-
-        Ok(self.direction)
+    /// Gets whether or not the rotation sensor should be reversed.
+    pub fn direction(&self) -> Direction {
+        self.direction
     }
 
     /// Get the total number of degrees rotated by the sensor based on direction.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Changes several device getters that do not interact with hardware to be infallible.
Closes #172 
## Additional Context
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).

-->
