### PR TITLE
refactor: don't gate `vexide::allocator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Before releasing:
 - The `vexide::async_runtime::task` module is now a top-level `vexide::task` module. (#305) (**Breaking Change**)
 - Merged `vexide::core::time` and `vexide::async_runtime::time` into a single `vexide::time` module. (#305) (**Breaking Change**)
 - Moved `vexide::core` modules to the top-level `vexide` crate. For example, `vexide::core::fs` is now `vexide::fs`. (#305) (**Breaking Change**)
+- `vexide::allocator` is no longer cfg-gated to `target_vendor = "vex"`. (#307)
 
 ### Removed
 

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -14,7 +14,6 @@
 
 extern crate alloc;
 
-#[cfg(target_vendor = "vex")]
 pub mod allocator;
 pub mod backtrace;
 pub mod competition;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
