### PR TITLE
fix: Checking for AdiExpander ports to match should be == not !=

### DIFF
--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -110,7 +110,7 @@ impl AdiEncoder {
 
         // Top and bottom must be plugged into the same ADI expander.
         ensure!(
-            top_port.expander_index() != bottom_port.expander_index(),
+            top_port.expander_index() == bottom_port.expander_index(),
             ExpanderPortMismatchSnafu {
                 top_port_expander: top_port.expander_number(),
                 bottom_port_expander: bottom_port.expander_number()


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
When trying to create a new AdiEncoder the program will panic and give ExpanderPortMismatch regardless if there is an Adi Expander or the encoder is plugged into valid ports. When it checks to ensure the ports are from the same Adi Expander a != is used instead of ==.

<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
