### PR TITLE
docs: show opt-in APIs on docs.rs

### DIFF
--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -34,4 +34,5 @@ dangerous_motor_tuning = []
 smart_leds_trait = ["dep:smart-leds-trait"]
 
 [package.metadata.docs.rs]
+all-features = true # Show optional APIs
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.

--- a/packages/vexide-graphics/Cargo.toml
+++ b/packages/vexide-graphics/Cargo.toml
@@ -36,4 +36,5 @@ embedded-graphics = ["dep:embedded-graphics-core"]
 slint = ["dep:slint"]
 
 [package.metadata.docs.rs]
+all-features = true # Otherwise the crate is completely empty.
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Enables features which add additional APIs during docs.rs builds.
This fixes (along with a couple other things) the fact that there are [no API docs at all](https://docs.rs/vexide-graphics/0.1.7/vexide_graphics/) for vexide-graphics.

## Additional Context

- These are *only* non-code changes (e.g. documentation, README.md).

<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->