### PR TITLE
feat: Panic Hooks v2

### DIFF
--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -11,8 +11,9 @@ use alloc::{
     boxed::Box,
     string::{String, ToString},
 };
+use core::cell::UnsafeCell;
 
-use vexide_core::{println, sync::Mutex};
+use vexide_core::println;
 #[cfg(feature = "display_panics")]
 use vexide_devices::{
     color::Rgb,
@@ -92,41 +93,27 @@ fn draw_error(screen: &mut Screen, msg: &str) -> Result<(), ScreenError> {
     Ok(())
 }
 
-static HOOK: Mutex<Option<Box<dyn Fn(&core::panic::PanicInfo<'_>)>>> = Mutex::new(None);
-
-/// Set a panic hook to run before vexide panic
+/// The default panic handler.
+///
+/// This function is called when a panic occurs and no custom panic hook is set,
+/// but you can also use it as a fallback in your custom panic hook to print the
+/// panic message to the screen and stdout.
+///
+/// # Examples
 ///
 /// ```
-/// use vexide_panic::set_panic_hook;
+/// # use vexide_panic::{default_panic_hook, set_hook};
+/// #
+/// set_hook(|info| {
+///     // Do something bespoke with the panic info
+///     // ...
 ///
-/// set_panic_hook(|info| println!("{:?}", info));
+///     // Then, call the default panic hook to show the message on the screen
+///     default_panic_hook(info);
+/// });
 /// ```
-pub fn set_panic_hook<F>(hook: F)
-where
-    F: Fn(&core::panic::PanicInfo<'_>) + 'static,
-{
-    loop {
-        if let Some(mut hook_lock) = HOOK.try_lock() {
-            *hook_lock = Some(Box::new(hook));
-            return;
-        }
-    }
-}
-
-#[panic_handler]
-/// The panic handler for vexide.
-pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+pub fn default_panic_hook(info: &core::panic::PanicInfo<'_>) {
     println!("{info}");
-
-    loop {
-        if let Some(hook) = HOOK.try_lock() {
-            match *hook {
-                None => {}
-                Some(ref hook) => hook(info),
-            }
-            break;
-        }
-    }
 
     unsafe {
         #[cfg(feature = "display_panics")]
@@ -136,13 +123,106 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
 
         #[cfg(target_arch = "wasm32")]
         sim_log_backtrace();
+    }
+}
 
-        #[cfg(not(feature = "display_panics"))]
-        vexide_core::program::exit();
-        // unreachable without display_panics
-        #[cfg(feature = "display_panics")]
-        loop {
-            // Flush the serial buffer so that the panic message is printed
+/// The panic hook type
+///
+/// This mirrors the one available in the standard library.
+enum Hook {
+    Default,
+    Custom(Box<dyn Fn(&core::panic::PanicInfo<'_>)>),
+}
+
+/// A word-for-word copy of the Rust `std` impl
+impl Hook {
+    #[inline]
+    fn into_box(self) -> Box<dyn Fn(&core::panic::PanicInfo<'_>)> {
+        match self {
+            Hook::Default => Box::new(default_hook),
+            Hook::Custom(hook) => hook,
+        }
+    }
+}
+
+/// A newtype wrapper over the hook type so we can implement `Sync`
+/// This is only safe because we're single-threaded
+struct HookWrapper(UnsafeCell<Hook>);
+unsafe impl Sync for HookWrapper {}
+
+static HOOK: HookWrapper = HookWrapper(UnsafeCell::new(Hook::Default));
+
+/// Registers a custom panic hook, replacing the current one if any.
+///
+/// This can be used to, for example, output a different message to the screen
+/// than the default one shown when the `display_panics` feature is enabled, or
+/// to log the panic message to a log file or other output (you will need to use
+/// `unsafe` to get peripheral access).
+///
+/// **Note**: Just like in the standard library, a custom panic hook _does
+/// override_ the default panic hook. In `vexide`'s case, this means that the
+/// error _will not automatically print to the screen or console_ when you set
+/// a custom panic hook. You will need to either do that yourself in the custom
+/// panic hook, or call [`default_panic_hook`] from your custom panic hook.
+///
+/// # Examples
+///
+/// ```
+/// use vexide_panic::set_panic_hook;
+///
+/// set_hook(|info| {
+///     // Do something with the panic info
+///     // This is pretty useless since vexide already does this
+///     println!("{:?}", info);
+/// });
+/// ```
+pub fn set_hook<F>(hook: F)
+where
+    F: Fn(&core::panic::PanicInfo<'_>) + 'static,
+{
+    // SAFETY: We're expected to uphold the invariant "Ensure that the access
+    // is unique (no active references, mutable or not) when casting to &mut T
+    // We only obtain a reference to the `UnsafeCell` in this function and the
+    // panic handler, and since this function never panics (please make sure!)
+    // it should be safe.
+    // Also, V5 is single-threaded so we don't need to worry about `Sync` issues
+    unsafe {
+        HOOK.0.get().write(Hook::Custom(Box::new(hook)));
+    }
+}
+
+/// Unregisters the current panic hook, if any, and returns it, replacing it
+/// with the default panic hook.
+///
+/// The default panic hook will remain registered if no custom hook was set.
+pub fn take_hook() -> Box<dyn Fn(&core::panic::PanicInfo<'_>)> {
+    // SAFETY: We're expected to uphold the invariant "Ensure that the access
+    // is unique (no active references, mutable or not) when casting to &mut T
+    // We only obtain a reference to the `UnsafeCell` in this function and the
+    // panic handler, and since this function never panics it should be safe.
+    unsafe { HOOK.0.get().replace(Hook::Default).into_box() }
+}
+
+#[panic_handler]
+/// The panic handler for vexide.
+pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
+    // SAFETY: We're expected to uphold the invariant "ensure that there are no
+    // mutations or mutable aliases going on when casting to &T"
+    // This is upheld by the fact that we only ever write to the `UnsafeCell` in
+    // the `set_panic_hook` function, which should never panic while writing.
+    //
+    // We release a reference to the `UnsafeCell` to safe code because we will
+    // never take a mutable reference again.
+    let panic_hook = unsafe { HOOK.0.get().read().into_box() };
+    panic_hook(info);
+
+    #[cfg(not(feature = "display_panics"))]
+    vexide_core::program::exit();
+    // unreachable without display_panics
+    #[cfg(feature = "display_panics")]
+    loop {
+        // Flush the serial buffer so that the panic message is printed
+        unsafe {
             vex_sdk::vexTasksRun();
         }
     }

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -11,7 +11,7 @@ use alloc::{
     boxed::Box,
     string::{String, ToString},
 };
-use core::cell::UnsafeCell;
+use core::{cell::UnsafeCell, default};
 
 use vexide_core::println;
 #[cfg(feature = "display_panics")]
@@ -139,7 +139,7 @@ impl Hook {
     #[inline]
     fn into_box(self) -> Box<dyn Fn(&core::panic::PanicInfo<'_>)> {
         match self {
-            Hook::Default => Box::new(default_hook),
+            Hook::Default => Box::new(default_panic_hook),
             Hook::Custom(hook) => hook,
         }
     }

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -3,7 +3,6 @@
 //! If the `display_panics` feature is enabled, it will also display the panic message on the V5 Brain display.
 
 #![no_std]
-#![feature(fn_traits)]
 
 extern crate alloc;
 
@@ -11,7 +10,7 @@ use alloc::{
     boxed::Box,
     string::{String, ToString},
 };
-use core::{cell::UnsafeCell, default};
+use core::cell::UnsafeCell;
 
 use vexide_core::println;
 #[cfg(feature = "display_panics")]

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -7,10 +7,12 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
-use alloc::string::{String, ToString};
-use vexide_core::println;
-use vexide_core::sync::Mutex;
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
+
+use vexide_core::{println, sync::Mutex};
 #[cfg(feature = "display_panics")]
 use vexide_devices::{
     color::Rgb,
@@ -99,7 +101,10 @@ static HOOK: Mutex<Option<Box<dyn Fn(&core::panic::PanicInfo<'_>)>>> = Mutex::ne
 ///
 /// set_panic_hook(|info| println!("{:?}", info));
 /// ```
-pub fn set_panic_hook<F>(hook: F) where F: Fn(&core::panic::PanicInfo<'_>) + 'static {
+pub fn set_panic_hook<F>(hook: F)
+where
+    F: Fn(&core::panic::PanicInfo<'_>) + 'static,
+{
     loop {
         if let Some(mut hook_lock) = HOOK.try_lock() {
             *hook_lock = Some(Box::new(hook));
@@ -117,7 +122,7 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
         if let Some(hook) = HOOK.try_lock() {
             match *hook {
                 None => {}
-                Some(ref hook) => { hook(info) }
+                Some(ref hook) => hook(info),
             }
             break;
         }

--- a/packages/vexide/examples/panic_hooks.rs
+++ b/packages/vexide/examples/panic_hooks.rs
@@ -2,6 +2,7 @@
 #![no_std]
 
 use core::time::Duration;
+
 use vexide::prelude::*;
 use vexide_devices::controller::ControllerId;
 use vexide_panic::set_panic_hook;

--- a/packages/vexide/examples/panic_hooks.rs
+++ b/packages/vexide/examples/panic_hooks.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#![no_std]
+
+use core::time::Duration;
+use vexide::prelude::*;
+use vexide_devices::controller::ControllerId;
+use vexide_panic::set_panic_hook;
+
+#[vexide::main]
+async fn main(_peripherals: Peripherals) {
+    println!("Hello, world!");
+
+    set_panic_hook(|_| {
+        let mut controller_primary = unsafe { Controller::new(ControllerId::Primary) };
+
+        let _ = controller_primary.screen.set_text("Panic!", 0, 0);
+    });
+
+    sleep(Duration::from_millis(1000)).await;
+
+    panic!();
+}

--- a/packages/vexide/examples/panic_hooks.rs
+++ b/packages/vexide/examples/panic_hooks.rs
@@ -3,18 +3,32 @@
 
 use core::time::Duration;
 
-use vexide::prelude::*;
-use vexide_devices::controller::ControllerId;
-use vexide_panic::set_panic_hook;
+use vexide::{
+    devices::{controller::ControllerId, geometry::Point2, screen::Rect},
+    prelude::*,
+};
 
 #[vexide::main]
 async fn main(_peripherals: Peripherals) {
     println!("Hello, world!");
 
-    set_panic_hook(|_| {
+    vexide::panic::set_hook(|info| {
+        // Show the panic message on the primary controller
         let mut controller_primary = unsafe { Controller::new(ControllerId::Primary) };
-
         let _ = controller_primary.screen.set_text("Panic!", 0, 0);
+
+        // Fill the screen with red
+        let mut screen = unsafe { Screen::new() };
+        screen.fill(
+            &Rect::from_dimensions(
+                Point2 { x: 0, y: 0 },
+                Screen::HORIZONTAL_RESOLUTION as u16,
+                Screen::VERTICAL_RESOLUTION as u16,
+            ),
+            0xff0000 as u32,
+        );
+
+        vexide::panic::default_panic_hook(&info);
     });
 
     sleep(Duration::from_millis(1000)).await;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This change allows the panic handler to be overridden by the user in a manner similar to the Rust standard library: using `set_hook` and `take_hook`.

Also, compared to #118, this PR also makes use of `UnsafeCell` to reduce the (probably minimal) overhead of using a `Mutex`.

## Additional Context

- I have tested these changes on a VEX V5 brain.
- These changes update the crate's interface (e.g. functions/modules added or changed).
- Supersedes #118
