### PR TITLE
fix: use correct max voltage for 5.5w motor

### DIFF
--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -138,7 +138,7 @@ impl Motor {
     /// The maximum voltage value that can be sent to a V5 [`Motor`].
     pub const V5_MAX_VOLTAGE: f64 = 12.0;
     /// The maximum voltage value that can be sent to a EXP [`Motor`].
-    pub const EXP_MAX_VOLTAGE: f64 = 10.0;
+    pub const EXP_MAX_VOLTAGE: f64 = 8.0;
 
     /// The rate at which data can be read from a [`Motor`].
     pub const DATA_READ_INTERVAL: Duration = Duration::from_millis(10);


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
