### PR TITLE
fix: correctly handle VEXlink errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Before releasing:
 - Fixed an issue preventing ADI updates in fast loops. (#210)
 - `Motor::status` can now actually return the `MotorStatus::BUSY` flag. (#211)
 - Fixed a memory leak on every `RadioLink` construction. (#220)
-- Fixed a panic in `RadioLink::new` that would occur if a program using a VEXlink radio was ran twice. (#243)
+- Fixed a panic in `RadioLink::open` that would occur if a program using a VEXlink radio was ran twice. (#243)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Before releasing:
 - Fixed an issue preventing ADI updates in fast loops. (#210)
 - `Motor::status` can now actually return the `MotorStatus::BUSY` flag. (#211)
 - Fixed a memory leak on every `RadioLink` construction. (#220)
+- Fixed a panic in `RadioLink::new` that would occur if a program using a VEXlink radio was ran twice. (#243)
 
 ### Changed
 
@@ -103,6 +104,8 @@ Before releasing:
 - Refactored `InertialCalibrateFuture` to an opaque wrapper over the internal state machine. (#225) (**Breaking Change**)
 - `GpsSensor::new` is now infallible and no longer returns a `Result`. (#240) (**Breaking Change**)
 - `RadioLink::new` can now only fail on `NulError` and will not bail if a radio is disconnected. (#240) (**Breaking Change**)
+- `RadioLink::unread_bytes` can now return a `LinkError::ReadError`. (#243)
+- `RadioLink::is_linked` is now infallible. (#243) (**Breaking Change**)
 
 ### Removed
 
@@ -118,6 +121,7 @@ Before releasing:
 - Removed `SmartDeviceType::None`. `SmartPort::device_type` now returns an `Option<SmartDeviceType>` which serves the same purpose. (#219) (**Breaking Change**)
 - Removed `Position`-to-`Position` `Mul`/`Div` ops, as they were mathematically unsound. Prefer using `Position`-to-scalar operations for this. (#237) (**Breaking Change**)
 - Removed `LinkError::Nul`. (#240) (**Breaking Change**)
+- Removed `LinkError::Port`, because it was broken. VEXlink will no longer perform port validation. (#243) (**Breaking Change**)
 
 ### New Contributors
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ vexide-panic = { version = "0.1.6-rc.1", path = "packages/vexide-panic", default
 vexide-startup = { version = "0.3.3-rc.1", path = "packages/vexide-startup", default-features = false }
 vexide-graphics = { version = "0.1.6-rc.1", path = "packages/vexide-graphics", default-features = false }
 vexide-macro = { version = "0.3.1-rc.1", path = "packages/vexide-macro", default-features = false }
-vex-sdk = "0.25.2"
+vex-sdk = "0.25.3"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ vexide-panic = { version = "0.1.6-rc.1", path = "packages/vexide-panic", default
 vexide-startup = { version = "0.3.3-rc.1", path = "packages/vexide-startup", default-features = false }
 vexide-graphics = { version = "0.1.6-rc.1", path = "packages/vexide-graphics", default-features = false }
 vexide-macro = { version = "0.3.1-rc.1", path = "packages/vexide-macro", default-features = false }
-vex-sdk = "0.23.0"
+vex-sdk = "0.25.2"
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 
 [workspace.lints.rust]

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,10 @@ Showcases writing text to the display through `write!`, drawing a shape, both fi
 
 Creates and communicates with several smart devices.
 
+### [`vexlink_manager`](./vexlink_manager.rs) & [`vexlink_worker`](./vexlink_worker.rs)
+
+Demonstrates basic usage of the VEXlink protocol for wireless message passing between two radios. These examples will need to be uploaded to two different robots (one "manager robot" and one "worker robot") each with their own radios in port 21.
+
 ## Async
 
 Examples showcasing vexide's async capabilities

--- a/examples/vexlink_manager.rs
+++ b/examples/vexlink_manager.rs
@@ -1,0 +1,33 @@
+#![no_main]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec;
+use core::str;
+
+use vexide::prelude::*;
+
+#[vexide::main]
+async fn main(peripherals: Peripherals) {
+    let mut link = RadioLink::open(peripherals.port_21, "643A", LinkType::Manager).unwrap();
+
+    println!("[MANAGER] Waiting for worker radio...");
+
+    while !link.is_linked() {
+        sleep(RadioLink::UPDATE_INTERVAL).await;
+    }
+
+    println!("[MANAGER] Found worker - link established.");
+
+    link.write(b"Hi from manager :3").unwrap();
+
+    loop {
+        if link.unread_bytes().unwrap() > 0 {
+            let mut read = vec![0; link.unread_bytes().unwrap()];
+            link.read(&mut read).unwrap();
+            println!("[WORKER] {}", str::from_utf8(&read).unwrap());
+        }
+        sleep(RadioLink::UPDATE_INTERVAL).await;
+    }
+}

--- a/examples/vexlink_worker.rs
+++ b/examples/vexlink_worker.rs
@@ -1,0 +1,33 @@
+#![no_main]
+#![no_std]
+
+extern crate alloc;
+
+use alloc::vec;
+use core::str;
+
+use vexide::prelude::*;
+
+#[vexide::main]
+async fn main(peripherals: Peripherals) {
+    let mut link = RadioLink::open(peripherals.port_21, "643A", LinkType::Worker).unwrap();
+
+    println!("[WORKER] Waiting for manager radio...");
+
+    while !link.is_linked() {
+        sleep(RadioLink::UPDATE_INTERVAL).await;
+    }
+
+    println!("[WORKER] Found manager - link established.");
+
+    link.write(b"Hi from worker :3").unwrap();
+
+    loop {
+        if link.unread_bytes().unwrap() > 0 {
+            let mut read = vec![0; link.unread_bytes().unwrap()];
+            link.read(&mut read).unwrap();
+            println!("[MANAGER] {}", str::from_utf8(&read).unwrap());
+        }
+        sleep(RadioLink::UPDATE_INTERVAL).await;
+    }
+}

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -27,12 +27,3 @@ workspace = true
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -47,12 +47,3 @@ backtraces = ["dep:vex-libunwind"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -35,12 +35,3 @@ smart_leds_trait = ["dep:smart-leds-trait"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -37,12 +37,3 @@ slint = ["dep:slint"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]

--- a/packages/vexide-panic/Cargo.toml
+++ b/packages/vexide-panic/Cargo.toml
@@ -33,12 +33,3 @@ workspace = true
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -28,12 +28,3 @@ default = []
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -68,12 +68,3 @@ display_panics = ["panic", "vexide-panic/display_panics"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.
-# Trick docs.rs to use our actual target instead.
-cargo-args = [
-    "--target",
-    "./armv7a-vex-v5.json",
-    "-Z",
-    "build-std=core,alloc,compiler_builtins",
-    "-Z",
-    "build-std-features=compiler-builtins-mem",
-]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- Removes port validation from VEXlink radios. Once a `RadioLink` is opened, VEXos will reconfigure the radio's smartport as generic serial, making it impossible to do any validation (the port will continue to report a `GenericSerial` connected_type even if no device is plugged in). This also caused a panic on second run, since serial configuration lasts across program runs.
- `available_write_bytes` now correctly handles its errors in the event of a -1 return. This prompted an update to `vex-sdk` 0.25.2, which relies on multiple breaking changes in our target spec. Oh well.