### PR TITLE
feat: :sparkles: Implement PartialOrd/Ord for Version

### DIFF
--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -7,7 +7,7 @@ use core::fmt;
 use vex_sdk::vexSystemVersion;
 
 /// A VexOS version
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct Version {
     /// The major version
     pub major: u8,


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR implements PartialOrd/Ord for Version, allowing VEXos versions to be compared with `>`/`<`. Closes #287 

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
