### PR TITLE
fix: abort on recursive panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Before releasing:
 - Fixed error handling for rangefinder port numbers. (#268)
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
+- Recursive panics (panics that occur *within* `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
 
 ### Changed
 

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -234,7 +234,7 @@ pub fn take_hook() -> Box<dyn Fn(&core::panic::PanicInfo<'_>) + Send> {
     // functions, which don't panic while holding a lock.
     let mut guard = HOOK
         .try_lock()
-        .expect("failed to set custom panic hook (mutex poisoned or locked)");
+        .expect("failed to set custom panic hook (mutex locked)");
     // Don't do anything that could panic until guard is dropped
     let old_hook = core::mem::replace(&mut *guard, Hook::Default).into_box();
     core::mem::drop(guard);
@@ -274,7 +274,7 @@ pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
     } else {
         // Since this is in theory unreachable, if it is reached, let's ask the
         // user to file a bug report.
-        println!("Panic handler hook mutex is poisoned. Using default `vexide-panic` panic handler. This should never happen.");
+        println!("Panic handler hook mutex was locked while using the default panic hook. This should never happen.");
         println!("If you see this, please consider filing a bug: https://github.com/vexide/vexide/issues/new");
         default_panic_hook(info);
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
If a user-registered panic hook happens to panic itself, or a call to `println!` in our current `panic_handler` happens to panic, then we end up with a potentially recursive panic, which can result in some nasty stack overflow bugs. This ends up having some bad side-effects, such as `println!` being called in a tight loop causing a stack overflow:

```rs
loop {
	println!("What");
}
```

To recap:
`println!()` -> `stdout().write_all()` -> `panic!()` (because the buffer is unabled to be flushed in a tight loop thanks to #273) -> `println!()`

This PR puts a check in place to make sure we only call the hook and proceed with the I/O portion of the panic if this is the first time `panic!` has been called. If a recursive panic occurs, we immediately abort.