### PR TITLE
feat: :sparkles: Add uptime and VEXos version getters to vexide-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Before releasing:
 
 ### Added
 
+- Added functions to get vexOS version and uptime. (#278)
+
 ### Fixed
 
 - Fixed error handling for encoder port numbers. (#264)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Before releasing:
 
 ### Added
 
-- Added functions to get vexOS version and uptime. (#278)
+- Added functions to get VEXos version and uptime. (#278)
 
 ### Fixed
 

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -69,12 +69,6 @@ pub enum CompetitionMode {
     Driver,
 }
 
-impl fmt::Display for CompetitionMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
 /// Represents a type of system used to control competition state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompetitionSystem {

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -5,7 +5,6 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::{
     cell::UnsafeCell,
-    fmt,
     future::{Future, IntoFuture},
     marker::{PhantomData, PhantomPinned},
     ops::ControlFlow,

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::{
     cell::UnsafeCell,
+    fmt,
     future::{Future, IntoFuture},
     marker::{PhantomData, PhantomPinned},
     ops::ControlFlow,
@@ -66,6 +67,12 @@ pub enum CompetitionMode {
     /// connecting, but are typically placed into this mode following the autonomous
     /// period.
     Driver,
+}
+
+impl fmt::Display for CompetitionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
 }
 
 /// Represents a type of system used to control competition state.

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod competition;
 pub mod float;
 pub mod fs;
 pub mod io;
+pub mod os;
 pub mod path;
 pub mod program;
 pub mod sync;

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -1,6 +1,7 @@
-//! vexOS functions
+//! VEXos functions
 //!
-//! Module for retreiving information about vexOS
+//! This module provides utilities for for interacting and retrieving
+//! information from VEXos.
 
 use core::fmt;
 

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -2,9 +2,9 @@
 //!
 //! Module for retreiving information about vexOS
 
-use core::{fmt, time::Duration};
+use core::fmt;
 
-use vex_sdk::{vexSystemPowerupTimeGet, vexSystemUsbStatus, vexSystemVersion};
+use vex_sdk::{vexSystemUsbStatus, vexSystemVersion};
 
 /// A VexOS version
 #[derive(Clone, Copy, Debug)]
@@ -31,7 +31,7 @@ impl fmt::Display for Version {
 
 /// Returns the current VexOS version.
 #[must_use]
-pub fn get_version() -> Version {
+pub fn system_version() -> Version {
     let version_bytes = unsafe { vexSystemVersion() }.to_be_bytes();
     Version {
         major: version_bytes[0],
@@ -39,12 +39,6 @@ pub fn get_version() -> Version {
         build: version_bytes[2],
         patch: version_bytes[3],
     }
-}
-
-/// Returns the duration that the brain has been turned on.
-#[must_use]
-pub fn get_uptime() -> Duration {
-    Duration::from_micros(unsafe { vexSystemPowerupTimeGet() })
 }
 
 /// Whether or not the brain has a USB cable plugged in.

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -4,7 +4,7 @@
 
 use core::fmt;
 
-use vex_sdk::{vexSystemUsbStatus, vexSystemVersion};
+use vex_sdk::vexSystemVersion;
 
 /// A VexOS version
 #[derive(Clone, Copy, Debug)]
@@ -39,10 +39,4 @@ pub fn system_version() -> Version {
         build: version_bytes[2],
         patch: version_bytes[3],
     }
-}
-
-/// Whether or not the brain has a USB cable plugged in.
-#[must_use]
-pub fn has_usb() -> bool {
-    (unsafe { vexSystemUsbStatus() } == 1)
 }

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -6,8 +6,8 @@ use core::fmt;
 
 use vex_sdk::vexSystemVersion;
 
-/// A VexOS version
-#[derive(Clone, Copy, Debug)]
+/// A VEXos version
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Version {
     /// The major version
     pub major: u8,
@@ -15,16 +15,16 @@ pub struct Version {
     pub minor: u8,
     /// The build version
     pub build: u8,
-    /// The patch version
-    pub patch: u8,
+    /// The beta version
+    pub beta: u8,
 }
 
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{}.{}.{}-r{}",
-            self.major, self.minor, self.patch, self.patch
+            "{}.{}.{}-b{}",
+            self.major, self.minor, self.build, self.beta
         )
     }
 }
@@ -37,6 +37,6 @@ pub fn system_version() -> Version {
         major: version_bytes[0],
         minor: version_bytes[1],
         build: version_bytes[2],
-        patch: version_bytes[3],
+        beta: version_bytes[3],
     }
 }

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -1,0 +1,54 @@
+//! vexOS functions
+//!
+//! Module for retreiving information about vexOS
+
+use core::{fmt, time::Duration};
+
+use vex_sdk::{vexSystemPowerupTimeGet, vexSystemUsbStatus, vexSystemVersion};
+
+/// A VexOS version
+#[derive(Clone, Copy, Debug)]
+pub struct Version {
+    /// The major version
+    pub major: u8,
+    /// The minor version
+    pub minor: u8,
+    /// The build version
+    pub build: u8,
+    /// The patch version
+    pub patch: u8,
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}.{}.{}-r{}",
+            self.major, self.minor, self.patch, self.patch
+        )
+    }
+}
+
+/// Returns the current VexOS version.
+#[must_use]
+pub fn get_version() -> Version {
+    let version_bytes = unsafe { vexSystemVersion() }.to_be_bytes();
+    Version {
+        major: version_bytes[0],
+        minor: version_bytes[1],
+        build: version_bytes[2],
+        patch: version_bytes[3],
+    }
+}
+
+/// Returns the duration that the brain has been turned on.
+#[must_use]
+pub fn get_uptime() -> Duration {
+    Duration::from_micros(unsafe { vexSystemPowerupTimeGet() })
+}
+
+/// Whether or not the brain has a USB cable plugged in.
+#[must_use]
+pub fn has_usb() -> bool {
+    (unsafe { vexSystemUsbStatus() } == 1)
+}

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -29,7 +29,7 @@ impl fmt::Display for Version {
     }
 }
 
