### PR TITLE
fix: remove useless generics from `AdiAddrLed::new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Before releasing:
 - `AdiAddrLed::set_pixel` will now correctly return an error if the device's ADI expander is disconnected. (#155)
 - The `dbg!();` now works as expected when no arguments are supplied to it. (#175)
 - `Motor::velocity` now correctly returns the estimated velocity instead of target velocity. (#184) (**Breaking Change**)
+- Removed useless generics from `AdiAddrLed::new`. (#197) (**Breaking Change**)
 
 ### Changed
 

--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -30,7 +30,7 @@ impl AdiAddrLed {
     ///
     /// If the `length` parameter exceeds [`Self::MAX_LENGTH`], the function returns
     /// [`AddrLedError::BufferTooLarge`].
-    pub fn new<T, I>(port: AdiPort, length: usize) -> Result<Self, AddrLedError> {
+    pub fn new(port: AdiPort, length: usize) -> Result<Self, AddrLedError> {
         if length > Self::MAX_LENGTH {
             return Err(AddrLedError::BufferTooLarge);
         }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Does what it says in the title.
Closes #191.
## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
