### PR TITLE
chore: move cargo-v5 metadata to examples package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "examples"
 edition = "2021"
 version = "0.0.1"
 
+[package.metadata.v5]
+upload-strategy = "differential"
+slot = 1
+icon = "cool-x"
+compress = true
+
 [dev-dependencies]
 vexide = { path = "packages/vexide" }
 

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -16,12 +16,6 @@ authors = [
 ]
 rust-version = "1.75.0"
 
-[package.metadata.v5]
-upload-strategy = "differential"
-slot = 1
-icon = "cool-x"
-compress = true
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
`cargo-v5` will only take metadata from the current package in the next release rather than finding the first package with metadata. This PR moves the examples metadata to the correct `Cargo.toml`. 