### PR TITLE
fix(panic): allow if_let_rescope lint for Rust 2024

### DIFF
--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -247,6 +247,13 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
     //
     // We should be able to lock the mutex, since we know that the mutex is only
     // otherwise locked in `take_hook` and `set_hook`, which don't panic.
+
+    // Allow if_let_rescope lint since we actually prefer the Rust 2024 rescope
+    // in this case.
+    // Formerly, in the `else` branch, the lock would be held to the end of the
+    // block, but it doesn't in the 2024 edition of Rust. That behavior is
+    // actually preferable here.
+    #[allow(if_let_rescope)]
     if let Some(mut guard) = HOOK.try_lock() {
         let hook = core::mem::replace(&mut *guard, Hook::Default);
         // Drop the guard first to avoid preventing set_hook or take_hook from


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

The Rust 2024 clippy lints seemed to have triggered on my code. I've reviewed it and it seems that the new behavior is actually better than the old behavior. Thus, I added an `#[allow]` and a comment.

## Additional Context

I wrote this message at 2024-12-19 21:40:42 JST.