### PR TITLE
feat: add `#[clippy::has_significant_drop]` and `#[must_use]` attributes to `vexide_core::sync`

### DIFF
--- a/packages/vexide-core/src/sync/mutex.rs
+++ b/packages/vexide-core/src/sync/mutex.rs
@@ -176,6 +176,8 @@ impl<T> From<T> for Mutex<T> {
 /// Allows the user to access the data from a locked mutex.
 /// Dereference to get the inner data.
 #[derive(Debug)]
+#[must_use = "if unused the Mutex will immediately unlock"]
+#[clippy::has_significant_drop]
 pub struct MutexGuard<'a, T: ?Sized> {
     mutex: &'a Mutex<T>,
 }

--- a/packages/vexide-core/src/sync/rwlock.rs
+++ b/packages/vexide-core/src/sync/rwlock.rs
@@ -59,6 +59,8 @@ impl RwLockState {
 
 /// Allows for gaining immutable access to the data in an [`RwLock`]`.
 /// Multiple readers can access the data at the same time.
+#[must_use = "if unused the RwLock will immediately unlock"]
+#[clippy::has_significant_drop]
 pub struct RwLockReadGuard<'a, T> {
     lock: &'a RwLock<T>,
 }
@@ -97,6 +99,8 @@ impl<'a, T> Future for RwLockReadFuture<'a, T> {
 
 /// Allows for gaining mutable access to the data in an [`RwLock`]`.
 /// Only one writer can access the data at a time.
+#[must_use = "if unused the RwLock will immediately unlock"]
+#[clippy::has_significant_drop]
 pub struct RwLockWriteGuard<'a, T> {
     lock: &'a RwLock<T>,
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR adds some attributes to Mutex and RwLock guards that make some clippy lints more useful and mirrors `std` and `parking_lot`'s implementations.

## Additional Context
- These are *only* non-code changes. (Well, they  _are_ code changes, but they're documentation code changes.)
- Fixes #244