### PR TITLE
fix: close files on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Before releasing:
 
 ### Fixed
 
+- Added a missing `Drop` implementation to `File` that will close and flush the file descriptor. (#295)
+
 ### Changed
 
 - `Controller::battery_capacity` now returns a float from 0.0 to 1.0 instead of an i32. (#286) (**Breaking Change**)

--- a/examples/fs.rs
+++ b/examples/fs.rs
@@ -10,7 +10,8 @@ extern crate alloc;
 async fn main(_peripherals: Peripherals) {
     let mut file = vexide::core::fs::File::create("foo").unwrap();
     file.write_all(b"bar").unwrap();
-    file.flush().unwrap();
+    drop(file);
+
     let mut file = vexide::core::fs::File::open("foo").unwrap();
     let mut buf = [0; 3];
     file.read(&mut buf).unwrap();

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -20,7 +20,7 @@ use alloc::{ffi::CString, string::String, vec::Vec};
 
 use no_std_io::io::{Read, Seek, Write};
 
-use crate::{io, path::Path, println};
+use crate::{io, path::Path};
 
 mod fs_str;
 
@@ -825,7 +825,7 @@ impl Seek for File {
 impl Drop for File {
     fn drop(&mut self) {
         // We do not need to sync because vexFileClose will do that for us
-        unsafe  {
+        unsafe {
             vex_sdk::vexFileClose(self.fd);
         }
     }

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -20,7 +20,7 @@ use alloc::{ffi::CString, string::String, vec::Vec};
 
 use no_std_io::io::{Read, Seek, Write};
 
-use crate::{io, path::Path};
+use crate::{io, path::Path, println};
 
 mod fs_str;
 
@@ -819,6 +819,15 @@ impl Seek for File {
         }
 
         self.tell()
+    }
+}
+
+impl Drop for File {
+    fn drop(&mut self) {
+        // We do not need to sync because vexFileClose will do that for us
+        unsafe  {
+            vex_sdk::vexFileClose(self.fd);
+        }
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR adds a Drop implementation to File which will close the files FD. Closing the FD also automatically flushes it.
Closes #294 
## Additional Context
- I have tested these changes on a VEX V5 Brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
