### PR TITLE
fix: disallow explicit construction of Stdin/Stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Before releasing:
 - The `InvalidId` and `InvalidIdInCode` `AiVisionError` variants have been removed. These errors now cause panics. (#266) (**Breaking Change**)
 - `VisionError::InvalidId` has been removed. Invalid signature IDs given to `VisionSensor` will now cause panics. (#266) (**Breaking Change**)
 - The `lock` functions on `Stdin` and `Stdout` are now async. (#265) (**Breaking Change**)
+- `Stdin` and `Stdout` instances can no longer be instantiated using struct initialization syntax. Prefer using `stdin()`/`stdout()`. (#281) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-core/src/io/stdio.rs
+++ b/packages/vexide-core/src/io/stdio.rs
@@ -55,6 +55,8 @@ impl Write for StdoutLock<'_> {
 }
 
 /// A handle to the serial output stream of this program.
+///
+/// An instance of this can be obtained using the [`stdout`] function.
 pub struct Stdout(());
 
 /// Constructs a handle to the serial output stream
@@ -123,10 +125,12 @@ impl io::Read for StdinLock<'_> {
 }
 
 /// A handle to the serial input stream of this program.
+///
+/// An instance of this can be obtained using the [`stdin`] function.
 pub struct Stdin(());
 
 impl Stdin {
-    /// The size of the internal VEXOs serial in buffer.
+    /// The size of the internal VEXos serial in buffer.
     pub const STDIN_BUFFER_SIZE: usize = 4096;
 
     /// Locks the stdin for reading.

--- a/packages/vexide-core/src/io/stdio.rs
+++ b/packages/vexide-core/src/io/stdio.rs
@@ -55,12 +55,12 @@ impl Write for StdoutLock<'_> {
 }
 
 /// A handle to the serial output stream of this program.
-pub struct Stdout;
+pub struct Stdout(());
 
 /// Constructs a handle to the serial output stream
 #[must_use]
 pub const fn stdout() -> Stdout {
-    Stdout
+    Stdout(())
 }
 
 impl Stdout {
@@ -123,7 +123,7 @@ impl io::Read for StdinLock<'_> {
 }
 
 /// A handle to the serial input stream of this program.
-pub struct Stdin;
+pub struct Stdin(());
 
 impl Stdin {
     /// The size of the internal VEXOs serial in buffer.
@@ -149,7 +149,7 @@ impl Stdin {
 /// Constructs a handle to the serial input stream.
 #[must_use]
 pub const fn stdin() -> Stdin {
-    Stdin
+    Stdin(())
 }
 
 #[macro_export]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Prevents instantiation of `Stdout`/`Stdin` instances outside of their respective functions. This ensures we can backwards-compatibly add potential private fields to said structs.

Bad:
```rs
let wow_stdout = io::Stdout;
```

Good:
```rs
let wow_stdout = io::stdout();
```

