### PR TITLE
fix: improve rust 2024 compat

### DIFF
--- a/packages/vexide-core/src/float/newlib.rs
+++ b/packages/vexide-core/src/float/newlib.rs
@@ -27,13 +27,13 @@ static mut errno: c_int = 0;
 ///
 /// This function returns a raw pointer to a mutable static. It is intended for
 /// interoptability with libm.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn __errno() -> *mut c_int {
     core::ptr::addr_of_mut!(errno)
 }
 
 #[link(name = "m")]
-extern "C" {
+unsafe extern "C" {
     //
     // f32 bindings
     //

--- a/packages/vexide-core/src/float/newlib.rs
+++ b/packages/vexide-core/src/float/newlib.rs
@@ -27,7 +27,7 @@ static mut errno: c_int = 0;
 ///
 /// This function returns a raw pointer to a mutable static. It is intended for
 /// interoptability with libm.
-#[unsafe(no_mangle)]
+#[unsafe(no_mangle)] // SAFETY: libm requires this symbol to exist, and this is the only place it is defined
 unsafe extern "C" fn __errno() -> *mut c_int {
     core::ptr::addr_of_mut!(errno)
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Fixes some warnings that will become errors in Rust 2024.

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
