### PR TITLE
fix: `AdiEncoder` port misconfiguration case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Before releasing:
 - Added a missing `Drop` implementation to `File` that will close and flush the file descriptor. (#295)
 - Fixed an issue where printing large amounts of data to `Stdout` without ticking the executor would immediately exit the program. (#296)
 - `StdoutRaw::flush` now flushes the outgoing serial buffer (#296)
+- Fixed an issue with `AdiEncoder` potentially configuring the wrong port. (#301)
 
 ### Changed
 

--- a/packages/vexide-devices/src/adi/encoder.rs
+++ b/packages/vexide-devices/src/adi/encoder.rs
@@ -121,7 +121,11 @@ impl AdiEncoder {
             adi_port_name(bottom_number),
         );
 
-        top_port.configure(AdiDeviceType::Encoder);
+        if top_number < bottom_number {
+            top_port.configure(AdiDeviceType::Encoder);
+        } else {
+            bottom_port.configure(AdiDeviceType::Encoder);
+        }
 
         Self {
             top_port,
@@ -160,7 +164,6 @@ impl AdiEncoder {
     /// ```
     pub fn position(&self) -> Result<Position, PortError> {
         self.top_port.validate_expander()?;
-        self.top_port.configure(self.device_type());
 
         Ok(Position::from_ticks(
             unsafe {


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
See https://github.com/purduesigbots/pros/blob/develop-pros-4/src/devices/vdml_ext_adi.c#L113

`AdiRangeFinder` should be unaffected due to us already asserting the output port being below the input.