### PR TITLE
feat: add controller ID getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Before releasing:
 - Added support for 5.5W motors with a new constructor (`Motor::new_exp`) and four new getters (`Motor::max_voltage`, `Motor::motor_type`, `Motor::is_v5`, and `Motor::is_exp`) for `Motor`. (#167)
 - The conditions upon which functions return errors are now documented. (#155).
 - Implemented the `Copy` trait for `BannerTheme`.
+- Added a getter that retrieves a `Controller`'s identifier. (#189)
 
 ### Fixed
 

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -321,7 +321,7 @@ impl Controller {
         }
     }
 
-    /// Gets the identifier of this controller.
+    /// Returns the identifier of this controller.
     #[must_use]
     pub const fn id(&self) -> ControllerId {
         self.id

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -321,6 +321,12 @@ impl Controller {
         }
     }
 
+    /// Gets the identifier of this controller.
+    #[must_use]
+    pub const fn id(&self) -> ControllerId {
+        self.id
+    }
+
     /// Returns the current state of all buttons and joysticks on the controller.
     ///
     /// # Note


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Adds a getter to retrieve a controller's ID. This is useful for debugging and logging as it provides users with more information about the controller.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
-->
