### PR TITLE
refactor: clean up two-wire ADI devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Before releasing:
 
 ### Removed
 
-- Renmoved `EncoderError::BadTopPort`. (#271) (**Breaking Change**)
+- Removed `EncoderError::BadTopPort`. (#271) (**Breaking Change**)
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,13 @@ Before releasing:
 
 - Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)
 - All `Position` methods are now usable in `const` context. (#254)
-- Two-wire ADI devices (`AdiEncoder` and `AdiRangeFinder`) now take their ports as separate arguments instead of a tuple. (#) (**Breaking Change**)
-- Renamed `EncoderError::BadBottomPort` to `EncoderError::BadPortPlacement`.  (#) (**Breaking Change**)
-- Swapped the naming of `RangeFinderError::BadInputPort` and `RangeFinderError::BadOutputPort`.  (#) (**Breaking Change**)
+- Two-wire ADI devices (`AdiEncoder` and `AdiRangeFinder`) now take their ports as separate arguments instead of a tuple. (#271) (**Breaking Change**)
+- Renamed `EncoderError::BadBottomPort` to `EncoderError::BadPortPlacement`. (#271) (**Breaking Change**)
+- Swapped the naming of `RangeFinderError::BadInputPort` and `RangeFinderError::BadOutputPort`. (#271) (**Breaking Change**)
 
 ### Removed
 
-- Renmoved `EncoderError::BadTopPort`. (#) (**Breaking Change**)
+- Renmoved `EncoderError::BadTopPort`. (#271) (**Breaking Change**)
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,13 @@ Before releasing:
 
 - Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)
 - All `Position` methods are now usable in `const` context. (#254)
+- Two-wire ADI devices (`AdiEncoder` and `AdiRangeFinder`) now take their ports as separate arguments instead of a tuple. (#) (**Breaking Change**)
+- Renamed `EncoderError::BadBottomPort` to `EncoderError::BadPortPlacement`.  (#) (**Breaking Change**)
+- Swapped the naming of `RangeFinderError::BadInputPort` and `RangeFinderError::BadOutputPort`.  (#) (**Breaking Change**)
 
 ### Removed
+
+- Renmoved `EncoderError::BadTopPort`. (#) (**Breaking Change**)
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Before releasing:
 - All `Position` methods are now usable in `const` context. (#254)
 - Two-wire ADI devices (`AdiEncoder` and `AdiRangeFinder`) now take their ports as separate arguments instead of a tuple. (#271) (**Breaking Change**)
 - `AdiEncoder` and `AdiRangeFinder` will now panic if invalid port pairings are passed rather than return a `Result`. (#271) (**Breaking Change**)
+- `AdiDevice` is now const-generic over the number of ports used by the device. (#271) (**Breaking Change**)
+- Replaced `AdiDevice::port_number` with `AdiDevice::port_numbers`. (#271) (**Breaking Change**)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,10 @@ Before releasing:
 - Renamed `Once::is_complete` to `Once::is_completed` for consistency with the standard library. (#257) (**Breaking Change**)
 - All `Position` methods are now usable in `const` context. (#254)
 - Two-wire ADI devices (`AdiEncoder` and `AdiRangeFinder`) now take their ports as separate arguments instead of a tuple. (#271) (**Breaking Change**)
-- Renamed `EncoderError::BadBottomPort` to `EncoderError::BadPortPlacement`. (#271) (**Breaking Change**)
-- Swapped the naming of `RangeFinderError::BadInputPort` and `RangeFinderError::BadOutputPort`. (#271) (**Breaking Change**)
+- `AdiEncoder` and `AdiRangeFinder` will now panic if invalid port pairings are passed rather than return a `Result`. (#271) (**Breaking Change**)
 
 ### Removed
 
-- Removed `EncoderError::BadTopPort`. (#271) (**Breaking Change**)
 - Replaced `vexide_core::allocator::init_heap` with `vexide_core::allocator::claim`, which allows claiming uninitialized memory spans as heap space.
 - The `Nul`, `InvalidLine`, and `InvalidColumn` `ControllerError` variants have been removed. These errors now cause panics. (#266) (**Breaking Change**)
 - `DisplayError` has been removed and `Display::draw_buffer` now panics when given a buffer of invalid size. (#266) (**Breaking Change**)
@@ -53,6 +51,7 @@ Before releasing:
 - The `lock` functions on `Stdin` and `Stdout` are now async. (#265) (**Breaking Change**)
 - Removed the `Deref` implementation and `force` method on `LazyLock` to prevent deadlocks. use the async `LazyLock::get` instead. (#265) (**Breaking Change**)
 - Removed the `Read` and `Write` implementations on `Stdin` and `Stdout` respectively to prevent deadlocks. (#265) (**Breaking Change**)
+- Removed `EncoderError` and `RangeFinderError`. The respective devices now just return `PortError`. (#271) (**Breaking Change**)
 
 ### New Contributors
 

--- a/examples/adi.rs
+++ b/examples/adi.rs
@@ -13,12 +13,12 @@ async fn main(peripherals: Peripherals) {
     let line_tracker = AdiLineTracker::new(peripherals.adi_b);
 
     // Create an ultrasonic range finder on triport C.
-    let range_finder = AdiRangeFinder::new(peripherals.adi_c, peripherals.adi_d).unwrap();
+    let range_finder = AdiRangeFinder::new(peripherals.adi_c, peripherals.adi_d);
 
     loop {
         // Print out the sensor values to stdout every 10ms (the update rate of ADI devices).
         println!(
-            "Potentiometer Angle: {}\nLine Tracker Reflectivity: {}%\nUltrasonic Distance: {}\n",
+            "Potentiometer Angle: {}\nLine Tracker Reflectivity: {}%\nUltrasonic Distance: {:?}\n",
             potentiometer.angle().unwrap(),
             line_tracker.reflectivity().unwrap() * 100.0,
             range_finder.distance().unwrap()

--- a/examples/adi.rs
+++ b/examples/adi.rs
@@ -13,7 +13,7 @@ async fn main(peripherals: Peripherals) {
     let line_tracker = AdiLineTracker::new(peripherals.adi_b);
 
     // Create an ultrasonic range finder on triport C.
-    let range_finder = AdiRangeFinder::new((peripherals.adi_c, peripherals.adi_d)).unwrap();
+    let range_finder = AdiRangeFinder::new(peripherals.adi_c, peripherals.adi_d).unwrap();
 
     loop {
         // Print out the sensor values to stdout every 10ms (the update rate of ADI devices).

--- a/packages/vexide-devices/src/adi/accelerometer.rs
+++ b/packages/vexide-devices/src/adi/accelerometer.rs
@@ -128,8 +128,6 @@ impl Sensitivity {
 }
 
 impl AdiDevice<1> for AdiAccelerometer {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/accelerometer.rs
+++ b/packages/vexide-devices/src/adi/accelerometer.rs
@@ -127,11 +127,11 @@ impl Sensitivity {
     }
 }
 
-impl AdiDevice for AdiAccelerometer {
+impl AdiDevice<1> for AdiAccelerometer {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -149,11 +149,11 @@ impl AdiAddrLed {
     }
 }
 
-impl AdiDevice for AdiAddrLed {
+impl AdiDevice<1> for AdiAddrLed {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -150,8 +150,6 @@ impl AdiAddrLed {
 }
 
 impl AdiDevice<1> for AdiAddrLed {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/analog.rs
+++ b/packages/vexide-devices/src/adi/analog.rs
@@ -79,8 +79,6 @@ impl AdiAnalogIn {
 }
 
 impl AdiDevice<1> for AdiAnalogIn {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/analog.rs
+++ b/packages/vexide-devices/src/adi/analog.rs
@@ -78,11 +78,11 @@ impl AdiAnalogIn {
     }
 }
 
-impl AdiDevice for AdiAnalogIn {
+impl AdiDevice<1> for AdiAnalogIn {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -123,8 +123,6 @@ impl AdiDigitalIn {
 }
 
 impl AdiDevice<1> for AdiDigitalIn {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }
@@ -389,8 +387,6 @@ impl AdiDigitalOut {
 }
 
 impl AdiDevice<1> for AdiDigitalOut {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -122,11 +122,11 @@ impl AdiDigitalIn {
     }
 }
 
-impl AdiDevice for AdiDigitalIn {
+impl AdiDevice<1> for AdiDigitalIn {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {
@@ -388,11 +388,11 @@ impl AdiDigitalOut {
     }
 }
 
-impl AdiDevice for AdiDigitalOut {
+impl AdiDevice<1> for AdiDigitalOut {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -249,11 +249,11 @@ impl AdiEncoder {
     }
 }
 
-impl AdiDevice for AdiEncoder {
+impl AdiDevice<2> for AdiEncoder {
     type PortNumberOutput = (u8, u8);
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        (self.top_port.number(), self.bottom_port.number())
+    fn port_numbers(&self) -> [u8; 2] {
+        [self.top_port.number(), self.bottom_port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -250,8 +250,6 @@ impl AdiEncoder {
 }
 
 impl AdiDevice<2> for AdiEncoder {
-    type PortNumberOutput = (u8, u8);
-
     fn port_numbers(&self) -> [u8; 2] {
         [self.top_port.number(), self.bottom_port.number()]
     }

--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -83,7 +83,7 @@ impl AdiEncoder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b).expect("could not create encoder");
+    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b);
     ///
     ///     loop {
     ///         println!("encoder position: {:?}", encoder.position());
@@ -150,7 +150,7 @@ impl AdiEncoder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b).expect("could not create encoder");
+    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b);
     ///
     ///     loop {
     ///         println!("encoder position: {:?}", encoder.position());
@@ -195,7 +195,7 @@ impl AdiEncoder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b).expect("could not create encoder");
+    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b);
     ///
     ///     // Treat the encoder as if it were at 180 degrees.
     ///     _ = encoder.set_position(Position::from_degrees(180));
@@ -237,7 +237,7 @@ impl AdiEncoder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b).expect("could not create encoder");
+    ///     let encoder = AdiEncoder::new(peripherals.adi_a, peripherals.adi_b);
     ///
     ///     // Reset the encoder position to zero.
     ///     // This doesn't really do anything in this case, but it's a good example.

--- a/packages/vexide-devices/src/adi/gyroscope.rs
+++ b/packages/vexide-devices/src/adi/gyroscope.rs
@@ -198,11 +198,11 @@ impl AdiGyroscope {
     }
 }
 
-impl AdiDevice for AdiGyroscope {
+impl AdiDevice<1> for AdiGyroscope {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/gyroscope.rs
+++ b/packages/vexide-devices/src/adi/gyroscope.rs
@@ -199,8 +199,6 @@ impl AdiGyroscope {
 }
 
 impl AdiDevice<1> for AdiGyroscope {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/light_sensor.rs
+++ b/packages/vexide-devices/src/adi/light_sensor.rs
@@ -120,8 +120,6 @@ impl AdiLightSensor {
 }
 
 impl AdiDevice<1> for AdiLightSensor {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/light_sensor.rs
+++ b/packages/vexide-devices/src/adi/light_sensor.rs
@@ -119,11 +119,11 @@ impl AdiLightSensor {
     }
 }
 
-impl AdiDevice for AdiLightSensor {
+impl AdiDevice<1> for AdiLightSensor {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/line_tracker.rs
+++ b/packages/vexide-devices/src/adi/line_tracker.rs
@@ -124,11 +124,11 @@ impl AdiLineTracker {
     }
 }
 
-impl AdiDevice for AdiLineTracker {
+impl AdiDevice<1> for AdiLineTracker {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/line_tracker.rs
+++ b/packages/vexide-devices/src/adi/line_tracker.rs
@@ -125,8 +125,6 @@ impl AdiLineTracker {
 }
 
 impl AdiDevice<1> for AdiLineTracker {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -198,7 +198,7 @@ pub trait AdiDevice<const N: usize> {
     /// Update rate of ADI devices.
     const UPDATE_INTERVAL: Duration = ADI_UPDATE_INTERVAL;
 
-    /// Returns the port numbers of the [`AdiPort`s] this device is registered to.
+    /// Returns the port numbers of the [`AdiPort`]s that this device is registered to.
     ///
     /// Ports are numbered starting from 1.
     fn port_numbers(&self) -> [u8; N];

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -157,23 +157,23 @@ impl AdiPort {
     }
 }
 
-impl<T: AdiDevice<PortNumberOutput = u8>> From<T> for AdiPort {
+impl<T: AdiDevice<1>> From<T> for AdiPort {
     fn from(device: T) -> Self {
         // SAFETY: We can do this, since we ensure that the old Smart Port was disposed of.
         // This can effectively be thought as a move out of the device's private `port` field.
-        unsafe { Self::new(device.port_number(), device.expander_port_number()) }
+        unsafe { Self::new(device.port_numbers()[0], device.expander_port_number()) }
     }
 }
 
 impl From<AdiRangeFinder> for (AdiPort, AdiPort) {
     fn from(device: AdiRangeFinder) -> Self {
-        let numbers = device.port_number();
+        let numbers = device.port_numbers();
         let expander_number = device.expander_port_number();
 
         unsafe {
             (
-                AdiPort::new(numbers.0, expander_number),
-                AdiPort::new(numbers.1, expander_number),
+                AdiPort::new(numbers[0], expander_number),
+                AdiPort::new(numbers[1], expander_number),
             )
         }
     }
@@ -181,20 +181,20 @@ impl From<AdiRangeFinder> for (AdiPort, AdiPort) {
 
 impl From<AdiEncoder> for (AdiPort, AdiPort) {
     fn from(device: AdiEncoder) -> Self {
-        let numbers = device.port_number();
+        let numbers = device.port_numbers();
         let expander_number = device.expander_port_number();
 
         unsafe {
             (
-                AdiPort::new(numbers.0, expander_number),
-                AdiPort::new(numbers.1, expander_number),
+                AdiPort::new(numbers[0], expander_number),
+                AdiPort::new(numbers[1], expander_number),
             )
         }
     }
 }
 
 /// Common functionality for a ADI (three-wire) devices.
-pub trait AdiDevice {
+pub trait AdiDevice<const N: usize> {
     /// Update rate of ADI devices.
     const UPDATE_INTERVAL: Duration = ADI_UPDATE_INTERVAL;
 
@@ -205,7 +205,7 @@ pub trait AdiDevice {
     /// Returns the port number of the [`AdiPort`] this device is registered on.
     ///
     /// Ports are numbered starting from 1.
-    fn port_number(&self) -> Self::PortNumberOutput;
+    fn port_numbers(&self) -> [u8; N];
 
     /// Returns the port number of the [`AdiPort`] this device is registered on.
     ///

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -198,16 +198,13 @@ pub trait AdiDevice<const N: usize> {
     /// Update rate of ADI devices.
     const UPDATE_INTERVAL: Duration = ADI_UPDATE_INTERVAL;
 
-    /// The type that [`Self::port_number`] should return. This is usually `u8`, but
-    /// occasionally `(u8, u8)` if the device has two ADI wires.
-    type PortNumberOutput;
-
-    /// Returns the port number of the [`AdiPort`] this device is registered on.
+    /// Returns the port numbers of the [`AdiPort`s] this device is registered to.
     ///
     /// Ports are numbered starting from 1.
     fn port_numbers(&self) -> [u8; N];
 
-    /// Returns the port number of the [`AdiPort`] this device is registered on.
+    /// Returns the port number of the [`SmartPort`] this device's expander is connected to,
+    /// or [`None`] if the device is plugged into an onboard ADI port.
     ///
     /// Ports are numbered starting from 1.
     fn expander_port_number(&self) -> Option<u8>;

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -227,11 +227,11 @@ impl AdiMotor {
     }
 }
 
-impl AdiDevice for AdiMotor {
+impl AdiDevice<1> for AdiMotor {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -228,8 +228,6 @@ impl AdiMotor {
 }
 
 impl AdiDevice<1> for AdiMotor {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/potentiometer.rs
+++ b/packages/vexide-devices/src/adi/potentiometer.rs
@@ -161,8 +161,6 @@ impl PotentiometerType {
 }
 
 impl AdiDevice<1> for AdiPotentiometer {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/potentiometer.rs
+++ b/packages/vexide-devices/src/adi/potentiometer.rs
@@ -160,11 +160,11 @@ impl PotentiometerType {
     }
 }
 
-impl AdiDevice for AdiPotentiometer {
+impl AdiDevice<1> for AdiPotentiometer {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/pwm.rs
+++ b/packages/vexide-devices/src/adi/pwm.rs
@@ -94,11 +94,11 @@ impl AdiPwmOut {
     }
 }
 
-impl AdiDevice for AdiPwmOut {
+impl AdiDevice<1> for AdiPwmOut {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/pwm.rs
+++ b/packages/vexide-devices/src/adi/pwm.rs
@@ -95,8 +95,6 @@ impl AdiPwmOut {
 }
 
 impl AdiDevice<1> for AdiPwmOut {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -59,8 +59,8 @@ impl AdiRangeFinder {
     ///
     /// - If the top and bottom ports originate from different [`AdiExpander`](crate::smart::expander::AdiExpander)s,
     ///   returns [`RangeFinderError::ExpanderPortMismatch`].
-    /// - If the output port is not odd (A, C, E, G), returns [`RangeFinderError::BadInputPort`].
-    /// - If the input port is not the next after the output port, returns [`RangeFinderError::BadOutputPort`].
+    /// - If the output port is not odd (A, C, E, G), returns [`RangeFinderError::BadOutputPort`].
+    /// - If the input port is not the next after the output port, returns [`RangeFinderError::BadInputPort`].
     ///
     /// # Examples
     ///
@@ -69,7 +69,7 @@ impl AdiRangeFinder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let range_finder = AdiRangeFinder::new((peripherals.adi_a, peripherals.adi_b)).expect("Failed to create range finder");
+    ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b).expect("Failed to create range finder");
     ///     loop {
     ///         let distance = range_finder.distance().expect("Failed to get distance");
     ///         println!("Distance: {} cm", distance);
@@ -77,7 +77,7 @@ impl AdiRangeFinder {
     ///     }
     /// }
     /// ```
-    pub fn new((output_port, input_port): (AdiPort, AdiPort)) -> Result<Self, RangeFinderError> {
+    pub fn new(output_port: AdiPort, input_port: AdiPort) -> Result<Self, RangeFinderError> {
         let output_number = output_port.number();
         let input_number = input_port.number();
 
@@ -93,14 +93,14 @@ impl AdiRangeFinder {
         // Output must be on an odd indexed port (A, C, E, G).
         ensure!(
             output_number % 2 != 0,
-            BadInputPortSnafu {
+            BadOutputPortSnafu {
                 port: output_number
             }
         );
         // Input must be directly next to top on the higher port index.
         ensure!(
             input_number == output_number + 1,
-            BadOutputPortSnafu {
+            BadInputPortSnafu {
                 input_port: input_number,
                 output_port: output_number,
             }
@@ -130,7 +130,7 @@ impl AdiRangeFinder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let range_finder = AdiRangeFinder::new((peripherals.adi_a, peripherals.adi_b)).expect("Failed to create range finder");
+    ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b).expect("Failed to create range finder");
     ///     loop {
     ///         let distance = range_finder.distance().expect("Failed to get distance");
     ///         println!("Distance: {} cm", distance);
@@ -173,12 +173,11 @@ pub enum RangeFinderError {
     NoReading,
 
     /// The output wire must be on an odd numbered port (A, C, E, G).
-    // TODO: Change this to be `BadOutputPort`.
     #[snafu(display(
         "The output ADI port provided (`{}`) was not odd numbered (A, C, E, G).",
         adi_port_name(*port)
     ))]
-    BadInputPort {
+    BadOutputPort {
         /// The port number that caused the error.
         port: u8,
     },
@@ -190,7 +189,7 @@ pub enum RangeFinderError {
         adi_port_name(*output_port),
         adi_port_name(*output_port + 1),
     ))]
-    BadOutputPort {
+    BadInputPort {
         /// The bottom port number that caused the error.
         input_port: u8,
         /// The top port number that caused the error.

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -154,8 +154,6 @@ impl AdiRangeFinder {
 }
 
 impl AdiDevice<2> for AdiRangeFinder {
-    type PortNumberOutput = (u8, u8);
-
     fn port_numbers(&self) -> [u8; 2] {
         [self.output_port.number(), self.input_port.number()]
     }

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -153,11 +153,11 @@ impl AdiRangeFinder {
     }
 }
 
-impl AdiDevice for AdiRangeFinder {
+impl AdiDevice<2> for AdiRangeFinder {
     type PortNumberOutput = (u8, u8);
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        (self.output_port.number(), self.input_port.number())
+    fn port_numbers(&self) -> [u8; 2] {
+        [self.output_port.number(), self.input_port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -67,7 +67,7 @@ impl AdiRangeFinder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b).expect("Failed to create range finder");
+    ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b);
     ///     loop {
     ///         let distance = range_finder.distance().expect("Failed to get distance");
     ///         println!("Distance: {} cm", distance);
@@ -130,7 +130,7 @@ impl AdiRangeFinder {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b).expect("Failed to create range finder");
+    ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b);
     ///     loop {
     ///         match range_finder.distance().expect("Failed to get distance") {
     ///             Some(distance) => println!("Distance: {} cm", distance),

--- a/packages/vexide-devices/src/adi/range_finder.rs
+++ b/packages/vexide-devices/src/adi/range_finder.rs
@@ -36,7 +36,6 @@
 //! ports. For the sensor to work properly, the "OUTPUT" wire must be in an odd-numbered slot
 //! (A, C, E, G), and the "INPUT" wire must be in the higher slot next to the input wire.
 
-use snafu::{ensure, Snafu};
 use vex_sdk::vexDeviceAdiValueGet;
 
 use super::{AdiDevice, AdiDeviceType, AdiPort};
@@ -55,12 +54,11 @@ pub struct AdiRangeFinder {
 impl AdiRangeFinder {
     /// Create a new rangefinder sensor from an output and input [`AdiPort`].
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// - If the top and bottom ports originate from different [`AdiExpander`](crate::smart::expander::AdiExpander)s,
-    ///   returns [`RangeFinderError::ExpanderPortMismatch`].
-    /// - If the output port is not odd (A, C, E, G), returns [`RangeFinderError::BadOutputPort`].
-    /// - If the input port is not the next after the output port, returns [`RangeFinderError::BadInputPort`].
+    /// - If the top and bottom ports originate from different [`AdiExpander`](crate::smart::expander::AdiExpander)s.
+    /// - If the output port is not odd (A, C, E, G).
+    /// - If the input port is not the next after the output port.
     ///
     /// # Examples
     ///
@@ -77,51 +75,53 @@ impl AdiRangeFinder {
     ///     }
     /// }
     /// ```
-    pub fn new(output_port: AdiPort, input_port: AdiPort) -> Result<Self, RangeFinderError> {
+    #[must_use]
+    pub fn new(output_port: AdiPort, input_port: AdiPort) -> Self {
         let output_number = output_port.number();
         let input_number = input_port.number();
 
         // Input and output must be plugged into the same ADI expander.
-        ensure!(
-            input_port.expander_index() != output_port.expander_index(),
-            ExpanderPortMismatchSnafu {
-                top_port_expander: input_port.expander_number(),
-                bottom_port_expander: output_port.expander_number()
-            }
+        assert!(
+            input_port.expander_index() == output_port.expander_index(),
+            "The specified output and input ports belong to different ADI expanders. Both expanders {:?} and {:?} were provided.",
+            output_port.expander_number(),
+            input_port.expander_number(),
         );
 
         // Output must be on an odd indexed port (A, C, E, G).
-        ensure!(
+        assert!(
             output_number % 2 != 0,
-            BadOutputPortSnafu {
-                port: output_number
-            }
+            "The output ADI port provided (`{}`) was not odd numbered (A, C, E, G).",
+            adi_port_name(output_number),
         );
+
         // Input must be directly next to top on the higher port index.
-        ensure!(
+        assert!(
             input_number == output_number + 1,
-            BadInputPortSnafu {
-                input_port: input_number,
-                output_port: output_number,
-            }
+            "The input ADI port provided (`{}`) was not directly above the output port (`{}`). Instead, it should be port `{}`.",
+            adi_port_name(input_number),
+            adi_port_name(output_number),
+            adi_port_name(output_number + 1),
         );
 
         output_port.configure(AdiDeviceType::RangeFinder);
 
-        Ok(Self {
+        Self {
             output_port,
             input_port,
-        })
+        }
     }
 
-    /// Returns the distance reading of the rangefinder sensor in centimeters.
+    /// Returns the distance reading of the rangefinder sensor in centimeters, or `None` if the sensor was unable
+    /// to find an object in range.
     ///
     /// Round and/or fluffy objects can cause inaccurate values to be returned.
     ///
     /// # Errors
     ///
-    /// - A [`RangeFinderError::NoReading`] error is returned if the rangefinder cannot find a valid reading.
-    /// - A [`RangeFinderError::Port`] error is returned if the ADI device could not be accessed.
+    /// - A [`PortError::Disconnected`] error is returned if an ADI expander device was required but not connected.
+    /// - A [`PortError::IncorrectDevice`] error is returned if an ADI expander device was required but
+    ///   something else was connected.
     ///
     /// # Examples
     ///
@@ -132,20 +132,23 @@ impl AdiRangeFinder {
     /// async fn main(peripherals: Peripherals) {
     ///     let range_finder = AdiRangeFinder::new(peripherals.adi_a, peripherals.adi_b).expect("Failed to create range finder");
     ///     loop {
-    ///         let distance = range_finder.distance().expect("Failed to get distance");
-    ///         println!("Distance: {} cm", distance);
+    ///         match range_finder.distance().expect("Failed to get distance") {
+    ///             Some(distance) => println!("Distance: {} cm", distance),
+    ///             None => println!("Can't find anything in range :("),
+    ///         }
+    ///
     ///         sleep(vexide::devices::adi::ADI_UPDATE_INTERVAL).await;
     ///     }
     /// }
     /// ```
-    pub fn distance(&self) -> Result<u16, RangeFinderError> {
+    pub fn distance(&self) -> Result<Option<u16>, PortError> {
         self.output_port.validate_expander()?;
 
         match unsafe {
             vexDeviceAdiValueGet(self.output_port.device_handle(), self.output_port.index())
         } {
-            -1 => NoReadingSnafu.fail(),
-            val => Ok(val as u16),
+            -1 => Ok(None),
+            val => Ok(Some(val as u16)),
         }
     }
 }
@@ -164,55 +167,4 @@ impl AdiDevice for AdiRangeFinder {
     fn device_type(&self) -> AdiDeviceType {
         AdiDeviceType::RangeFinder
     }
-}
-
-#[derive(Debug, Snafu)]
-/// Errors that can occur when interacting with an rangefinder range finder.
-pub enum RangeFinderError {
-    /// The sensor is unable to return a valid reading.
-    NoReading,
-
-    /// The output wire must be on an odd numbered port (A, C, E, G).
-    #[snafu(display(
-        "The output ADI port provided (`{}`) was not odd numbered (A, C, E, G).",
-        adi_port_name(*port)
-    ))]
-    BadOutputPort {
-        /// The port number that caused the error.
-        port: u8,
-    },
-
-    /// The input wire must be plugged in directly above the output wire.
-    #[snafu(display(
-        "The input ADI port provided (`{}`) was not directly above the output port (`{}`). Instead, it should be port `{}`.",
-        adi_port_name(*input_port),
-        adi_port_name(*output_port),
-        adi_port_name(*output_port + 1),
-    ))]
-    BadInputPort {
-        /// The bottom port number that caused the error.
-        input_port: u8,
-        /// The top port number that caused the error.
-        output_port: u8,
-    },
-
-    /// The specified top and bottom ports may belong to different ADI expanders.
-    #[snafu(display(
-        "The specified top and bottom ports may belong to different ADI expanders. Both expanders {:?} and {:?} were provided.",
-        top_port_expander,
-        bottom_port_expander
-    ))]
-    ExpanderPortMismatch {
-        /// The top port's expander number.
-        top_port_expander: Option<u8>,
-        /// The bottom port's expander number.
-        bottom_port_expander: Option<u8>,
-    },
-
-    /// Generic port related error.
-    #[snafu(transparent)]
-    Port {
-        /// The source of the error.
-        source: PortError,
-    },
 }

--- a/packages/vexide-devices/src/adi/servo.rs
+++ b/packages/vexide-devices/src/adi/servo.rs
@@ -138,11 +138,11 @@ impl AdiServo {
     }
 }
 
-impl AdiDevice for AdiServo {
+impl AdiDevice<1> for AdiServo {
     type PortNumberOutput = u8;
 
-    fn port_number(&self) -> Self::PortNumberOutput {
-        self.port.number()
+    fn port_numbers(&self) -> [u8; 1] {
+        [self.port.number()]
     }
 
     fn expander_port_number(&self) -> Option<u8> {

--- a/packages/vexide-devices/src/adi/servo.rs
+++ b/packages/vexide-devices/src/adi/servo.rs
@@ -139,8 +139,6 @@ impl AdiServo {
 }
 
 impl AdiDevice<1> for AdiServo {
-    type PortNumberOutput = u8;
-
     fn port_numbers(&self) -> [u8; 1] {
         [self.port.number()]
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
- Fixes naming of error handling variants.
- Removes unused error handling variants.
- Changed constructor functions of two-wire devices to take their ports as separate arguments rather than one tuple.
- Implements a solution for #120 by refactoring how `AdiDevice` works.

## Additional Context
Breaking Change.