### PR TITLE
bugfix: controller: fixed initial was_pressed

### DIFF
--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -62,10 +62,12 @@ impl Button {
     /// function was called.
     pub fn was_pressed(&mut self) -> Result<bool, ControllerError> {
         if self.is_pressed()? {
+            if !self.was_pressed {
+                self.was_pressed = true;
+                return Ok(true);
+            }
+        } else {
             self.was_pressed = false;
-        } else if !self.was_pressed {
-            self.was_pressed = true;
-            return Ok(true);
         }
 
         Ok(false)
@@ -261,62 +263,62 @@ impl Controller {
             button_a: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonA,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_b: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonB,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_x: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonX,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_y: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonY,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_up: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonUp,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_down: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonDown,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_left: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonLeft,
-                was_pressed: true,
+                was_pressed: false,
             },
             button_right: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonRight,
-                was_pressed: true,
+                was_pressed: false,
             },
             left_trigger_1: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonL1,
-                was_pressed: true,
+                was_pressed: false,
             },
             left_trigger_2: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonL2,
-                was_pressed: true,
+                was_pressed: false,
             },
             right_trigger_1: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonR1,
-                was_pressed: true,
+                was_pressed: false,
             },
             right_trigger_2: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonR2,
-                was_pressed: true,
+                was_pressed: false,
             },
         }
     }

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -261,62 +261,62 @@ impl Controller {
             button_a: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonA,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_b: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonB,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_x: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonX,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_y: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonY,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_up: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonUp,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_down: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonDown,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_left: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonLeft,
-                was_pressed: false,
+                was_pressed: true,
             },
             button_right: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonRight,
-                was_pressed: false,
+                was_pressed: true,
             },
             left_trigger_1: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonL1,
-                was_pressed: false,
+                was_pressed: true,
             },
             left_trigger_2: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonL2,
-                was_pressed: false,
+                was_pressed: true,
             },
             right_trigger_1: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonR1,
-                was_pressed: false,
+                was_pressed: true,
             },
             right_trigger_2: Button {
                 id,
                 channel: V5_ControllerIndex::ButtonR2,
-                was_pressed: false,
+                was_pressed: true,
             },
         }
     }


### PR DESCRIPTION
`was_pressed` field needs to initialise as true, otherwise the initial call of `was_pressed()` will return true even if the button hasn't been touched.

## Describe the changes this PR makes. Why should it be merged?

fixes the behaviour of was_pressed in vexide 0.4.2.

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->

- I have tested these changes on a VEX V5 brain.
