### PR TITLE
fix: implement naive print macro flushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Before releasing:
 ### Fixed
 
 - Added a missing `Drop` implementation to `File` that will close and flush the file descriptor. (#295)
+- Fixed an issue where printing large amounts of data to `Stdout` without ticking the executor would immediately exit the program. (#296)
+- `StdoutRaw::flush` now flushes the outgoing serial buffer (#296)
 
 ### Changed
 

--- a/packages/vexide-core/src/allocator.rs
+++ b/packages/vexide-core/src/allocator.rs
@@ -1,6 +1,6 @@
 //! VEXos heap allocator implemented with the `talc` crate.
 //!
-//! [`init_heap`] must be called before any heap allocations are made.
+//! [`claim`] must be called before any heap allocations are made.
 //! This is done automatically in the `vex-startup` crate,
 //! so you should not need to call it yourself unless you are writing your own startup implementation.
 

--- a/packages/vexide-core/src/fs/fs_str.rs
+++ b/packages/vexide-core/src/fs/fs_str.rs
@@ -1,6 +1,7 @@
 use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 use core::{fmt::Debug, mem::ManuallyDrop, ptr};
 
+/// A type that allows safely displaying [`FsStr`]s that may contain non-UTF-8 data.
 pub struct Display<'a> {
     fs_str: &'a FsStr,
 }
@@ -382,8 +383,8 @@ impl From<String> for FsString {
 }
 
 impl<T: ?Sized + AsRef<FsStr>> From<&T> for FsString {
-    /// Copies any value implementing <code>[AsRef]&lt;[OsStr]&gt;</code>
-    /// into a newly allocated [`OsString`].
+    /// Copies any value implementing <code>[AsRef]&lt;[FsStr]&gt;</code>
+    /// into a newly allocated [`FsString`].
     fn from(s: &T) -> FsString {
         s.as_ref().to_fs_string()
     }

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 
 mod fs_str;
 
-pub use fs_str::{FsStr, FsString};
+pub use fs_str::{FsStr, FsString, Display};
 
 /// Options and flags which can be used to configure how a file is opened.
 ///
@@ -926,10 +926,6 @@ impl DirEntry {
     /// - `./foo`
     /// - `../foo`
     /// - `/some/global/foo`
-    ///
-    /// # Examples
-    ///
-    /// ``````
     #[must_use]
     pub fn file_name(&self) -> FsString {
         self.name.clone()

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 
 mod fs_str;
 
-pub use fs_str::{FsStr, FsString, Display};
+pub use fs_str::{Display, FsStr, FsString};
 
 /// Options and flags which can be used to configure how a file is opened.
 ///

--- a/packages/vexide-core/src/io/mod.rs
+++ b/packages/vexide-core/src/io/mod.rs
@@ -7,5 +7,6 @@ mod stdio;
 #[doc(inline)]
 pub use no_std_io::io::*;
 pub(crate) use stdio::STDIO_CHANNEL;
-pub use stdio::{dbg, print, println, stdin, stdout, Stdin, StdinLock, Stdout, StdoutLock};
-pub use stdio::__print;
+pub use stdio::{
+    dbg, print, println, stdin, stdout, Stdin, StdinLock, Stdout, StdoutLock, __print,
+};

--- a/packages/vexide-core/src/io/mod.rs
+++ b/packages/vexide-core/src/io/mod.rs
@@ -8,3 +8,4 @@ mod stdio;
 pub use no_std_io::io::*;
 pub(crate) use stdio::STDIO_CHANNEL;
 pub use stdio::{dbg, print, println, stdin, stdout, Stdin, StdinLock, Stdout, StdoutLock};
+pub use stdio::__print;

--- a/packages/vexide-devices/src/adi/gyroscope.rs
+++ b/packages/vexide-devices/src/adi/gyroscope.rs
@@ -5,7 +5,7 @@
 //!
 //! # Hardware overview
 //!
-//! The ADI gyroscope is a (LY3100ALH MEMS motion sensor)[https://content.vexrobotics.com/docs/276-2333-Datasheet-1011.pdf].
+//! The ADI gyroscope is a (LY3100ALH MEMS motion sensor)[<https://content.vexrobotics.com/docs/276-2333-Datasheet-1011.pdf>].
 //! This means that it can measure the rate of rotation up to ±1000 degrees per second.
 //! VEXos only provides the calculated yaw rotation of the robot.
 //!

--- a/packages/vexide-devices/src/adi/mod.rs
+++ b/packages/vexide-devices/src/adi/mod.rs
@@ -203,7 +203,7 @@ pub trait AdiDevice<const N: usize> {
     /// Ports are numbered starting from 1.
     fn port_numbers(&self) -> [u8; N];
 
-    /// Returns the port number of the [`SmartPort`] this device's expander is connected to,
+    /// Returns the port number of the [`SmartPort`](crate::smart::SmartPort) this device's expander is connected to,
     /// or [`None`] if the device is plugged into an onboard ADI port.
     ///
     /// Ports are numbered starting from 1.

--- a/packages/vexide-devices/src/adi/servo.rs
+++ b/packages/vexide-devices/src/adi/servo.rs
@@ -4,7 +4,7 @@
 //!
 //! # Hardware Overview
 //!
-//! Servos are similar in both appearance and function to [`AdiMotor`]s, with the
+//! Servos are similar in both appearance and function to [`AdiMotor`](super::motor::AdiMotor)s, with the
 //! caveat that they are designed to hold a specific *angle* rather than a continious
 //! *speed*. In other words:
 //!

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -924,10 +924,12 @@ impl Controller {
     ///
     /// # Errors
     ///
-    /// - A [`ControllerError::Nul`] error if a NUL (0x00) character was
-    ///   found anywhere in the specified text.
     /// - A [`ControllerError::Offline`] error is returned if the controller is
     ///   not connected.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if a NUL (0x00) character was found anywhere in the specified text.
     ///
     /// # Examples
     ///
@@ -959,10 +961,12 @@ impl Controller {
     ///
     /// # Errors
     ///
-    /// - A [`ControllerError::Nul`] error if a NUL (0x00) character was
-    ///   found anywhere in the specified text.
     /// - A [`ControllerError::Offline`] error is returned if the controller is
     ///   not connected.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if a NUL (0x00) character was found anywhere in the specified text.
     ///
     /// # Examples
     ///

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -343,7 +343,7 @@ impl FontSize {
     ///
     /// # Errors
     ///
-    /// - [`NegativeFontSizeError`] if the given size is negative.
+    /// - [`InvalidFontSizeError`] if the given size is negative.
     pub fn from_float(size: f32) -> Result<Self, InvalidFontSizeError> {
         ensure!(
             size.is_finite() && !size.is_sign_negative(),


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This PR makes the printing macros flush the serial buffer if it would be overflowed by the write.
I also fixed some docs issues along the way.

TODO:

- [x] figure out how to handle prints over 2048 bytes.
- [x] changelog 

## Additional Context
- I have tested these changes on a VEX V5 Brain.
<!--
Move all applicable items out of the comment:

- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
