### PR TITLE
fix: correctly bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,21 @@ Before releasing:
 
 @zabackary made their first contribution in #164!
 
+
+## [0.4.2]
+
+### Added
+
+### Fixed
+
+- Fixed an issue related to the calling convention of vex-sdk functions causing docs.rs api reference build failures. (#165)
+
+### Changed
+
+### Removed
+
+### New Contributors
+
 ## [0.4.1]
 
 ### Added
@@ -241,4 +256,5 @@ Before releasing:
 [0.3.0]: https://github.com/vexide/vexide/compare/v0.2.1...v0.3.0
 [0.4.0]: https://github.com/vexide/vexide/compare/v0.3.0...v0.4.0
 [0.4.1]: https://github.com/vexide/vexide/compare/v0.4.0...v0.4.1
-[0.5.0]: https://github.com/vexide/vexide/compare/v0.4.1...v0.5.0
+[0.4.2]: https://github.com/vexide/vexide/compare/v0.4.1...v0.4.2
+[0.5.0]: https://github.com/vexide/vexide/compare/v0.4.2...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ snafu = { version = "0.8.0", default-features = false, features = [
     "rust_1_61",
     "unstable-core-error",
 ] }
-vexide-async = { version = "0.1.5-rc.1", path = "packages/vexide-async", default-features = false }
-vexide-core = { version = "0.5.0-rc.1", path = "packages/vexide-core", default-features = false }
-vexide-devices = { version = "0.5.0-rc.1", path = "packages/vexide-devices", default-features = false }
-vexide-panic = { version = "0.1.5-rc.1", path = "packages/vexide-panic", default-features = false }
-vexide-startup = { version = "0.3.2-rc.1", path = "packages/vexide-startup", default-features = false }
-vexide-graphics = { version = "0.1.5-rc.1", path = "packages/vexide-graphics", default-features = false }
+vexide-async = { version = "0.1.6-rc.1", path = "packages/vexide-async", default-features = false }
+vexide-core = { version = "0.5.0-rc.2", path = "packages/vexide-core", default-features = false }
+vexide-devices = { version = "0.5.0-rc.2", path = "packages/vexide-devices", default-features = false }
+vexide-panic = { version = "0.1.6-rc.1", path = "packages/vexide-panic", default-features = false }
+vexide-startup = { version = "0.3.3-rc.1", path = "packages/vexide-startup", default-features = false }
+vexide-graphics = { version = "0.1.6-rc.1", path = "packages/vexide-graphics", default-features = false }
 vexide-macro = { version = "0.3.1-rc.1", path = "packages/vexide-macro", default-features = false }
 vex-sdk = "0.23.0"
 no_std_io = { version = "0.6.0", features = ["alloc"] }

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-async"
-version = "0.1.5-rc.1"
+version = "0.1.6-rc.1"
 edition = "2021"
 license = "MIT"
 description = "The async executor at the core of vexide"

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-core"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 edition = "2021"
 license = "MIT"
 description = "Core functionality for vexide"

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-devices"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 edition = "2021"
 license = "MIT"
 description = "High level device bindings for vexide"

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-graphics"
-version = "0.1.5-rc.1"
+version = "0.1.6-rc.1"
 edition = "2021"
 license = "MIT"
 description = "Graphics driver implementations for vexide"

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-panic"
-version = "0.1.5-rc.1"
+version = "0.1.6-rc.1"
 edition = "2021"
 license = "MIT"
 description = "Panic handler for vexide"

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-startup"
-version = "0.3.2-rc.1"
+version = "0.3.3-rc.1"
 edition = "2021"
 license = "MIT"
 description = "Support code for V5 Brain user program booting"

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 edition = "2021"
 description = "async/await powered Rust library for VEX V5 Brains"
 keywords = ["Robotics", "bindings", "vex", "v5"]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
I did bad things cause I forgor about the 0.4.2 branch. rc1 still works but its cursed so this should fix it.
![{E2FB4785-6E34-46FC-8983-42E4080B64D2}](https://github.com/user-attachments/assets/751e6af7-a236-4192-a857-6e614b7649c8)

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
