### PR TITLE
fix: avoid trying to reset IMU if calibration is already occurring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Before releasing:
 - Fixed error handling for rangefinder port numbers. (#268)
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
+- Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275)
 
 ### Changed
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

See the discussion in #200 for a more detailed explanation of what this PR aims to fix.

**These changes have been hardware tested.**