-/// Returns the current VexOS version.
+/// Returns the current VEXos version.
 #[must_use]
 pub fn system_version() -> Version {
     let version_bytes = unsafe { vexSystemVersion() }.to_be_bytes();

--- a/packages/vexide-core/src/time.rs
+++ b/packages/vexide-core/src/time.rs
@@ -8,6 +8,8 @@ use core::{
     time::Duration,
 };
 
+use vex_sdk::vexSystemPowerupTimeGet;
+
 /// Represents a timestamp on a monotonically nondecreasing clock relative to the
 /// start of the user program.
 ///
@@ -178,4 +180,10 @@ impl fmt::Debug for Instant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
+}
+
+/// Returns the duration that the brain has been turned on.
+#[must_use]
+pub fn uptime() -> Duration {
+    Duration::from_micros(unsafe { vexSystemPowerupTimeGet() })
 }

--- a/packages/vexide-startup/src/banner/mod.rs
+++ b/packages/vexide-startup/src/banner/mod.rs
@@ -6,13 +6,9 @@
 //!
 //! For a full list of premade themes and more theme documentation, see the [`themes`] module.
 
-use core::time::Duration;
-
 use themes::BannerTheme;
-use vex_sdk::{
-    vexBatteryCapacityGet, vexCompetitionStatus, vexSystemPowerupTimeGet, vexSystemVersion,
-};
-use vexide_core::println;
+use vex_sdk::vexBatteryCapacityGet;
+use vexide_core::{competition, os, println};
 
 pub mod themes;
 
@@ -21,13 +17,7 @@ pub mod themes;
 /// This function is used internally in the [`startup`](crate::startup) function to print the banner.
 #[inline]
 pub fn print(theme: BannerTheme) {
-    const DISABLED: u32 = 1 << 0;
-    const AUTONOMOUS: u32 = 1 << 1;
-
     const VEXIDE_VERSION: &str = "0.5.1";
-
-    let system_version = unsafe { vexSystemVersion() }.to_be_bytes();
-    let competition_status = unsafe { vexCompetitionStatus() };
 
     println!(
         "
@@ -51,19 +41,10 @@ pub fn print(theme: BannerTheme) {
         mk = theme.metadata_key,
         emoji = theme.emoji,
         vexide_version = VEXIDE_VERSION,
-        vexos_version = format_args!(
-            "{}.{}.{}-r{}",
-            system_version[0], system_version[1], system_version[2], system_version[3],
-        ),
+        vexos_version = os::get_version(),
         battery = unsafe { vexBatteryCapacityGet() } as u8,
         rust_version = compile_time::rustc_version_str!(),
-        competition_mode = if competition_status & DISABLED != 0 {
-            "Disabled"
-        } else if competition_status & AUTONOMOUS != 0 {
-            "Autonomous"
-        } else {
-            "Driver"
-        },
-        uptime = Duration::from_micros(unsafe { vexSystemPowerupTimeGet() }),
+        competition_mode = competition::mode(),
+        uptime = os::get_uptime(),
     );
 }

--- a/packages/vexide-startup/src/banner/mod.rs
+++ b/packages/vexide-startup/src/banner/mod.rs
@@ -8,7 +8,7 @@
 
 use themes::BannerTheme;
 use vex_sdk::vexBatteryCapacityGet;
-use vexide_core::{competition, os, println};
+use vexide_core::{competition, os, println, time};
 
 pub mod themes;
 
@@ -41,10 +41,10 @@ pub fn print(theme: BannerTheme) {
         mk = theme.metadata_key,
         emoji = theme.emoji,
         vexide_version = VEXIDE_VERSION,
-        vexos_version = os::get_version(),
+        vexos_version = os::system_version(),
         battery = unsafe { vexBatteryCapacityGet() } as u8,
         rust_version = compile_time::rustc_version_str!(),
         competition_mode = competition::mode(),
-        uptime = os::get_uptime(),
+        uptime = time::uptime(),
     );
 }

--- a/packages/vexide-startup/src/banner/mod.rs
+++ b/packages/vexide-startup/src/banner/mod.rs
@@ -25,7 +25,7 @@ pub fn print(theme: BannerTheme) {
 {lp2}  -#%%%%#-  {ls}:%-\x1B[0m{lp2}  -*%%%%#\x1B[0m       ---------------
 {lp3}    *%%%%#=   -#%%%%%+\x1B[0m         ╭─\x1B{mk}🔲 VEXos:\x1B[0m {vexos_version}
 {lp4}      *%%%%%+#%%%%%%%#=\x1B[0m        ├─\x1B{mk}🦀 Rust:\x1B[0m {rust_version}
-{lp5}        *%%%%%%%*-+%%%%%+\x1B[0m      ├─\x1B{mk}🏆 Mode:\x1B[0m {competition_mode}
+{lp5}        *%%%%%%%*-+%%%%%+\x1B[0m      ├─\x1B{mk}🏆 Mode:\x1B[0m {competition_mode:?}
 {lp6}          +%%%*:   .+###%#\x1B[0m     ├─\x1B{mk}🔋 Battery:\x1B[0m {battery}%
 {lp7}           .%:\x1B[0m                 ╰─\x1B{mk}⌚ Uptime:\x1B[0m {uptime:.2?}
 ",


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR adds functions to vexide for getting the vexOS version and uptime.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
-->
