### PR TITLE
refactor: flatten top-level modules in `vexide`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,16 @@ Before releasing:
 - `Controller::battery_capacity` now returns a float from 0.0 to 1.0 instead of an i32. (#286) (**Breaking Change**)
 - `RadioLink::open` now panics if `id` is not a valid `CStr` rather than returning a `Result`. (#293) (**Breaking Change**)
 - `SerialPort::open` now returns a `Future` that must be awaited before opening the port. (#293) (**Breaking Change**)
+- Renamed `vexide::async_runtime` module to `vexide::runtime`. (#305) (**Breaking Change**)
+- The `vexide::async_runtime::task` module is now a top-level `vexide::task` module. (#305) (**Breaking Change**)
+- Merged `vexide::core::time` and `vexide::async_runtime::time` into a single `vexide::time` module. (#305) (**Breaking Change**)
+- Moved `vexide::core` modules to the top-level `vexide` crate. For example, `vexide::core::fs` is now `vexide::fs`. (#305) (**Breaking Change**)
 
 ### Removed
 
 - Removed `SerialError::Port`. `SerialPort` methods can no longer return `PortError`. (#293) (**Breaking Change**)
+- Removed the `vexide::macro` module. (#305) (**Breaking Change**)
+- Removed the `vexide::core` module in favor of top-level modules of the `vexide` crate. (#305) (**Breaking Change**)
 
 ### New Contributors
 

--- a/examples/fs.rs
+++ b/examples/fs.rs
@@ -5,7 +5,7 @@ use alloc::string::String;
 use core::time::Duration;
 
 use vexide::{
-    core::fs::{metadata, read_dir, File},
+    fs::{metadata, read_dir, File},
     prelude::*,
 };
 extern crate alloc;

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -4,8 +4,8 @@
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
 use vexide::{
-    sync::{Barrier, Condvar, LazyLock, Mutex, RwLock},
     prelude::*,
+    sync::{Barrier, Condvar, LazyLock, Mutex, RwLock},
 };
 
 extern crate alloc;

--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -4,7 +4,7 @@
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
 use vexide::{
-    core::sync::{Barrier, Condvar, LazyLock, Mutex, RwLock},
+    sync::{Barrier, Condvar, LazyLock, Mutex, RwLock},
     prelude::*,
 };
 

--- a/packages/vexide-core/src/allocator.rs
+++ b/packages/vexide-core/src/allocator.rs
@@ -1,4 +1,6 @@
-//! VEXos heap allocator implemented with the `talc` crate.
+//! Global heap allocator.
+//!
+//! This module provide's vexide's `#[global_allocator]`, which is implemented using the `talc` crate.
 //!
 //! [`claim`] must be called before any heap allocations are made.
 //! This is done automatically in the `vex-startup` crate,

--- a/packages/vexide-core/src/backtrace.rs
+++ b/packages/vexide-core/src/backtrace.rs
@@ -1,4 +1,4 @@
-//! Support for capturing stack backtraces
+//! Support for capturing stack backtraces.
 //!
 //! This module contains the support for capturing a stack backtrace through
 //! the [`Backtrace`] type. Backtraces are helpful to attach to errors,

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -1,4 +1,4 @@
-//! Utilities for getting competition control state.
+//! Competition control and state.
 
 extern crate alloc;
 

--- a/packages/vexide-core/src/float/mod.rs
+++ b/packages/vexide-core/src/float/mod.rs
@@ -1,4 +1,4 @@
-//! Floating Point Numbers
+//! Floating point numbers.
 //!
 //! This module provides implementations of math functions of floating point
 //! primitive types (`f32`, `f64`).

--- a/packages/vexide-core/src/fs/fs_str.rs
+++ b/packages/vexide-core/src/fs/fs_str.rs
@@ -38,7 +38,7 @@ impl FsStr {
     /// # Examples
     ///
     /// ```
-    /// use vexide::core::fs::FsStr;
+    /// use vexide::fs::FsStr;
     ///
     /// let fs_str = FsStr::new("foo");
     /// ```

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -176,7 +176,6 @@ impl OpenOptions {
     ///
     /// [`write()`]: Write::write "io::Write::write"
     /// [`flush()`]: Write::flush "io::Write::flush"
-    /// [stream_position]: Seek::stream_position "io::Seek::stream_position"
     ///
     /// # Examples
     ///
@@ -374,7 +373,6 @@ impl FileType {
     /// only one of these tests may pass.
     ///
     /// [`is_file`]: FileType::is_file
-    /// [`is_symlink`]: FileType::is_symlink
     ///
     /// # Examples
     ///
@@ -492,7 +490,6 @@ impl Metadata {
     /// only one of these tests may pass.
     ///
     /// [`is_file`]: FileType::is_file
-    /// [`is_symlink`]: FileType::is_symlink
     ///
     /// # Examples
     ///

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -54,7 +54,7 @@ pub use fs_str::{Display, FsStr, FsString};
 /// Opening a file to read:
 ///
 /// ```no_run
-/// use vexide::core::fs::OpenOptions;
+/// use vexide::fs::OpenOptions;
 ///
 /// let file = OpenOptions::new().read(true).open("foo.txt");
 /// ```
@@ -62,7 +62,7 @@ pub use fs_str::{Display, FsStr, FsString};
 /// Opening a file for writing, as well as creating it if it doesn't exist:
 ///
 /// ```no_run
-/// use vexide::core::fs::OpenOptions;
+/// use vexide::fs::OpenOptions;
 ///
 /// let file = OpenOptions::new()
 ///             .write(true)
@@ -87,7 +87,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let mut options = OpenOptions::new();
     /// let file = options.read(true).open("foo.txt");
@@ -112,7 +112,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().read(true).open("foo.txt");
     /// ```
@@ -132,7 +132,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().write(true).open("foo.txt");
     /// ```
@@ -180,7 +180,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().append(true).open("foo.txt");
     /// ```
@@ -199,7 +199,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().write(true).truncate(true).open("foo.txt");
     /// ```
@@ -219,7 +219,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().write(true).create(true).open("foo.txt");
     /// ```
@@ -248,7 +248,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().write(true)
     ///                              .create_new(true)
@@ -284,7 +284,7 @@ impl OpenOptions {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs::OpenOptions;
+    /// use vexide::fs::OpenOptions;
     ///
     /// let file = OpenOptions::new().read(true).open("foo.txt");
     /// ```
@@ -377,7 +377,7 @@ impl FileType {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs;
+    /// use vexide::fs;
     ///
     /// let metadata = fs::metadata("foo.txt")?;
     /// let file_type = metadata.file_type();
@@ -402,7 +402,7 @@ impl FileType {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs;
+    /// use vexide::fs;
     ///
     /// let metadata = fs::metadata("foo.txt")?;
     /// let file_type = metadata.file_type();
@@ -472,7 +472,7 @@ impl Metadata {
     ///
     /// ```no_run
     /// fn main() -> std::io::Result<()> {
-    ///     use vexide::core::fs;
+    ///     use vexide::fs;
     ///
     ///     let metadata = fs::metadata("foo.txt")?;
     ///
@@ -494,7 +494,7 @@ impl Metadata {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs;
+    /// use vexide::fs;
     ///
     /// let metadata = fs::metadata("foo.txt")?;
     ///
@@ -518,7 +518,7 @@ impl Metadata {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs;
+    /// use vexide::fs;
     ///
     /// let metadata = fs::metadata("foo.txt")?;
     ///
@@ -534,7 +534,7 @@ impl Metadata {
     /// # Examples
     ///
     /// ```no_run
-    /// use vexide::core::fs;
+    /// use vexide::fs;
     ///
     /// let metadata = fs::metadata("foo.txt")?;
     ///
@@ -973,7 +973,7 @@ impl Iterator for ReadDir {
 /// # Examples
 ///
 /// ```
-/// for entry in vexide::core::fs::read_dir("somefolder") {
+/// for entry in vexide::fs::read_dir("somefolder") {
 ///     println!("{:?}", entry.path);
 /// }
 /// ```
@@ -1159,7 +1159,7 @@ pub fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
 /// # Examples
 ///
 /// ```
-/// use vexide::core::fs::*;
+/// use vexide::fs::*;
 ///
 /// assert!(exists("existent.txt"));
 /// assert!(!exists("nonexistent.txt"));

--- a/packages/vexide-core/src/io/mod.rs
+++ b/packages/vexide-core/src/io/mod.rs
@@ -1,4 +1,4 @@
-//! Serial input and output functionality.
+//! Traits, helpers, and type definitions for core I/O functionality.
 //!
 //! This module aims to provide a very similar API to the Rust standard library's `std::io` module.
 

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -1,4 +1,4 @@
-//! VEXos functions
+//! VEXos-related functionality.
 //!
 //! This module provides utilities for for interacting and retrieving
 //! information from VEXos.

--- a/packages/vexide-core/src/path.rs
+++ b/packages/vexide-core/src/path.rs
@@ -25,7 +25,7 @@ impl Path {
     /// # Examples
     ///
     /// ```
-    /// use vexide::core::path::Path;
+    /// use vexide::path::Path;
     ///
     /// Path::new("foo.txt");
     /// ```
@@ -34,7 +34,7 @@ impl Path {
     ///
     /// ```
     /// use alloc::string::String;
-    /// use vexide::core::path::Path;
+    /// use vexide::path::Path;
     ///
     /// let string = String::from("foo.txt");
     /// let from_string = Path::new(&string);
@@ -50,7 +50,7 @@ impl Path {
     /// # Examples
     ///
     /// ```
-    /// use vexide::core::{path::Path, fs::FsStr};
+    /// use vexide::{path::Path, fs::FsStr};
     ///
     /// let fs_str = Path::new("foo.txt").as_os_str();
     /// assert_eq!(os_str, FsStr::new("foo.txt"));

--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -1,5 +1,4 @@
-//! Functions for modifying the state of the current
-//! user program.
+//! User program state.
 
 use core::{convert::Infallible, fmt::Debug, time::Duration};
 

--- a/packages/vexide-core/src/sync/mod.rs
+++ b/packages/vexide-core/src/sync/mod.rs
@@ -12,6 +12,9 @@ mod rwlock;
 pub use barrier::{Barrier, BarrierWaitFuture};
 pub use condvar::{Condvar, CondvarWaitFuture};
 pub use lazy::LazyLock;
-pub use mutex::{Mutex, MutexGuard, MutexLockFuture, RawMutex};
+pub use mutex::{Mutex, MutexGuard, MutexLockFuture};
 pub use once::{Once, OnceLock};
 pub use rwlock::{RwLock, RwLockReadFuture, RwLockReadGuard, RwLockWriteFuture, RwLockWriteGuard};
+
+// Used for synchronizing stdio
+pub(crate) use mutex::RawMutex;

--- a/packages/vexide-core/src/sync/mod.rs
+++ b/packages/vexide-core/src/sync/mod.rs
@@ -12,9 +12,8 @@ mod rwlock;
 pub use barrier::{Barrier, BarrierWaitFuture};
 pub use condvar::{Condvar, CondvarWaitFuture};
 pub use lazy::LazyLock;
+// Used for synchronizing stdio
+pub(crate) use mutex::RawMutex;
 pub use mutex::{Mutex, MutexGuard, MutexLockFuture};
 pub use once::{Once, OnceLock};
 pub use rwlock::{RwLock, RwLockReadFuture, RwLockReadGuard, RwLockWriteFuture, RwLockWriteGuard};
-
-// Used for synchronizing stdio
-pub(crate) use mutex::RawMutex;

--- a/packages/vexide-core/src/sync/mutex.rs
+++ b/packages/vexide-core/src/sync/mutex.rs
@@ -26,7 +26,7 @@ impl MutexState {
 }
 
 /// A raw, synchronous, spinning mutex type.
-pub struct RawMutex {
+pub(crate) struct RawMutex {
     state: MutexState,
 }
 impl RawMutex {
@@ -125,7 +125,7 @@ impl<T: ?Sized> Mutex<T> {
     }
 
     /// Gets a mutable reference to the inner data.
-    pub fn get_mut(&mut self) -> &mut T {
+    pub const fn get_mut(&mut self) -> &mut T {
         self.data.get_mut()
     }
 }

--- a/packages/vexide-core/src/time.rs
+++ b/packages/vexide-core/src/time.rs
@@ -24,7 +24,7 @@ impl Instant {
     /// # Examples
     ///
     /// ```
-    /// use vexide::core::time::Instant;
+    /// use vexide::time::Instant;
     ///
     /// let now = Instant::now();
     /// ```
@@ -40,7 +40,7 @@ impl Instant {
     ///
     /// ```no_run
     /// use core::time::Duration;
-    /// use vexide::core::time::Instant;
+    /// use vexide::time::Instant;
     ///
     /// let now = Instant::now();
     /// sleep(Duration::new(1, 0)).await;
@@ -60,7 +60,7 @@ impl Instant {
     ///
     /// ```no_run
     /// use core::time::Duration;
-    /// use vexide::core::time::Instant;
+    /// use vexide::time::Instant;
     ///
     /// let now = Instant::now();
     /// sleep(Duration::new(1, 0)).await;
@@ -84,7 +84,7 @@ impl Instant {
     ///
     /// ```no_run
     /// use core::time::Duration;
-    /// use vexide::core::time::Instant;
+    /// use vexide::time::Instant;
     ///
     /// let now = Instant::now();
     /// sleep(Duration::new(1, 0)).await;
@@ -103,7 +103,7 @@ impl Instant {
     ///
     /// ```no_run
     /// use core::time::Duration;
-    /// use vexide::core::time::Instant;
+    /// use vexide::time::Instant;
     ///
     /// let instant = Instant::now();
     /// let three_secs = Duration::from_secs(3);

--- a/packages/vexide-devices/src/adi/gyroscope.rs
+++ b/packages/vexide-devices/src/adi/gyroscope.rs
@@ -106,7 +106,7 @@ impl AdiGyroscope {
     ///     let gyro = AdiGyroscope::new(peripherals.adi_port_a());
     ///     // Do something with the gyroscope
     ///     _ = gyro.calibrate(Duration::from_secs(2)).await;
-    ///     println!("{:?}, gyro.yaw());
+    ///     println!("{:?}", gyro.yaw());
     /// }
     /// ```
     #[must_use]

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -157,10 +157,6 @@ impl SerialPort {
     ///     }
     /// }
     /// ```
-    ///
-    /// # Errors
-    ///
-    /// - A [`SerialError::Port`] error is returned if a generic serial device is not currently connected to the Smart Port.
     pub fn read_byte(&mut self) -> Option<u8> {
         let byte = unsafe { vexDeviceGenericSerialReadChar(self.device) };
 

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -90,11 +90,11 @@ fn make_entrypoint(inner: &ItemFn, opts: MacroOpts) -> proc_macro2::TokenStream 
             ::vexide::startup::startup::<#banner_enabled>(#banner_theme);
 
             #inner
-            let termination: #ret_type = ::vexide::async_runtime::block_on(
+            let termination: #ret_type = ::vexide::runtime::block_on(
                 #inner_ident(::vexide::devices::peripherals::Peripherals::take().unwrap())
             );
-            ::vexide::core::program::Termination::report(termination);
-            ::vexide::core::program::exit();
+            ::vexide::program::Termination::report(termination);
+            ::vexide::program::exit();
         }
     }
 }
@@ -217,12 +217,12 @@ mod test {
 
                     #source
 
-                    let termination: () = ::vexide::async_runtime::block_on(
+                    let termination: () = ::vexide::runtime::block_on(
                         main(::vexide::devices::peripherals::Peripherals::take().unwrap())
                     );
 
-                    ::vexide::core::program::Termination::report(termination);
-                    ::vexide::core::program::exit();
+                    ::vexide::program::Termination::report(termination);
+                    ::vexide::program::exit();
                 }
             }
             .to_string()

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -1,4 +1,4 @@
-//! Panic handler implementation for [`vexide`](https://crates.io/crates/vexide)
+//! Panic handler for [`vexide`](https://crates.io/crates/vexide).
 //!
 //! Supports capturing and printing backtraces to aid in debugging.
 //!

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate provides a minimal startup routine for user code on the VEX V5 Brain.
+//! Startup routine and behavior in `vexide`.
 //!
 //! - User code begins at an assembly routine called `_boot`, which sets up the stack
 //!   section before jumping to a user-provided `_start` symbol, which should be your

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -50,32 +50,20 @@ pub use vexide_async::task;
 ///   for or until a specific instant in time.
 #[cfg(any(feature = "core", feature = "async"))]
 pub mod time {
-    #[cfg(feature = "core")]
-    pub use vexide_core::time::*;
     #[cfg(feature = "async")]
     pub use vexide_async::time::*;
+    #[cfg(feature = "core")]
+    pub use vexide_core::time::*;
 }
 
 #[cfg(feature = "core")]
-pub use vexide_core::{
-    allocator,
-    backtrace,
-    competition,
-    float,
-    fs,
-    io,
-    os,
-    path,
-    program,
-    sync,
-};
-
-#[doc(inline)]
-#[cfg(feature = "macro")]
-pub use vexide_macro::main;
+pub use vexide_core::{allocator, backtrace, competition, float, fs, io, os, path, program, sync};
 #[doc(inline)]
 #[cfg(feature = "devices")]
 pub use vexide_devices as devices;
+#[doc(inline)]
+#[cfg(feature = "macro")]
+pub use vexide_macro::main;
 #[doc(inline)]
 #[cfg(feature = "panic")]
 pub use vexide_panic as panic;
@@ -87,20 +75,6 @@ pub use vexide_startup as startup;
 ///
 /// This module is meant to be glob imported.
 pub mod prelude {
-    #[cfg(feature = "async")]
-    pub use crate::{
-        runtime::block_on,
-        task::{Task, spawn},
-        time::{sleep, sleep_until},
-    };
-
-    #[cfg(feature = "core")]
-    pub use crate::{
-        competition::{Compete, CompeteExt, CompetitionRuntime},
-        float::Float,
-        io::{BufRead, Read, Seek, Write, dbg, print, println},
-    };
-
     #[cfg(feature = "devices")]
     pub use crate::devices::{
         adi::{
@@ -141,5 +115,17 @@ pub mod prelude {
             },
             SmartDevice, SmartPort,
         },
+    };
+    #[cfg(feature = "core")]
+    pub use crate::{
+        competition::{Compete, CompeteExt, CompetitionRuntime},
+        float::Float,
+        io::{dbg, print, println, BufRead, Read, Seek, Write},
+    };
+    #[cfg(feature = "async")]
+    pub use crate::{
+        runtime::block_on,
+        task::{spawn, Task},
+        time::{sleep, sleep_until},
     };
 }

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -31,9 +31,11 @@
 /// Async runtime & executor.
 #[cfg(feature = "async")]
 pub mod runtime {
+    #[doc(inline)]
     pub use vexide_async::block_on;
 }
 
+#[doc(inline)]
 #[cfg(feature = "async")]
 pub use vexide_async::task;
 
@@ -61,6 +63,7 @@ pub mod time {
     pub use vexide_core::time::*;
 }
 
+#[doc(inline)]
 #[cfg(feature = "core")]
 pub use vexide_core::{allocator, backtrace, competition, float, fs, io, os, path, program, sync};
 #[doc(inline)]

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -25,6 +25,7 @@
 //! Check out our [docs](https://vexide.dev/docs/) for more in-depth usage guides.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_logo_url = "https://vexide.dev/images/logo.svg")]
 
 /// Async runtime & executor.
@@ -48,6 +49,10 @@ pub use vexide_async::task;
 ///
 /// - [`sleep`] and [`sleep_until`] provide ways to yield control away from a future
 ///   for or until a specific instant in time.
+///
+/// [`sleep`]: vexide_async::time::sleep
+/// [`sleep_until`]: vexide_async::time::sleep_until
+/// [`Instant`]: vexide_core::time::Instant
 #[cfg(any(feature = "core", feature = "async"))]
 pub mod time {
     #[cfg(feature = "async")]

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -57,8 +57,10 @@ pub use vexide_async::task;
 /// [`Instant`]: vexide_core::time::Instant
 #[cfg(any(feature = "core", feature = "async"))]
 pub mod time {
+    #[doc(inline)]
     #[cfg(feature = "async")]
     pub use vexide_async::time::*;
+    #[doc(inline)]
     #[cfg(feature = "core")]
     pub use vexide_core::time::*;
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
