### PR TITLE
refactor: adjust fallibility of `GpsSensor` & `RadioLink`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ Before releasing:
 - Made `ControllerScreen` methods and `Controller::rumble` asynchronous and added synchronous `try_<action>` variants. (#222) (**Breaking Change**)
 - Renamed `ControllerScreen::MAX_LINE_LENGTH` to `ControllerScreen::MAX_COLUMNS`. (#222) (**Breaking Change**)
 - Refactored `InertialCalibrateFuture` to an opaque wrapper over the internal state machine. (#225) (**Breaking Change**)
+- `GpsSensor::new` is now infallible and no longer returns a `Result`. (#240) (**Breaking Change**)
+- `RadioLink::new` can now only fail on `NulError` and will not bail if a radio is disconnected. (#240) (**Breaking Change**)
 
 ### Removed
 
@@ -115,6 +117,7 @@ Before releasing:
 - Removed the `nalgebra` feature. All math types should natively support nalgebra conversions without any additional features. (#218) (**Breaking Change**)
 - Removed `SmartDeviceType::None`. `SmartPort::device_type` now returns an `Option<SmartDeviceType>` which serves the same purpose. (#219) (**Breaking Change**)
 - Removed `Position`-to-`Position` `Mul`/`Div` ops, as they were mathematically unsound. Prefer using `Position`-to-scalar operations for this. (#237) (**Breaking Change**)
+- Removed `LinkError::Nul`. (#240) (**Breaking Change**)
 
 ### New Contributors
 

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -59,10 +59,6 @@ impl GpsSensor {
     /// - `offset`: The physical offset of the sensor from the robot's center of rotation.
     /// - `initial_pose`: The inital position and heading of the robot.
     ///
-    /// # Errors
-    ///
-    /// An error is returned if a GPS sensor is not currently connected to the specified port.
-    ///
     /// # Examples
     ///
     /// ```
@@ -76,16 +72,14 @@ impl GpsSensor {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     /// }
     /// ```
     pub fn new(
         port: SmartPort,
         offset: impl Into<Point2<f64>>,
         initial_pose: (impl Into<Point2<f64>>, f64),
-    ) -> Result<Self, PortError> {
-        port.validate_type(SmartDeviceType::Gps)?;
-
+    ) -> Self {
         let device = unsafe { port.device_handle() };
 
         let initial_position = initial_pose.0.into();
@@ -101,7 +95,7 @@ impl GpsSensor {
             );
         }
 
-        Ok(Self {
+        Self {
             device,
             imu: GpsImu {
                 device,
@@ -110,7 +104,7 @@ impl GpsSensor {
                 heading_offset: Default::default(),
             },
             port,
-        })
+        }
     }
 
     /// Returns the physical offset of the sensor from the robot's center of rotation.
@@ -130,7 +124,7 @@ impl GpsSensor {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///
     ///     // Get the configured offset of the sensor
     ///     if let Ok(offset) = gps.offset() {
@@ -176,7 +170,7 @@ impl GpsSensor {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///
     ///     // Get current position and heading
     ///     if let Ok((position, heading)) = gps.pose() {
@@ -229,7 +223,7 @@ impl GpsSensor {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///
     ///     // Check position accuracy
     ///     if gps.error().is_ok_and(|err| err > 0.3) {
@@ -260,7 +254,7 @@ impl GpsSensor {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///
     ///     if let Ok(status) = gps.status() {
     ///         println!("Status: {:b}", status);
@@ -338,7 +332,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Sleep for two seconds to allow the robot to be moved.
@@ -385,7 +379,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Sleep for two seconds to allow the robot to be moved.
@@ -426,7 +420,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Sleep for two seconds to allow the robot to be moved.
@@ -483,7 +477,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Sleep for two seconds to allow the robot to be moved.
@@ -536,7 +530,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Read out accleration values every 10mS
@@ -587,7 +581,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Read out angular velocity values every 10mS
@@ -643,7 +637,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Sleep for two seconds to allow the robot to be moved.
@@ -683,7 +677,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Sleep for two seconds to allow the robot to be moved.
@@ -722,7 +716,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Set rotation to 90 degrees clockwise.
@@ -761,7 +755,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Set heading to 90 degrees clockwise.
@@ -797,7 +791,7 @@ impl GpsImu {
     ///         peripherals.port_1,
     ///         [2.0, 1.0],
     ///         ([0.0, 0.0], 90.0)
-    ///     ).unwrap();
+    ///     );
     ///     let imu = gps.imu;
     ///
     ///     // Set to minimum interval.

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -58,8 +58,7 @@ impl RadioLink {
     ///
     /// # Errors
     ///
-    /// - A [`LinkError::Port`] error is returned if a radio device is not currently connected to the specified port.
-    /// - A [`LinkError::Nul`] error is returned if a NUL (0x00) character was found anywhere in the specified `id`.
+    /// - A [`NulError`] error is returned if a NUL (0x00) character was found anywhere in the specified `id`.
     ///
     /// # Examples
     ///
@@ -71,14 +70,7 @@ impl RadioLink {
     ///     let link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
     /// }
     /// ```
-    pub fn open(port: SmartPort, id: &str, link_type: LinkType) -> Result<Self, LinkError> {
-        // Ensure that a radio is plugged into the requested port.
-        //
-        // Once we call [`vexDeviceGenericRadioConnection`], this type
-        // will be changed to be generic serial, but we haven't called
-        // it yet.
-        port.validate_type(SmartDeviceType::Radio)?;
-
+    pub fn open(port: SmartPort, id: &str, link_type: LinkType) -> Result<Self, NulError> {
         let id = CString::new(id)?;
 
         // That this constructor literally has to be fallible unlike others.
@@ -365,13 +357,6 @@ pub enum LinkError {
 
     /// Internal read error occurred.
     ReadFailed,
-
-    /// A NUL (0x00) character was found in a string that may not contain NUL characters.
-    #[snafu(transparent)]
-    Nul {
-        /// The source of the error.
-        source: NulError,
-    },
 
     /// Generic port related error.
     #[snafu(transparent)]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- `GpsSensor::new` is now infallible.
- `RadioLink::open` no longer validates ports (this was causing panics since VEXos reconfigures a radio link as generic serial) and can only return `Nul`.

## Additional Context
Hardware tested
