### PR TITLE
fix: remove `Position`-to-`Position` `Mul`/`Div` ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Before releasing:
 - `GestureDirection` no longer has a `From` conversion for `u32`. (#215) (**Breaking Change**)
 - Removed the `nalgebra` feature. All math types should natively support nalgebra conversions without any additional features. (#218) (**Breaking Change**)
 - Removed `SmartDeviceType::None`. `SmartPort::device_type` now returns an `Option<SmartDeviceType>` which serves the same purpose. (#219) (**Breaking Change**)
+- Removed `Position`-to-`Position` `Mul`/`Div` ops, as they were mathematically unsound. Prefer using `Position`-to-scalar operations for this. (#237) (**Breaking Change**)
 
 ### New Contributors
 

--- a/packages/vexide-devices/src/position.rs
+++ b/packages/vexide-devices/src/position.rs
@@ -96,27 +96,11 @@ impl Sub<Position> for Position {
     }
 }
 
-impl Mul<Position> for Position {
-    type Output = Self;
-
-    fn mul(self, rhs: Self) -> Self::Output {
-        Self(self.0 * rhs.0)
-    }
-}
-
 impl Mul<i64> for Position {
     type Output = Self;
 
     fn mul(self, rhs: i64) -> Self::Output {
         Self(self.0 * rhs)
-    }
-}
-
-impl Div<Position> for Position {
-    type Output = Self;
-
-    fn div(self, rhs: Self) -> Self::Output {
-        Self(self.0 / rhs.0)
     }
 }
 
@@ -140,21 +124,9 @@ impl SubAssign<Position> for Position {
     }
 }
 
-impl MulAssign<Position> for Position {
-    fn mul_assign(&mut self, rhs: Self) {
-        self.0 *= rhs.0;
-    }
-}
-
 impl MulAssign<i64> for Position {
     fn mul_assign(&mut self, rhs: i64) {
         self.0 *= rhs;
-    }
-}
-
-impl DivAssign<Position> for Position {
-    fn div_assign(&mut self, rhs: Self) {
-        self.0 /= rhs.0;
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
`Position`-to-`Position` `Mul`/`Div` operations are mathematically unsound due to such operations creating a new dimension (specifically a [Steradian](https://en.wikipedia.org/wiki/Steradian), which is representible as m^2/m^2). This PR removes such operations and only allows `Angle {+, -} Angle` and `Angle {*, /} Scalar`

## Additional Context
![image](https://github.com/user-attachments/assets/fb257768-a5b1-4640-b0bc-87bddddfcdb1)
