### PR TITLE
fix(core): fix typo in `Mutex` `Sync` bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Before releasing:
 - Fixed an issue preventing ADI updates in fast loops. (#210)
 - `Motor::status` can now actually return the `MotorStatus::BUSY` flag. (#211)
 - Fixed a memory leak on every `RadioLink` construction. (#220)
+- Fixed a problem where `Sync` was incorrectly implemented for `Mutex` when it shouldn't have been (#238) (**Breaking Change**)
 
 ### Changed
 

--- a/packages/vexide-core/src/sync/mutex.rs
+++ b/packages/vexide-core/src/sync/mutex.rs
@@ -88,7 +88,7 @@ pub struct Mutex<T: ?Sized> {
     data: UnsafeCell<T>,
 }
 unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
-unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+unsafe impl<T: ?Sized + Sync> Sync for Mutex<T> {}
 
 impl<T> Mutex<T> {
     /// Creates a new mutex.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

It looks like `Mutex` had an `unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}` (probably as a result of copy-pasting) by mistake.

## Additional Context

- Not tested on a brain, but does it need to be?
- This is technically a breaking change, so I've put it in the changelog as such.