### PR TITLE
refactor(devices): update battery_capacity to return f64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Before releasing:
 
 ### Changed
 
+- `Controller::battery_capacity` now returns a float from 0.0 to 1.0 instead of an i32. (#286) (**Breaking Change**)
+
 ### Removed
 
 ### New Contributors

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -842,7 +842,8 @@ impl Controller {
         unsafe { vexControllerConnectionStatusGet(self.id.into()) }.into()
     }
 
-    /// Returns the controller's battery capacity.
+    /// Returns the controller's battery capacity as an f64 in the interval
+    /// [0.0, 1.0].
     ///
     /// # Errors
     ///
@@ -859,13 +860,15 @@ impl Controller {
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
     ///     let controller = peripherals.primary_controller;
-    ///     println!("Controller battery capacity: {}", controller.battery_capacity().unwrap_or(0));
+    ///     println!("Controller battery capacity: {}", controller.battery_capacity().unwrap_or(0.0));
     /// }
     /// ```
-    pub fn battery_capacity(&self) -> Result<i32, ControllerError> {
+    pub fn battery_capacity(&self) -> Result<f64, ControllerError> {
         validate_connection(self.id)?;
 
-        Ok(unsafe { vexControllerGet(self.id.into(), V5_ControllerIndex::BatteryCapacity) })
+        Ok(f64::from(unsafe {
+            vexControllerGet(self.id.into(), V5_ControllerIndex::BatteryCapacity)
+        }) / 100.0)
     }
 
     /// Returns the controller's battery level.


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

The `vexide-devices` `Battery` API returns a float from 0.0 to 1.0 indicating the robot battery's value. For consistancy, this PR updates the controller getter to act the same way.

## Additional Context

- Breaking change
- Needs hardware testing
