### PR TITLE
refactor: Asynchronous `SerialPort` opening, infallible VEXlink opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,21 @@ Before releasing:
 
 ### New Contributors
 
+## [0.6.1]
+
+### Added
+
+### Fixed
+
+- Fixed docs.rs build failures.
+- Fixed outdated dependencies of vexide-graphics.
+
+### Changed
+
+### Removed
+
+### New Contributors
+
 ## [0.6.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,28 +34,20 @@ Before releasing:
 
 ### Added
 
+- Implemented `PartialOrd` for `Version`. (#288)
+- Added `RadioLink::INTERNAL_BUFFER_SIZE` constant. (#293)
+
 ### Fixed
 
 ### Changed
 
 - `Controller::battery_capacity` now returns a float from 0.0 to 1.0 instead of an i32. (#286) (**Breaking Change**)
+- `RadioLink::open` now panics if `id` is not a valid `CStr` rather than returning a `Result`. (#293) (**Breaking Change**)
+- `SerialPort::open` now returns a `Future` that must be awaited before opening the port. (#293) (**Breaking Change**)
 
 ### Removed
 
-### New Contributors
-
-## [0.6.1]
-
-### Added
-
-### Fixed
-
-- Fixed docs.rs build failures.
-- Fixed outdated dependencies of vexide-graphics.
-
-### Changed
-
-### Removed
+- Removed `SerialError::Port`. `SerialPort` methods can no longer return `PortError`. (#293) (**Breaking Change**)
 
 ### New Contributors
 
@@ -360,7 +352,7 @@ Before releasing:
 
 ### New Contributors
 
-[unreleased]: https://github.com/vexide/vexide/compare/v0.6.1...HEAD
+[unreleased]: https://github.com/vexide/vexide/compare/v0.6.0...HEAD
 [0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...v0.2.0
 [0.2.1]: https://github.com/vexide/vexide/compare/v0.2.0...v0.2.1
 [0.3.0]: https://github.com/vexide/vexide/compare/v0.2.1...v0.3.0
@@ -370,4 +362,3 @@ Before releasing:
 [0.5.0]: https://github.com/vexide/vexide/compare/v0.4.2...v0.5.0
 [0.5.1]: https://github.com/vexide/vexide/compare/v0.5.0...v0.5.1
 [0.6.0]: https://github.com/vexide/vexide/compare/v0.5.1...v0.6.0
-[0.6.1]: https://github.com/vexide/vexide/compare/v0.6.0...v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,7 +352,7 @@ Before releasing:
 
 ### New Contributors
 
-[unreleased]: https://github.com/vexide/vexide/compare/v0.6.0...HEAD
+[unreleased]: https://github.com/vexide/vexide/compare/v0.6.1...HEAD
 [0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...v0.2.0
 [0.2.1]: https://github.com/vexide/vexide/compare/v0.2.0...v0.2.1
 [0.3.0]: https://github.com/vexide/vexide/compare/v0.2.1...v0.3.0
@@ -362,3 +362,4 @@ Before releasing:
 [0.5.0]: https://github.com/vexide/vexide/compare/v0.4.2...v0.5.0
 [0.5.1]: https://github.com/vexide/vexide/compare/v0.5.0...v0.5.1
 [0.6.0]: https://github.com/vexide/vexide/compare/v0.5.1...v0.6.0
+[0.6.1]: https://github.com/vexide/vexide/compare/v0.6.0...v0.6.1

--- a/examples/smart_devices.rs
+++ b/examples/smart_devices.rs
@@ -23,8 +23,7 @@ async fn main(peripherals: Peripherals) {
         peripherals.port_15,
         "example",
         vexide::devices::smart::link::LinkType::Manager,
-    )
-    .unwrap();
+    );
     // Send a message over vexlink.
     // We dont have to flush because VEXOs does that immediately.
     link.write(b"Hello, world!").unwrap();

--- a/examples/vexlink_manager.rs
+++ b/examples/vexlink_manager.rs
@@ -10,7 +10,7 @@ use vexide::prelude::*;
 
 #[vexide::main]
 async fn main(peripherals: Peripherals) {
-    let mut link = RadioLink::open(peripherals.port_21, "643A", LinkType::Manager).unwrap();
+    let mut link = RadioLink::open(peripherals.port_21, "643A", LinkType::Manager);
 
     println!("[MANAGER] Waiting for worker radio...");
 

--- a/examples/vexlink_worker.rs
+++ b/examples/vexlink_worker.rs
@@ -10,7 +10,7 @@ use vexide::prelude::*;
 
 #[vexide::main]
 async fn main(peripherals: Peripherals) {
-    let mut link = RadioLink::open(peripherals.port_21, "643A", LinkType::Worker).unwrap();
+    let mut link = RadioLink::open(peripherals.port_21, "643A", LinkType::Worker);
 
     println!("[WORKER] Waiting for manager radio...");
 

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -50,6 +50,9 @@ unsafe impl Send for RadioLink {}
 unsafe impl Sync for RadioLink {}
 
 impl RadioLink {
+    /// The length of the link's FIFO input and output buffers.
+    pub const INTERNAL_BUFFER_SIZE: usize = 512;
+
     /// Opens a radio link from a VEXNet radio plugged into a Smart Port. Once
     /// opened, other VEXNet functionality such as controller tethering on this
     /// specific radio will be disabled.

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -66,7 +66,7 @@ impl RadioLink {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
+    ///     let link = RadioLink::open(port_1, "643A", LinkType::Manager);
     /// }
     /// ```
     #[must_use]
@@ -105,7 +105,7 @@ impl RadioLink {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
+    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager);
     ///
     ///     let mut buffer = vec![0; 2048];
     ///
@@ -135,7 +135,7 @@ impl RadioLink {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
+    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager);
     ///
     ///     // Write a byte if there's free space in the buffer.
     ///     if link.available_write_bytes().is_ok_and(|available| available > 0) {
@@ -159,7 +159,7 @@ impl RadioLink {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
+    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager);
     ///
     ///     // Write a byte if we are connected to another radio.
     ///     if link.is_linked() == Ok(true) {
@@ -193,7 +193,7 @@ impl io::Read for RadioLink {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
+    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager);
     ///
     ///     let mut buffer = vec![0; 2048];
     ///
@@ -239,7 +239,7 @@ impl io::Write for RadioLink {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager).unwrap();
+    ///     let mut link = RadioLink::open(port_1, "643A", LinkType::Manager);
     ///
     ///     _ = link.write(b"yo");
     /// }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR addresses the concerns brought up in #277 by adding a dedicated future for `SerialPort::open` to wait until VEXos properly configures the port's uartlite for generic serial exchange. This is usually in the range of 10mS if the port wasn't previously configured in a past program run. Because we can now guarantee that the port will always be configured that way for the duration of the program, we can also remove `V5_DeviceType` validation from most of the APIs.

Additionally, i've made `RadioLink::open` panic rather than returning an error if the user passes an invalid ID containing a NUL. This is in compliance with #266. Documentation has been updated accordingly.

NOTE: `RadioLink::open` seemingly does not need a future, as it will immediately adjust the `V5_DeviceType` to `kDeviceTypeGenericSerial` immediately after calling `vexDeviceGenericRadioConnection`.

## Additional Context
I have hardware tested this to the extent of which I am capable, but I don't have any (functioning) custom hardware to verify that the other end is properly getting RS-485 communication from the brain (@SizzinSeal was having trouble on PROS with this even after delaying before doing tx/rx after opening the port). Either way, this PR should improve things regardless.