### PR TITLE
fix: use correct motor velocity getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Before releasing:
 ### Fixed
 
 - The `dbg!();` now works as expected when no arguments are supplied to it. (#175)
+- `Motor::velocity` now returns the estimated velocity instead of target velocity. (#184)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Before releasing:
 ### Fixed
 
 - The `dbg!();` now works as expected when no arguments are supplied to it. (#175)
-- `Motor::velocity` now returns the estimated velocity instead of target velocity. (#184)
+- `Motor::velocity` now correctly returns the estimated velocity instead of target velocity. (#184) (**Breaking Change**)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ vexide-panic = { version = "0.1.4", path = "packages/vexide-panic", default-feat
 vexide-startup = { version = "0.3.1", path = "packages/vexide-startup", default-features = false }
 vexide-graphics = { version = "0.1.4", path = "packages/vexide-graphics", default-features = false }
 vexide-macro = { version = "0.3.0", path = "packages/vexide-macro", default-features = false }
-vex-sdk = "0.22.0"
+vex-sdk = "0.23.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 
 [workspace.lints.clippy]

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -12,9 +12,9 @@ use vex_sdk::{
     vexDeviceMotorPositionGet, vexDeviceMotorPositionRawGet, vexDeviceMotorPositionReset,
     vexDeviceMotorPositionSet, vexDeviceMotorPowerGet, vexDeviceMotorReverseFlagGet,
     vexDeviceMotorReverseFlagSet, vexDeviceMotorTemperatureGet, vexDeviceMotorTorqueGet,
-    vexDeviceMotorVelocityGet, vexDeviceMotorVelocitySet, vexDeviceMotorVelocityUpdate,
-    vexDeviceMotorVoltageGet, vexDeviceMotorVoltageLimitGet, vexDeviceMotorVoltageLimitSet,
-    vexDeviceMotorVoltageSet, V5MotorBrakeMode, V5MotorGearset, V5_DeviceT,
+    vexDeviceMotorVelocitySet, vexDeviceMotorVelocityUpdate, vexDeviceMotorVoltageGet,
+    vexDeviceMotorVoltageLimitGet, vexDeviceMotorVoltageLimitSet, vexDeviceMotorVoltageSet,
+    V5MotorBrakeMode, V5MotorGearset, V5_DeviceT,
 };
 #[cfg(feature = "dangerous_motor_tuning")]
 use vex_sdk::{vexDeviceMotorPositionPidSet, vexDeviceMotorVelocityPidSet, V5_DeviceMotorPid};

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -5,16 +5,16 @@ use core::time::Duration;
 use bitflags::bitflags;
 use snafu::Snafu;
 use vex_sdk::{
-    vexDeviceMotorAbsoluteTargetSet, vexDeviceMotorBrakeModeSet, vexDeviceMotorCurrentGet,
-    vexDeviceMotorCurrentLimitGet, vexDeviceMotorCurrentLimitSet, vexDeviceMotorEfficiencyGet,
-    vexDeviceMotorEncoderUnitsSet, vexDeviceMotorFaultsGet, vexDeviceMotorFlagsGet,
-    vexDeviceMotorGearingGet, vexDeviceMotorGearingSet, vexDeviceMotorPositionGet,
-    vexDeviceMotorPositionRawGet, vexDeviceMotorPositionReset, vexDeviceMotorPositionSet,
-    vexDeviceMotorPowerGet, vexDeviceMotorReverseFlagGet, vexDeviceMotorReverseFlagSet,
-    vexDeviceMotorTemperatureGet, vexDeviceMotorTorqueGet, vexDeviceMotorVelocityGet,
-    vexDeviceMotorVelocitySet, vexDeviceMotorVelocityUpdate, vexDeviceMotorVoltageGet,
-    vexDeviceMotorVoltageLimitGet, vexDeviceMotorVoltageLimitSet, vexDeviceMotorVoltageSet,
-    V5MotorBrakeMode, V5MotorGearset, V5_DeviceT,
+    vexDeviceMotorAbsoluteTargetSet, vexDeviceMotorActualVelocityGet, vexDeviceMotorBrakeModeSet,
+    vexDeviceMotorCurrentGet, vexDeviceMotorCurrentLimitGet, vexDeviceMotorCurrentLimitSet,
+    vexDeviceMotorEfficiencyGet, vexDeviceMotorEncoderUnitsSet, vexDeviceMotorFaultsGet,
+    vexDeviceMotorFlagsGet, vexDeviceMotorGearingGet, vexDeviceMotorGearingSet,
+    vexDeviceMotorPositionGet, vexDeviceMotorPositionRawGet, vexDeviceMotorPositionReset,
+    vexDeviceMotorPositionSet, vexDeviceMotorPowerGet, vexDeviceMotorReverseFlagGet,
+    vexDeviceMotorReverseFlagSet, vexDeviceMotorTemperatureGet, vexDeviceMotorTorqueGet,
+    vexDeviceMotorVelocityGet, vexDeviceMotorVelocitySet, vexDeviceMotorVelocityUpdate,
+    vexDeviceMotorVoltageGet, vexDeviceMotorVoltageLimitGet, vexDeviceMotorVoltageLimitSet,
+    vexDeviceMotorVoltageSet, V5MotorBrakeMode, V5MotorGearset, V5_DeviceT,
 };
 #[cfg(feature = "dangerous_motor_tuning")]
 use vex_sdk::{vexDeviceMotorPositionPidSet, vexDeviceMotorVelocityPidSet, V5_DeviceMotorPid};
@@ -323,9 +323,13 @@ impl Motor {
     }
 
     /// Gets the estimated angular velocity (RPM) of the motor.
-    pub fn velocity(&self) -> Result<i32, MotorError> {
+    ///
+    /// # Note
+    ///
+    /// To get the current **target** velocity instead of the estimated velocity, use [`Motor::target`].
+    pub fn velocity(&self) -> Result<f64, MotorError> {
         self.validate_port()?;
-        Ok(unsafe { vexDeviceMotorVelocityGet(self.device) })
+        Ok(unsafe { vexDeviceMotorActualVelocityGet(self.device) })
     }
 
     /// Returns the power drawn by the motor in Watts.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR fixes an issue where `Motor::velocity` did not actually return the estimated velocity.
This is blocking on an update to vex-sdk that fixes the absolute velocity sdk call address.
## Additional Context
- I have tested these changes on a VEX V5 brain.
- These are breaking changes (semver: major).
<!--

Move all applicable items out of the comment:

- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
