### PR TITLE
fix: remove mutex related deadlocks

### DIFF
--- a/packages/vexide-core/src/sync/lazy.rs
+++ b/packages/vexide-core/src/sync/lazy.rs
@@ -1,4 +1,4 @@
-use core::{cell::UnsafeCell, fmt::Debug, mem::ManuallyDrop, ops::Deref};
+use core::{cell::UnsafeCell, fmt::Debug, mem::ManuallyDrop};
 
 use super::Once;
 

--- a/packages/vexide-core/src/sync/lazy.rs
+++ b/packages/vexide-core/src/sync/lazy.rs
@@ -55,11 +55,6 @@ impl<T, I: FnOnce() -> T> LazyLock<T, I> {
         self.once.call_once(|| unsafe { self.lazy_init() }).await;
         unsafe { &(*self.data.get()).data }
     }
-
-    fn force(&self) -> &T {
-        self.once.call_once_blocking(|| unsafe { self.lazy_init() });
-        unsafe { &(*self.data.get()).data }
-    }
 }
 impl<T: Default> Default for LazyLock<T> {
     fn default() -> Self {
@@ -69,13 +64,6 @@ impl<T: Default> Default for LazyLock<T> {
             }),
             once: Once::new(),
         }
-    }
-}
-impl<T, I: FnOnce() -> T> Deref for LazyLock<T, I> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.force()
     }
 }
 impl<T: Debug, I> Debug for LazyLock<T, I> {

--- a/packages/vexide-core/src/sync/mutex.rs
+++ b/packages/vexide-core/src/sync/mutex.rs
@@ -107,13 +107,6 @@ impl<T: ?Sized> Mutex<T> {
         MutexLockFuture { mutex: self }
     }
 
-    /// Used internally to lock the mutex in a blocking fashion.
-    /// This is necessary because a mutex may be created internally before the executor is ready to be initialized.
-    pub(crate) fn lock_blocking(&self) -> MutexGuard<'_, T> {
-        self.raw.lock();
-        MutexGuard::new(self)
-    }
-
     /// Attempts to acquire this lock. This function does not block.
     pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
         if self.raw.try_lock() {

--- a/packages/vexide-core/src/sync/once.rs
+++ b/packages/vexide-core/src/sync/once.rs
@@ -52,14 +52,6 @@ impl Once {
             *state = true;
         }
     }
-
-    pub(crate) fn call_once_blocking<F: FnOnce()>(&self, fun: F) {
-        let mut state = self.state.lock_blocking();
-        if *state == Self::ONCE_INCOMPLETE {
-            fun();
-            *state = true;
-        }
-    }
 }
 impl Debug for Once {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -181,6 +181,7 @@ enum ControllerScreenWriteFutureState<'a> {
 }
 
 /// A future that completes once a write to the controller screen has been performed.
+///
 /// This future waits until the controller is able to accept a new write
 /// and fails if the controller is disconnected or if the requested write is bad.
 pub struct ControllerScreenWriteFuture<'a> {

--- a/packages/vexide-devices/src/smart/ai_vision.rs
+++ b/packages/vexide-devices/src/smart/ai_vision.rs
@@ -201,6 +201,7 @@ pub struct AiVisionColor {
 }
 
 /// A color code used by an AI Vision Sensor to detect groups of color blobs.
+///
 /// The color code can have up to 7 color signatures.
 /// When the colors in a color code are detected next to eachother, the sensor will detect the color code.
 pub struct AiVisionColorCode([Option<u8>; 7]);


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR removes `Mutex::lock_blocking` and deletes or refactors all code that used it to be async.
The most notable API that has changed is `vexide::core::io` where `Stdin` and `Stdout` no longer implement `Read` or `Write`. While this does not match the standard library, these implementations would cause a complete deadlock of the program if they were used while stdio was locked. The `lock` functions on both stdio types have been made async and a `try_lock` function has been added to both. While these changes don't match std either, they will prevent any future deadlock issues.
Due to these `Stdout` changes, the behavior of the printing macros had to be changed. This PR makes printing silently fail if `Stdout` is already locked. I personally believe that this is the best option. The other two options are unsafely writing without a lock, which might mess up sensitive protocols such as the proposed `LemLog` protocol, and simply deadlocking the entire program (the current behavior).
## Additional Context
- These are breaking changes (semver: major).
- Draft until thoroughly tested.
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
