### PR TITLE
feat: add `Mul<i64>` and `Div<i64>` impls for `Position`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ Before releasing:
 
 ### Added
 
-* Added implementations of `Mul<i64>` and `Div<i64>` for `Position`, allowing
-  for opaque scaling (#230)
-
 ### Fixed
 
 ### Changed
@@ -52,6 +49,8 @@ Before releasing:
 - Added a `toggle` method to `AdiDigitalOut` to toggle between level outputs.
 - Added a `SerialPort::set_baud_rate` method for the adjusting baudrate of a generic serial smartport after initialization. (#217)
 - Added fields containing relevant failure information to several error types (#221) (**Breaking Change**)
+- Added implementations of `Mul<i64>` and `Div<i64>` for `Position`, allowing
+  for opaque scaling (#230)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Before releasing:
 
 ### Added
 
+* Added implementations of `Mul<i64>` and `Div<i64>` for `Position`, allowing
+  for opaque scaling (#230)
+
 ### Fixed
 
 ### Changed

--- a/packages/vexide-devices/src/position.rs
+++ b/packages/vexide-devices/src/position.rs
@@ -104,11 +104,27 @@ impl Mul<Position> for Position {
     }
 }
 
+impl Mul<i64> for Position {
+    type Output = Self;
+
+    fn mul(self, rhs: i64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
 impl Div<Position> for Position {
     type Output = Self;
 
     fn div(self, rhs: Self) -> Self::Output {
         Self(self.0 / rhs.0)
+    }
+}
+
+impl Div<i64> for Position {
+    type Output = Self;
+
+    fn div(self, rhs: i64) -> Self::Output {
+        Self(self.0 / rhs)
     }
 }
 
@@ -130,9 +146,21 @@ impl MulAssign<Position> for Position {
     }
 }
 
+impl MulAssign<i64> for Position {
+    fn mul_assign(&mut self, rhs: i64) {
+        self.0 *= rhs;
+    }
+}
+
 impl DivAssign<Position> for Position {
     fn div_assign(&mut self, rhs: Self) {
         self.0 /= rhs.0;
+    }
+}
+
+impl DivAssign<i64> for Position {
+    fn div_assign(&mut self, rhs: i64) {
+        self.0 /= rhs;
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR simply adds some implementations for scaling `Position` instances which are helpful for e.g. computing averages.

This PR in theory still maintains the "opaqueness" of the `Position` type since it just allows scaling and not any other operations. This still might not be what you want; if you don't like it, feel free to close the PR.

## Additional Context

- semver: minor
- These changes update the crate's interface (e.g. functions/modules added or changed).
- Closes #229
