### PR TITLE
refactor: rename `AddrLedError::Adi` to `AddrLedError::Port`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Before releasing:
 - Made the following functions infallible: `AdiAccelerometer::sensitivity`, `AdiAccelerometer::max_acceleration`, `AdiPotentiometer::potentiometer_type`, `AdiPotentiometer::max_angle`, `Motor::target`, and `RotationSensor::direction`. (#182) (**Breaking Change**)
 - `OpticalSensor::led_brightness` now returns a number from `0.0` - `1.0` rather than a number from `1` - `100`. (#155) (**Breaking Change**)
 - Renamed `Motor::update_profiled_velocity` to `Motor::set_profiled_velocity`. (#155) (**Breaking Change**)
-- Renamed `AddrledError::Adi` to `AddrledError::Port`.
+- Renamed `AddrledError::Adi` to `AddrledError::Port`. (#203) (**Breaking Change**)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Before releasing:
 - Made the following functions infallible: `AdiAccelerometer::sensitivity`, `AdiAccelerometer::max_acceleration`, `AdiPotentiometer::potentiometer_type`, `AdiPotentiometer::max_angle`, `Motor::target`, and `RotationSensor::direction`. (#182) (**Breaking Change**)
 - `OpticalSensor::led_brightness` now returns a number from `0.0` - `1.0` rather than a number from `1` - `100`. (#155) (**Breaking Change**)
 - Renamed `Motor::update_profiled_velocity` to `Motor::set_profiled_velocity`. (#155) (**Breaking Change**)
+- Renamed `AddrledError::Adi` to `AddrledError::Port`.
 
 ### Removed
 

--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -164,9 +164,9 @@ pub enum AddrLedError {
     /// The length of the provided buffer exceeded the maximum strip length that ADI can control (64).
     BufferTooLarge,
 
-    #[snafu(display("{source}"), context(false))]
     /// Generic ADI related error.
-    Adi {
+    #[snafu(display("{source}"), context(false))]
+    Port {
         /// The source of the error
         source: PortError,
     },


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Closes #159. Breaking Change.