### PR TITLE
fix(panic): remove feature gate which shouldn't exist

### DIFF
--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -271,8 +271,7 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
         default_panic_hook(info);
     }
 
-    // unreachable without display_panics
-    #[cfg(feature = "display_panics")]
+    // enter into an endless loop if the panic hook didn't exit the program
     loop {
         unsafe {
             // Flush the serial buffer so that the panic message is printed


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

#234 broke some people's CI because it didn't return `!` to the panic handler if `display_panics` was not enabled. Now it does.

## Additional Context

This is a bugfix.