### PR TITLE
feat(devices): add `with_initial_level` to `AdiDigitalOut`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Before releasing:
 - Added implementations of `Mul<i64>` and `Div<i64>` for `Position`, allowing
   for opaque scaling (#230)
 - Added panic hook support comparable to the Rust standard library through `vexide::panic::set_hook` and `vexide::panic::take_hook` (#234)
+- Added `AdiDigitalOut::with_initial_state` to set the initial state of a digital output while creating it (#246)
 
 ### Fixed
 

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -172,21 +172,22 @@ impl AdiDigitalOut {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let digital_out = AdiDigitalOut::with_initial_level(peripherals.adi_a, LogicLevel::High).expect("failed to initialize digital output");
+    ///     let digital_out = AdiDigitalOut::with_initial_level(peripherals.adi_a, LogicLevel::High);
     /// }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// - A [`PortError::Disconnected`] error is returned if an ADI expander device was required but not connected.
-    /// - A [`PortError::IncorrectDevice`] error is returned if an ADI expander device was required but
-    ///   something else was connected.
-    pub fn with_initial_level(port: AdiPort, initial_level: LogicLevel) -> Result<Self, PortError> {
+    #[must_use]
+    pub fn with_initial_level(port: AdiPort, initial_level: LogicLevel) -> Self {
         port.configure(AdiDeviceType::DigitalOut);
 
-        let mut adi_digital_out = Self { port };
-        adi_digital_out.set_level(initial_level)?;
-        Ok(adi_digital_out)
+        unsafe {
+            vexDeviceAdiValueSet(
+                port.device_handle(),
+                port.index(),
+                i32::from(initial_level.is_high()),
+            );
+        }
+
+        Self { port }
     }
 
     /// Sets the digital logic level (high or low) of a pin.

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -163,6 +163,32 @@ impl AdiDigitalOut {
         Self { port }
     }
 
+    /// Create a digital output from an [`AdiPort`] with an initial logic level.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use vexide::prelude::*;
+    ///
+    /// #[vexide::main]
+    /// async fn main(peripherals: Peripherals) {
+    ///     let digital_out = AdiDigitalOut::with_initial_level(peripherals.adi_a, LogicLevel::High).expect("failed to initialize digital output");
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - A [`PortError::Disconnected`] error is returned if an ADI expander device was required but not connected.
+    /// - A [`PortError::IncorrectDevice`] error is returned if an ADI expander device was required but
+    ///   something else was connected.
+    pub fn with_initial_level(port: AdiPort, initial_level: LogicLevel) -> Result<Self, PortError> {
+        port.configure(AdiDeviceType::DigitalOut);
+
+        let mut adi_digital_out = Self { port };
+        adi_digital_out.set_level(initial_level)?;
+        Ok(adi_digital_out)
+    }
+
     /// Sets the digital logic level (high or low) of a pin.
     ///
     /// # Errors


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR adds a way to specify the initial level of a digital ADI port while creating the port. This simplifies the common use case of starting a competition with a pneumatic piston at a certain state.

## Additional Context

- semver: minor
- These changes update the crate's interface (e.g. functions/modules added or changed).
