### PR TITLE
fix: rename Once::is_complete to is_completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,19 +28,6 @@ Before releasing:
 ### Changed
 
 - Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)
-
-### Removed
-
-### New Contributors
-
-## [0.5.1]
-
-### Added
-
-### Fixed
-
-### Changed
-
 - All `Position` methods are now usable in `const` context. (#254)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ Before releasing:
 - @new-contributor made their first contribution in #11!
 -->
 
+## Unreleased
+
+### Added
+
+### Fixed
+
+### Changed
+
+- Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)
+
+### Removed
+
+### New Contributors
+
 ## [0.5.1]
 
 ### Added

--- a/packages/vexide-core/src/sync/lazy.rs
+++ b/packages/vexide-core/src/sync/lazy.rs
@@ -31,7 +31,7 @@ impl<T, I: FnOnce() -> T> LazyLock<T, I> {
     /// containing the initializer function.
     pub fn into_inner(self) -> Result<T, I> {
         let mut data = unsafe { core::ptr::read(&self.data).into_inner() };
-        match self.once.is_complete() {
+        match self.once.is_completed() {
             true => Ok(unsafe { ManuallyDrop::take(&mut data.data) }),
             false => Err(unsafe { ManuallyDrop::take(&mut data.init) }),
         }
@@ -81,7 +81,7 @@ impl<T, I: FnOnce() -> T> Deref for LazyLock<T, I> {
 impl<T: Debug, I> Debug for LazyLock<T, I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut struct_ = f.debug_struct("LazyLock");
-        if self.once.is_complete() {
+        if self.once.is_completed() {
             struct_.field("data", unsafe { &(*self.data.get()).data });
         } else {
             struct_.field("data", &"Uninitialized");
@@ -91,7 +91,7 @@ impl<T: Debug, I> Debug for LazyLock<T, I> {
 }
 impl<T, I> Drop for LazyLock<T, I> {
     fn drop(&mut self) {
-        match self.once.is_complete() {
+        match self.once.is_completed() {
             true => unsafe {
                 ManuallyDrop::drop(&mut (*self.data.get()).data);
             },


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Fixes #255

## Additional Context

- Breaking changes! Major semver
- Renamed using the Rust LSP implementation!