### PR TITLE
docs: fix electromagnet examples, add `SerialPort::set_baud_rate` exampe

### DIFF
--- a/packages/vexide-devices/src/smart/electromagnet.rs
+++ b/packages/vexide-devices/src/smart/electromagnet.rs
@@ -48,7 +48,7 @@ impl Electromagnet {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let electromagnet = Electromagnet::new(peripherals.port_1);
+    ///     let mut electromagnet = Electromagnet::new(peripherals.port_1);
     ///     // Use the electromagnet
     ///     _ = electromagnet.set_power(1.0, Electromagnet::MAX_POWER_DURATION);
     ///     _ = electromagnet.set_power(-0.2, Duration::from_secs(1));
@@ -80,7 +80,7 @@ impl Electromagnet {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let electromagnet = Electromagnet::new(peripherals.port_1);
+    ///     let mut electromagnet = Electromagnet::new(peripherals.port_1);
     ///     _ = electromagnet.set_power(1.0, Electromagnet::MAX_POWER_DURATION);
     /// }
     /// ```
@@ -111,10 +111,12 @@ impl Electromagnet {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let electromagnet = Electromagnet::new(peripherals.port_1);
+    ///     let mut electromagnet = Electromagnet::new(peripherals.port_1);
     ///     _ = electromagnet.set_power(0.5, Electromagnet::MAX_POWER_DURATION);
-    ///     let power = electromagnet.power().unwrap();
-    ///     println!("Power: {}", power);
+    ///
+    ///     if let Ok(power) = electromagnet.power() {
+    ///         println!("Power: {}%", power * 100.0);
+    ///     }
     /// }
     /// ```
     pub fn power(&self) -> Result<f64, PortError> {
@@ -138,10 +140,12 @@ impl Electromagnet {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let electromagnet = Electromagnet::new(peripherals.port_1);
+    ///     let mut electromagnet = Electromagnet::new(peripherals.port_1);
     ///     _ = electromagnet.set_power(1.0, Electromagnet::MAX_POWER_DURATION);
-    ///     let current = electromagnet.current().unwrap();
-    ///     println!("Current: {}", current);
+    ///
+    ///     if let Ok(current) = electromagnet.current() {
+    ///         println!("Current: {}A", current);
+    ///     }
     /// }
     /// ```
     pub fn current(&self) -> Result<f64, PortError> {
@@ -166,7 +170,10 @@ impl Electromagnet {
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
     ///     let electromagnet = Electromagnet::new(peripherals.port_1);
-    ///     println!("Temperature: {}", electromagnet.temperature().unwrap());
+    ///
+    ///     if let Ok(temperature) = electromagnet.temperature() {
+    ///         println!("Temperature: {}°C", temperature);
+    ///     }
     /// }
     /// ```
     pub fn temperature(&self) -> Result<f64, PortError> {
@@ -191,7 +198,10 @@ impl Electromagnet {
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
     ///     let electromagnet = Electromagnet::new(peripherals.port_1);
-    ///     println!("Status: {:b}", electromagnet.status().unwrap());
+    ///
+    ///     if let Ok(status) = electromagnet.status() {
+    ///         println!("Status: {:b}", status);
+    ///     }
     /// }
     /// ```
     pub fn status(&self) -> Result<u32, PortError> {

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -91,6 +91,20 @@ impl SerialPort {
     /// # Errors
     ///
     /// - A [`SerialError::Port`] error is returned if a generic serial device is not currently connected to the Smart Port.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use vexide::prelude::*;
+    ///
+    /// #[vexide::main]
+    /// async fn main(peripherals: Peripherals) {
+    ///     let mut serial = SerialPort::open(peripherals.port_1, 115200);
+    ///
+    ///     // Change to 9600 baud
+    ///     _ = serial.set_baud_rate(9600);
+    /// }
+    /// ```
     pub fn set_baud_rate(&mut self, baud_rate: u32) -> Result<(), SerialError> {
         self.validate_port()?;
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- Removes `unwrap` calls in electromagnet examples.
- Adds mutability to electromagnet instance in examples that require it.
- Adds an example for `SerialPort::set_baud_rate`.