### PR TITLE
refactor: turn errors caused by user end bugs into panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Before releasing:
 
 - Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)
 - All `Position` methods are now usable in `const` context. (#254)
+- The `Nul`, `InvalidLine`, and `InvalidColumn` `ControllerError` variants have been removed. These errors now cause panics. (#266) (**Breaking Change**)
+- `DisplayError` has been removed and `Display::draw_buffer` now panics when given a buffer of invalid size. (#266) (**Breaking Change**)
+- The `InvalidId` and `InvalidIdInCode` `AiVisionError` variants have been removed. These errors now cause panics. (#266) (**Breaking Change**)
+- `VisionError::InvalidId` has been removed. Invalid signature IDs given to `VisionSensor` will now cause panics. (#266) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -235,7 +235,10 @@ impl Future for ControllerScreenWriteFuture<'_> {
                 ControllerScreen::MAX_COLUMNS
             );
 
-            let text = text.as_deref().map_err(Clone::clone).expect("A NUL (0x00) character was found in the text input string.");
+            let text = text
+                .as_deref()
+                .map_err(Clone::clone)
+                .expect("A NUL (0x00) character was found in the text input string.");
 
             match validate_connection(controller.id) {
                 Ok(()) => {
@@ -543,7 +546,8 @@ impl ControllerScreen {
         );
 
         let id: V5_ControllerId = self.id.into();
-        let text = CString::new(text.as_ref()).expect("A NUL (0x00) character was found in the text input string.");
+        let text = CString::new(text.as_ref())
+            .expect("A NUL (0x00) character was found in the text input string.");
 
         if unsafe {
             vexControllerTextSet(

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -224,14 +224,18 @@ impl Future for ControllerScreenWriteFuture<'_> {
             enforce_visible: visible,
         } = state
         {
-            if *visible && (*line == 0 || *line > ControllerScreen::MAX_LINES as u8) {
-                return Poll::Ready(InvalidLineSnafu { line: *line }.fail());
-            }
-            if *column == 0 || *column > ControllerScreen::MAX_COLUMNS as u8 {
-                return Poll::Ready(InvalidColumnSnafu { column: *column }.fail());
-            }
+            assert!(
+                *visible && (*line == 0 || *line > ControllerScreen::MAX_LINES as u8),
+                "Invalid line number ({line}) is greater than the maximum number of lines ({})",
+                ControllerScreen::MAX_LINES
+            );
+            assert!(
+                *column == 0 || *column > ControllerScreen::MAX_COLUMNS as u8,
+                "Invalid column number ({column}) is greater than the maximum number of columns ({})",
+                ControllerScreen::MAX_COLUMNS
+            );
 
-            let text = text.as_deref().map_err(Clone::clone)?;
+            let text = text.as_deref().map_err(Clone::clone).expect("A NUL (0x00) character was found in the text input string.");
 
             match validate_connection(controller.id) {
                 Ok(()) => {
@@ -450,14 +454,14 @@ impl ControllerScreen {
     ///
     /// </section>
     ///
+    /// # Panics
+    ///
+    /// - Panics if `line` is greater than or equal to [`Self::MAX_LINES`].
+    /// - Panics if `col` is greater than or equal to [`Self::MAX_COLUMNS`].
+    /// - Panics if a NUL (0x00) character was found anywhere in the specified text.
+    ///
     /// # Errors
     ///
-    /// - A [`ControllerError::InvalidLine`] error is returned if `col` is
-    ///   greater than or equal to [`Self::MAX_LINES`].
-    /// - A [`ControllerError::InvalidColumn`] error is returned if `col` is
-    ///   greater than or equal to [`Self::MAX_COLUMNS`].
-    /// - A [`ControllerError::Nul`] error if a NUL (0x00) character was
-    ///   found anywhere in the specified text.
     /// - A [`ControllerError::Offline`] error is returned if the controller is
     ///   not connected.
     ///
@@ -494,14 +498,14 @@ impl ControllerScreen {
     ///
     /// </section>
     ///
+    /// # Panics
+    ///
+    /// - Panics if `line` is greater than or equal to [`Self::MAX_LINES`].
+    /// - Panics if `col` is greater than or equal to [`Self::MAX_COLUMNS`].
+    /// - Panics if a NUL (0x00) character was found anywhere in the specified text.
+    ///
     /// # Errors
     ///
-    /// - A [`ControllerError::InvalidLine`] error is returned if `col` is
-    ///   greater than or equal to [`Self::MAX_LINES`].
-    /// - A [`ControllerError::InvalidColumn`] error is returned if `col` is
-    ///   greater than or equal to [`Self::MAX_COLUMNS`].
-    /// - A [`ControllerError::Nul`] error if a NUL (0x00) character was
-    ///   found anywhere in the specified text.
     /// - A [`ControllerError::Offline`] error is returned if the controller is
     ///   not connected.
     /// - A [`ControllerError::WriteBusy`] error is returned if a screen write
@@ -527,17 +531,19 @@ impl ControllerScreen {
     ) -> Result<(), ControllerError> {
         validate_connection(self.id)?;
 
-        ensure!(
+        assert!(
             column < Self::MAX_COLUMNS as u8 && column != 0,
-            InvalidColumnSnafu { column }
+            "Invalid column number ({column}) is greater than the maximum number of columns ({})",
+            ControllerScreen::MAX_COLUMNS
         );
-        ensure!(
+        assert!(
             line < Self::MAX_LINES as u8 && line != 0,
-            InvalidLineSnafu { line }
+            "Invalid column number ({column}) is greater than the maximum number of columns ({})",
+            ControllerScreen::MAX_COLUMNS
         );
 
         let id: V5_ControllerId = self.id.into();
-        let text = CString::new(text.as_ref())?;
+        let text = CString::new(text.as_ref()).expect("A NUL (0x00) character was found in the text input string.");
 
         if unsafe {
             vexControllerTextSet(
@@ -972,38 +978,11 @@ pub enum ControllerError {
     /// The controller is not connected to the Brain.
     Offline,
 
-    /// A NUL (0x00) character was found in a string that may not contain NUL characters.
-    #[snafu(transparent)]
-    Nul {
-        /// The source of the error.
-        source: NulError,
-    },
-
     /// Access to controller data is restricted by competition control.
     ///
     /// When this error occurs, the requested data is not available outside of
     /// driver control mode.
     CompetitionControl,
-
-    /// The line number provided is larger than [`ControllerScreen::MAX_LINES`].
-    #[snafu(display(
-        "Invalid line number ({line}) is greater than the maximum number of lines ({})",
-        ControllerScreen::MAX_LINES
-    ))]
-    InvalidLine {
-        /// The line number that was given.
-        line: u8,
-    },
-
-    /// The column number provided is larger than [`ControllerScreen::MAX_COLUMNS`].
-    #[snafu(display(
-        "Invalid column number ({column}) is greater than the maximum number of columns ({})",
-        ControllerScreen::MAX_COLUMNS
-    ))]
-    InvalidColumn {
-        /// The column number that was given.
-        column: u8,
-    },
 
     /// Attempted to write a buffer to the controller's screen before the previous buffer was sent.
     WriteBusy,

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -770,12 +770,7 @@ impl Display {
     ///
     /// A [`DisplayError::BufferSize`] error is returned if `buf` does not have the correct number of bytes
     /// to fill the specified region.
-    pub fn draw_buffer<T, I>(
-        &mut self,
-        region: Rect,
-        buf: T,
-        src_stride: i32,
-    ) -> Result<(), DisplayError>
+    pub fn draw_buffer<T, I>(&mut self, region: Rect, buf: T, src_stride: i32)
     where
         T: IntoIterator<Item = I>,
         I: Into<Rgb<u8>>,
@@ -788,12 +783,10 @@ impl Display {
         let expected_size = ((region.end.x - region.start.x) as u32
             * (region.end.y - region.start.y) as u32) as usize;
 
-        ensure!(
-            raw_buf.len() == expected_size,
-            BufferSizeSnafu {
-                buffer_size: raw_buf.len(),
-                expected_size
-            }
+        let buffer_size = raw_buf.len();
+        assert_eq!(
+            buffer_size, expected_size,
+            "The given buffer of colors was wrong size to fill the specified area: expected {expected_size} bytes, got {buffer_size}."
         );
 
         // SAFETY: The buffer is guaranteed to be the correct size.
@@ -807,8 +800,6 @@ impl Display {
                 src_stride,
             );
         }
-
-        Ok(())
     }
 
     /// Returns the current touch status of the display.
@@ -829,21 +820,6 @@ impl Display {
             release_count: touch_status.releaseCount,
         }
     }
-}
-
-#[derive(Debug, Snafu)]
-/// Errors that can occur when interacting with the display.
-pub enum DisplayError {
-    /// The given buffer of colors was wrong size to fill the specified area.
-    #[snafu(display(
-        "The given buffer of colors was wrong size to fill the specified area: expected {expected_size} bytes, got {buffer_size}."
-    ))]
-    BufferSize {
-        /// The size of the buffer.
-        buffer_size: usize,
-        /// The expected size of the buffer.
-        expected_size: usize,
-    },
 }
 
 /// An error that occurs when a negative or non-finite font size is attempted to be created.

--- a/packages/vexide-devices/src/smart/ai_vision.rs
+++ b/packages/vexide-devices/src/smart/ai_vision.rs
@@ -405,15 +405,14 @@ impl AiVisionSensor {
 
     /// Sets a color code used to detect groups of colors.
     ///
-    /// # Note
+    /// # Panics
     ///
-    /// This function will return an error if the given ID is not in the range [1, 8].
+    /// - Panics if the given color code contains an ID that is not in the interval [1, 7].
+    /// - Panics if the given ID is not in the interval [1, 8].
     ///
     /// # Errors
     ///
     /// - A [`PortError`] is returned if an AI Vision is not connected to the Smart Port.
-    /// - A [`AiVisionError::InvalidId`] is returned if the given ID is not in the range [1, 8].
-    /// - A [`AiVisionError::InvalidIdInCode`] is returned if the given color code contains an ID that is not in the range [1, 7].
     ///
     /// # Examples
     ///
@@ -434,17 +433,19 @@ impl AiVisionSensor {
     /// }
     /// ```
     pub fn set_color_code(&mut self, id: u8, code: &AiVisionColorCode) -> Result<()> {
-        if !(1..=8).contains(&id) {
-            return InvalidIdSnafu { id, range: 1..=8 }.fail();
-        }
+        assert!(
+            !(1..=8).contains(&id),
+            "The given ID ({id}) is out of the interval [1, 8]."
+        );
         self.validate_port()?;
 
         // Copy the color code into the V5_DeviceAiVisionCode struct
         let mut ids = [0u8; 7];
         for (i, id) in code.0.iter().flatten().enumerate() {
-            if !(1..=7).contains(id) {
-                return InvalidIdInCodeSnafu { id: *id }.fail();
-            }
+            assert!(
+                !(1..=7).contains(id),
+                "The given color code contains an ID ({id}) that is out of the interval [1, 7]."
+            );
             ids[i] = *id;
         }
 
@@ -478,10 +479,13 @@ impl AiVisionSensor {
 
     /// Returns the color code set on the AI Vision sensor with the given ID if it exists.
     ///
+    /// # Panics
+    ///
+    /// - Panics if the given ID is not in the interval [1, 8].
+    ///
     /// # Errors
     ///
     /// - A [`PortError`] is returned if an AI Vision is not connected to the Smart Port.
-    /// - A [`AiVisionError::InvalidId`] is returned if the given ID is not in the range [1, 8].
     ///
     /// # Examples
     ///
@@ -501,9 +505,10 @@ impl AiVisionSensor {
     /// }
     /// ```
     pub fn color_code(&self, id: u8) -> Result<Option<AiVisionColorCode>> {
-        if !(1..=8).contains(&id) {
-            return InvalidIdSnafu { id, range: 1..=8 }.fail();
-        }
+        assert!(
+            !(1..=8).contains(&id),
+            "The given ID ({id}) is out of the interval [1, 8]."
+        );
         self.validate_port()?;
 
         // Get the color code from the sensor
@@ -563,14 +568,13 @@ impl AiVisionSensor {
 
     /// Sets a color signature for the AI Vision sensor.
     ///
-    /// # Note
+    /// # Panics
     ///
-    /// This function will return an error if the given ID is not in the range [1, 7].
+    /// - Panics if the given ID is not in the range [1, 7].
     ///
     /// # Errors
     ///
     /// - A [`PortError`] is returned if an AI Vision is not connected to the Smart Port.
-    /// - A [`AiVisionError::InvalidId`] is returned if the given ID is not in the range [1, 7].
     ///
     /// # Examples
     ///
@@ -590,9 +594,10 @@ impl AiVisionSensor {
     /// }
     /// ```
     pub fn set_color(&mut self, id: u8, color: AiVisionColor) -> Result<()> {
-        if !(1..=7).contains(&id) {
-            return InvalidIdSnafu { id, range: 1..=7 }.fail();
-        }
+        assert!(
+            !(1..=7).contains(&id),
+            "The given ID ({id}) is out of the interval [1, 7]."
+        );
         self.validate_port()?;
 
         let mut color = V5_DeviceAiVisionColor {
@@ -613,10 +618,13 @@ impl AiVisionSensor {
 
     /// Returns the color signature set on the AI Vision sensor with the given ID if it exists.
     ///
+    /// # Panics
+    ///
+    /// - Panics if the given ID is not in the interval [1, 7].
+    ///
     /// # Errors
     ///
     /// - A [`PortError`] is returned if an AI Vision is not connected to the Smart Port.
-    /// - A [`AiVisionError::InvalidId`] is returned if the given ID is not in the range [1, 7].
     ///
     /// # Examples
     ///
@@ -640,9 +648,10 @@ impl AiVisionSensor {
     /// }
     /// ```
     pub fn color(&self, id: u8) -> Result<Option<AiVisionColor>> {
-        if !(1..=7).contains(&id) {
-            return InvalidIdSnafu { id, range: 1..=7 }.fail();
-        }
+        assert!(
+            !(1..=7).contains(&id),
+            "The given ID ({id}) is out of the interval [1, 7]."
+        );
         self.validate_port()?;
 
         let mut color: V5_DeviceAiVisionColor = unsafe { core::mem::zeroed() };
@@ -1007,20 +1016,6 @@ impl From<AiVisionSensor> for SmartPort {
 pub enum AiVisionError {
     /// An object created by VEXos failed to be converted.
     InvalidObject,
-    /// The given signature ID or argument is out of range.
-    #[snafu(display("The given ID ({id}) is out of the range {range:?}."))]
-    InvalidId {
-        /// The ID that was out of range.
-        id: u8,
-        /// The range of possible values for the ID.
-        range: core::ops::RangeInclusive<u8>,
-    },
-    /// A color signature ID in a given color code is out of range.
-    #[snafu(display("The given color code contains an ID ({id}) that is out of range."))]
-    InvalidIdInCode {
-        /// The ID that was out of range.
-        id: u8,
-    },
     /// Failed to fetch the class name of a model-detected object due it having a invalid
     /// string representation.
     #[snafu(transparent)]

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -113,9 +113,12 @@ impl VisionSensor {
     /// loses power. As a result, this function should be called every time the sensor is used on
     /// program start.
     ///
+    /// # Panics
+    ///
+    /// - Panics if the given signature ID is not in the interval [0, 7).
+    ///
     /// # Errors
     ///
-    /// - A [`VisionError::InvalidId`] error is returned if the `id` parameter is greater than or equal to 7.
     /// - A [`VisionError::Port`] error is returned if a vision sensor is not currently connected to the Smart Port.
     ///
     /// # Examples
@@ -139,7 +142,10 @@ impl VisionSensor {
     /// }
     /// ```
     pub fn set_signature(&mut self, id: u8, signature: VisionSignature) -> Result<(), VisionError> {
-        ensure!((1..7).contains(&id), InvalidIdSnafu { provided_id: id });
+        assert!(
+            (1..7).contains(&id),
+            "The given signature ID `{id}` is not in the expected interval [0, 7)."
+        );
         self.validate_port()?;
 
         let mut signature = V5_DeviceVisionSignature {
@@ -170,7 +176,10 @@ impl VisionSensor {
     /// Reads a signature off the sensor's onboard memory, returning `Some(sig)` if the slot is filled
     /// or `None` if no signature is stored with the given ID.
     fn read_raw_signature(&self, id: u8) -> Result<Option<V5_DeviceVisionSignature>, VisionError> {
-        ensure!((1..7).contains(&id), InvalidIdSnafu { provided_id: id });
+        assert!(
+            (1..7).contains(&id),
+            "The given signature ID `{id}` is not in the expected interval [0, 7)."
+        );
 
         let mut raw_signature = V5_DeviceVisionSignature::default();
         let read_operation =
@@ -207,10 +216,13 @@ impl VisionSensor {
 
     /// Returns a signature from the sensor's onboard volatile memory.
     ///
+    /// # Panics
+    ///
+    /// - Panics if the given signature ID is not in the interval [0, 7).
+    ///
     /// # Errors
     ///
     /// - A [`VisionError::Port`] error is returned if a vision sensor is not currently connected to the Smart Port.
-    /// - A [`VisionError::InvalidId`] error is returned if the `id` parameter is greater than or equal to 7.
     /// - A [`VisionError::ReadingFailed`] error is returned if the read operation failed.
     ///
     /// # Examples
@@ -303,11 +315,13 @@ impl VisionSensor {
     /// sensor loses its power source. As a result, this function should be called every time the
     /// sensor is used on program start.
     ///
+    /// # Panics
+    ///
+    /// - Panics if one or more of the given signature IDs are not in the interval [0, 7).
+    ///
     /// # Errors
     ///
     /// - A [`VisionError::Port`] error is returned if a vision sensor is not currently connected to the Smart Port.
-    /// - A [`VisionError::InvalidId`] error is returned if one or more of the signature IDs in the
-    ///   [`VisionCode`] were greater than or equal to 7.
     /// - A [`VisionError::ReadingFailed`] error is returned if a read operation failed or there was
     ///   no signature previously set in the slot(s) specified in the [`VisionCode`].
     ///
@@ -1372,15 +1386,6 @@ impl From<LedMode> for V5VisionLedMode {
 pub enum VisionError {
     /// Objects cannot be detected while Wi-Fi mode is enabled.
     WifiMode,
-
-    /// The given signature ID is not in the expected range `0..7`.
-    #[snafu(display(
-        "The given signature ID `{provided_id}` is not in the expected range `0..7`."
-    ))]
-    InvalidId {
-        /// The given ID which caused the error.
-        provided_id: u8,
-    },
 
     /// The camera could not be read.
     ReadingFailed,

--- a/packages/vexide-graphics/src/slint.rs
+++ b/packages/vexide-graphics/src/slint.rs
@@ -90,7 +90,7 @@ impl Platform for V5Platform {
             self.window.draw_if_needed(|renderer| {
                 let mut buf = *self.buffer.borrow_mut();
                 renderer.render(&mut buf, Display::HORIZONTAL_RESOLUTION as _);
-                // Unwrap because the buffer is guaranteed to be the correct size
+
                 self.display.borrow_mut().draw_buffer(
                     Rect::from_dimensions(
                         [0, 0],

--- a/packages/vexide-graphics/src/slint.rs
+++ b/packages/vexide-graphics/src/slint.rs
@@ -101,8 +101,7 @@ impl Platform for V5Platform {
                         ),
                         buf,
                         Display::HORIZONTAL_RESOLUTION.into(),
-                    )
-                    .unwrap();
+                    );
             });
 
             self.window.dispatch_event(self.get_touch_event());

--- a/packages/vexide-graphics/src/slint.rs
+++ b/packages/vexide-graphics/src/slint.rs
@@ -91,17 +91,15 @@ impl Platform for V5Platform {
                 let mut buf = *self.buffer.borrow_mut();
                 renderer.render(&mut buf, Display::HORIZONTAL_RESOLUTION as _);
                 // Unwrap because the buffer is guaranteed to be the correct size
-                self.display
-                    .borrow_mut()
-                    .draw_buffer(
-                        Rect::from_dimensions(
-                            [0, 0],
-                            Display::HORIZONTAL_RESOLUTION as _,
-                            Display::VERTICAL_RESOLUTION as _,
-                        ),
-                        buf,
-                        Display::HORIZONTAL_RESOLUTION.into(),
-                    );
+                self.display.borrow_mut().draw_buffer(
+                    Rect::from_dimensions(
+                        [0, 0],
+                        Display::HORIZONTAL_RESOLUTION as _,
+                        Display::VERTICAL_RESOLUTION as _,
+                    ),
+                    buf,
+                    Display::HORIZONTAL_RESOLUTION.into(),
+                );
             });
 
             self.window.dispatch_event(self.get_touch_event());


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR refactors most of the error variants in device errors caused by user end bugs into panics.
> Functions often have contracts: their behavior is only guaranteed if the inputs meet particular requirements. Panicking when the contract is violated makes sense because a contract violation always indicates a caller-side bug, and it’s not a kind of error you want the calling code to have to explicitly handle.
## Additional Context
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.

- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
