### PR TITLE
fix: program exit behavior on single-core targets

### DIFF
--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -3,7 +3,7 @@
 
 use core::{convert::Infallible, fmt::Debug, time::Duration};
 
-use vex_sdk::{vexSerialWriteFree, vexSystemExitRequest, vexTaskSleep, vexTasksRun};
+use vex_sdk::{vexSerialWriteFree, vexSystemExitRequest, vexTasksRun};
 
 use crate::{io, time::Instant};
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Our current exit behavior has the possibility of freezing the CPU if we're compiling for a single-core target like EXP, since VEXos would get no time to handle a `vexSystemExitRequest`. This PR fixes that by calling `vexTasksRun` while waiting for the exit request to complete and also cleans up some docs around it.
