### PR TITLE
fix: encoder port validation, lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Before releasing:
 
 ### Fixed
 
+- Fixed error handling for encoder port numbers. (#264)
+
 ### Changed
 
 - Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)

--- a/packages/vexide-graphics/src/embedded_graphics.rs
+++ b/packages/vexide-graphics/src/embedded_graphics.rs
@@ -23,6 +23,7 @@ impl BrainDisplay {
         display.set_render_mode(vexide_devices::display::RenderMode::DoubleBuffered);
         Self {
             display,
+            #[allow(clippy::large_stack_arrays)] // we got plenty
             triple_buffer: [0; Display::HORIZONTAL_RESOLUTION as usize
                 * Display::VERTICAL_RESOLUTION as usize],
         }

--- a/packages/vexide-graphics/src/slint.rs
+++ b/packages/vexide-graphics/src/slint.rs
@@ -40,6 +40,7 @@ impl V5Platform {
             window,
             display: RefCell::new(display),
             display_pressed: RefCell::new(false),
+            #[allow(clippy::large_stack_arrays)] // we got plenty
             buffer: RefCell::new(
                 [Rgb8Pixel::new(0, 0, 0);
                     Display::HORIZONTAL_RESOLUTION as usize * Display::VERTICAL_RESOLUTION as usize],


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR fixes some misconceptions we had about encoder ports. VEX article summarizes it well:

![image](https://github.com/user-attachments/assets/a4ad0c85-c63f-4ab5-b1b7-540468833a87)
 
Also resolves some leftover lints from the nightly update a while back.

Closes #252 