### PR TITLE
fix: wait until status != 0 before imu calibrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Before releasing:
 - Fixed error handling for rangefinder port numbers. (#268)
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
-- Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275)
+- Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275, 279)
 - Recursive panics (panics that occur *within* `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Before releasing:
 - Fixed error handling for rangefinder port numbers. (#268)
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
-- Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275, 279)
+- Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275, #279)
 - Recursive panics (panics that occur *within* `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
 
 ### Changed

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -911,6 +911,12 @@ impl InertialStatus {
 /// Defines a waiting phase in [`InertialCalibrateFuture`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CalibrationPhase {
+    /// Waiting for IMU to report its status as something other than 0x0.
+    ///
+    /// This can happen at the start of the program where VEXos takes a bit to
+    /// give us the first sensor packet.
+    Status,
+
     /// Future is currently waiting for the IMU to report [`InertialStatus::CALIBRATING`], indicating
     /// that it has started calibration.
     Start,
@@ -955,6 +961,9 @@ impl core::future::Future for InertialCalibrateFuture<'_> {
             // 0xFF is returned when the sensor fails to report flags.
             if flags == InertialStatus::STATUS_ERROR {
                 return Poll::Ready(BadStatusSnafu.fail());
+            } else if flags == 0x0 {
+                this.state =
+                    InertialCalibrateFutureState::Waiting(Instant::now(), CalibrationPhase::Status);
             }
 
             flags
@@ -966,38 +975,33 @@ impl core::future::Future for InertialCalibrateFuture<'_> {
             // This only happens for one poll of the future (the first one). All future polls will
             // either be waiting for calibration to start or for calibration to end.
             InertialCalibrateFutureState::Calibrate => {
-                if let Err(err) = this.imu.validate_port() {
-                    // IMU isn't plugged in, no need to go any further.
-                    Poll::Ready(Err(err.into()))
+                // Check if the sensor was already calibrating before we recalibrate it ourselves.
+                //
+                // This can happen at the start of program execution or if the sensor loses then regains power.
+                // In those instances, VEXos will automatically start the calibration process without us asking.
+                // Calling [`vexDeviceImuReset`] while calibration is already happening has caused bugs in our
+                // testing, so we instead just want to wait until the calibration attempt has finished.
+                //
+                // See <https://github.com/vexide/vexide/issues/253> for more details.
+                if status.contains(InertialStatus::CALIBRATING) {
+                    // Sensor was already calibrating, so wait for that to finish.
+                    this.state = InertialCalibrateFutureState::Waiting(
+                        Instant::now(),
+                        CalibrationPhase::End,
+                    );
                 } else {
-                    // Check if the sensor was already calibrating before we recalibrate it ourselves.
-                    //
-                    // This can happen at the start of program execution or if the sensor loses then regains power.
-                    // In those instances, VEXos will automatically start the calibration process without us asking.
-                    // Calling [`vexDeviceImuReset`] while calibration is already happening has caused bugs in our
-                    // testing, so we instead just want to wait until the calibration attempt has finished.
-                    //
-                    // See <https://github.com/vexide/vexide/issues/253> for more details.
-                    if status.contains(InertialStatus::CALIBRATING) {
-                        // Sensor was already calibrating, so wait for that to finish.
-                        this.state = InertialCalibrateFutureState::Waiting(
-                            Instant::now(),
-                            CalibrationPhase::End,
-                        );
-                    } else {
-                        // Request that VEXos calibrate the IMU, and transition to pending state.
-                        unsafe { vexDeviceImuReset(device) }
+                    // Request that VEXos calibrate the IMU, and transition to pending state.
+                    unsafe { vexDeviceImuReset(device) }
 
-                        // Change to waiting for calibration to start.
-                        this.state = InertialCalibrateFutureState::Waiting(
-                            Instant::now(),
-                            CalibrationPhase::Start,
-                        );
-                    }
-
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
+                    // Change to waiting for calibration to start.
+                    this.state = InertialCalibrateFutureState::Waiting(
+                        Instant::now(),
+                        CalibrationPhase::Start,
+                    );
                 }
+
+                cx.waker().wake_by_ref();
+                Poll::Pending
             }
 
             // In this stage, we are either waiting for the calibration status flag to be set (CalibrationPhase::Start),
@@ -1006,7 +1010,9 @@ impl core::future::Future for InertialCalibrateFuture<'_> {
             InertialCalibrateFutureState::Waiting(timestamp, phase) => {
                 if timestamp.elapsed()
                     > match phase {
-                        CalibrationPhase::Start => InertialSensor::CALIBRATION_START_TIMEOUT,
+                        CalibrationPhase::Start | CalibrationPhase::Status => {
+                            InertialSensor::CALIBRATION_START_TIMEOUT
+                        }
                         CalibrationPhase::End => InertialSensor::CALIBRATION_END_TIMEOUT,
                     }
                 {
@@ -1025,8 +1031,8 @@ impl core::future::Future for InertialCalibrateFuture<'_> {
                         Instant::now(),
                         CalibrationPhase::End,
                     );
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
+                } else if !status.is_empty() && phase == CalibrationPhase::Status {
+                    this.state = InertialCalibrateFutureState::Calibrate;
                 } else if !status.contains(InertialStatus::CALIBRATING)
                     && phase == CalibrationPhase::End
                 {


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
When calibrating the inertial sensor, there will be a brief period at the start of the program where the sensor will report a 0x0 status code. This period can vary, and was over 20 milliseconds in my testing. When in this state, the sensor will refuse calibration and potentially miscalibrate. This PR adds a new waiting stage to `InertialCalibrateFuture` that waits until the status code is NOT 0.

## Additional Context
Hardware Tested :D