### PR TITLE
fix: AdiRangeFinder port validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Before releasing:
 ### Fixed
 
 - Fixed error handling for encoder port numbers. (#264)
+- Fixed error handling for rangefinder port numbers. (#268)
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Roughly the same deal as #264. In the future, `BadOutputPort` should swap names with  `BadInputPort`, since it's now a complete misnomer.