### PR TITLE
feat: `SerialPort::set_baud_rate`, `read_byte` mutability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Before releasing:
 - Added the ability to return Smart Ports, ADI ports, the display, and controllers to `DynamicPeripherals`. (#196)
 - Added a `SmartDevice::UPDATE_INTERVAL` constant for all devices, representing the amount of time between data updates from a given device. (#199) (**Breaking Change**)
 - Added a `toggle` method to `AdiDigitalOut` to toggle between level outputs.
+- Added a `SerialPort::set_baud_rate` method for the adjusting baudrate of a generic serial smartport after initialization. (#217)
 
 ### Fixed
 
@@ -62,6 +63,7 @@ Before releasing:
 - Renamed `InertialSensor::set_data_rate` to `InertialSensor::set_data_interval`. (#199) (**Breaking Change**)
 - Renamed `Motor::DATA_WRITE_INTERVAL` to `Motor::WRITE_INTERVAL`. (#199) (**Breaking Change**)
 - Renamed `InertialSensor::accel` to `InertialSensor::acceleration` (#213) (**Breaking Change**)
+- `SerialPort::read_byte` now takes `&mut self`. (#215) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -78,6 +78,24 @@ impl SerialPort {
         Self { port, device }
     }
 
+    /// Configures the baud rate of the serial port.
+    ///
+    /// Baud rate determines the speed of communication over the data channel. Under normal conditions, user code is limited
+    /// to a maximum baudrate of 921600.
+    ///
+    /// # Errors
+    ///
+    /// - A [`SerialError::Port`] error is returned if a generic serial device is not currently connected to the Smart Port.
+    pub fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), SerialError> {
+        self.validate_port()?;
+
+        unsafe {
+            vexDeviceGenericSerialBaudrate(self.device, baud_rate as i32);
+        }
+
+        Ok(())
+    }
+
     /// Clears the internal input and output FIFO buffers.
     ///
     /// This can be useful to reset state and remove old, potentially unneeded data
@@ -130,7 +148,7 @@ impl SerialPort {
     /// # Errors
     ///
     /// - A [`SerialError::Port`] error is returned if a generic serial device is not currently connected to the Smart Port.
-    pub fn read_byte(&self) -> Result<Option<u8>, SerialError> {
+    pub fn read_byte(&mut self) -> Result<Option<u8>, SerialError> {
         self.validate_port()?;
 
         let byte = unsafe { vexDeviceGenericSerialReadChar(self.device) };


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- Added a `SerialPort::set_baud_rate` method for the adjusting baudrate of a generic serial smartport after initialization.
- `SerialPort::read_byte` now takes `&mut self`. 

## Additional Context
Closes #216.