### PR TITLE
Panic Hooks v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Before releasing:
 - Added fields containing relevant failure information to several error types (#221) (**Breaking Change**)
 - Added implementations of `Mul<i64>` and `Div<i64>` for `Position`, allowing
   for opaque scaling (#230)
+- Added panic hook support comparable to the Rust standard library through `vexide::panic::set_hook` and `vexide::panic::take_hook` (#234)
 
 ### Fixed
 

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -1,0 +1,47 @@
+#![no_main]
+#![no_std]
+
+use core::time::Duration;
+
+use vexide::{
+    devices::{
+        controller::ControllerId,
+        display::{Display, Rect},
+        math::Point2,
+    },
+    prelude::*,
+};
+
+#[vexide::main]
+async fn main(_peripherals: Peripherals) {
+    println!("Hello, world!");
+
+    vexide::panic::set_hook(|info| {
+        println!("It looks like we hit a bump.");
+
+        // Show the panic message on the primary controller
+        block_on(async {
+            let mut controller_primary = unsafe { Controller::new(ControllerId::Primary) };
+            let _ = controller_primary.screen.set_text("Panic!", 0, 0).await;
+        });
+
+        // Fill the screen with red to indicate a panic
+        let mut display = unsafe { Display::new() };
+        display.fill(
+            &Rect::from_dimensions(
+                Point2 { x: 0, y: 0 },
+                Display::HORIZONTAL_RESOLUTION as u16,
+                Display::VERTICAL_RESOLUTION as u16,
+            ),
+            Rgb::new(255, 0, 0),
+        );
+
+        // Call the default panic hook to print the panic message to the serial
+        // console and put it on the display
+        vexide::panic::default_panic_hook(info);
+    });
+
+    sleep(Duration::from_millis(1000)).await;
+
+    panic!();
+}


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This change allows the panic handler to be overridden by the user in a manner similar to the Rust standard library: using `set_hook` and `take_hook`.

## Additional Context

- I have tested these changes on a VEX V5 brain.
- These changes update the crate's interface (e.g. functions/modules added or changed).
- Supersedes #118 and #233

![Photo from 2024-11-16 23-34-21 098061](https://github.com/user-attachments/assets/c88c7dee-4518-4397-820b-e333ef46532f)
(Note the red background behind the popup, which isn't present by default. This is a photo from the `panic_hook` example)
