### PR TITLE
docs: document `vexide-core` more extensively, add `abort`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Before releasing:
 - Added `RadioLink::INTERNAL_BUFFER_SIZE` constant. (#293)
 - `AiVisionSensor` is now re-exported through `vexide::devices`. (#302)
 - Added a new `GpsSensor::set_offset` method that allows reconfiguring the GPS sensor's physical offset after creation. (#302)
+- Added the `vexide::program::abort` method to match `std::process::abort`. Unlike `vexide::program::exit`, `abort` attempts to terminate the program as immediately as possible without doing any cleanup to the serial buffer. (#309)
 
 ### Fixed
 

--- a/packages/vexide-async/src/lib.rs
+++ b/packages/vexide-async/src/lib.rs
@@ -18,7 +18,7 @@ use core::future::Future;
 use executor::EXECUTOR;
 pub use task::spawn;
 
-/// Blocks the current task untill a return value can be extracted from the provided future.
+/// Blocks the current task until a return value can be extracted from the provided future.
 ///
 /// Does not poll all futures to completion.
 pub fn block_on<F: Future + 'static>(future: F) -> F::Output {

--- a/packages/vexide-core/src/allocator.rs
+++ b/packages/vexide-core/src/allocator.rs
@@ -3,8 +3,8 @@
 //! This module provide's vexide's `#[global_allocator]`, which is implemented using the `talc` crate.
 //!
 //! [`claim`] must be called before any heap allocations are made.
-//! This is done automatically in the `vex-startup` crate,
-//! so you should not need to call it yourself unless you are writing your own startup implementation.
+//! This is done automatically for you in the `vexide-startup` crate, so you should not need to call
+//! it yourself unless you are writing your own startup routine implementation.
 
 use talc::{ErrOnOom, Span, Talc, Talck};
 

--- a/packages/vexide-core/src/backtrace.rs
+++ b/packages/vexide-core/src/backtrace.rs
@@ -4,6 +4,15 @@
 //! the [`Backtrace`] type. Backtraces are helpful to attach to errors,
 //! containing information that can be used to get a chain of where an error
 //! was created.
+//!
+//! # Platform Support
+//!
+//! The [`Backtrace`] API is only functional on the `armv7a-vex-v5` platform
+//! target. At the moment, this target only platform that vexide supports,
+//! however this may change in the future.
+//!
+//! Additionally, backtraces will be unsupported if vexide is compiled without
+//! the `unwind` feature.
 
 use alloc::vec::Vec;
 use core::{ffi::c_void, fmt::Display};
@@ -16,12 +25,23 @@ use vex_libunwind::{registers, UnwindContext, UnwindCursor, UnwindError};
 /// This type stores the backtrace of a captured stack at a certain point in
 /// time. The backtrace is represented as a list of instruction pointers.
 ///
+/// # Platform Support
+///
+/// The [`Backtrace`] API is only functional on the `armv7a-vex-v5` platform
+/// target. At the moment, this target only platform that vexide supports,
+/// however this may change in the future.
+///
+/// Additionally, backtraces will be unsupported if vexide is compiled without
+/// the `unwind` feature.
+///
+/// # Example
+///
 /// ```
 /// let backtrace = Backtrace::capture();
 /// println!("{backtrace}");
 /// ```
 ///
-/// ## Symbolication
+/// # Symbolication
 ///
 /// The number stored in each frame is not particularly meaningful to humans on its own.
 /// Using a tool such as `llvm-symbolizer` or `addr2line`, it can be turned into
@@ -45,9 +65,9 @@ impl Backtrace {
     ///
     /// If a backtrace could not be captured, an empty backtrace is returned.
     ///
-    /// ## Platform Support
+    /// # Platform Support
     ///
-    /// Backtraces will be empty on non-armv7a targets (e.g. WebAssembly) or when
+    /// Backtraces will be empty on non-vex targets (e.g. WebAssembly) or when
     /// the `unwind` feature is disabled.
     #[allow(clippy::inline_always)]
     #[inline(always)] // Inlining keeps this function from appearing in backtraces
@@ -63,6 +83,10 @@ impl Backtrace {
 
     /// Captures a backtrace at the current point of execution,
     /// returning an error if the backtrace fails to capture.
+    ///
+    /// # Platform Support
+    ///
+    /// See [`Backtrace::capture`].
     ///
     /// # Errors
     ///

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -129,7 +129,7 @@ pub enum CompetitionMode {
 pub enum CompetitionSystem {
     /// Competition state is controlled by a VEX Field Controller (either [legacy] or [smart] field control).
     ///
-    /// [legacy]: https://www.vexrobotics.com/275-1401.html?srsltid=AfmBOopaclcyyUtEorMyBF97kTzeFlwzD5VB5TZCJoGOH5v5EosRgs7f
+    /// [legacy]: https://www.vexrobotics.com/275-1401.html
     /// [smart]: https://kb.vex.com/hc/en-us/articles/9121731684756-VEX-Field-Control-User-Manual
     FieldControl,
 

--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -856,14 +856,14 @@ pub trait Compete: Sized {
 
     /// Runs when the robot disconnects from a competition controller.
     ///
-    /// <div class="warning">
+    /// <section class="warning">
     ///
     /// This function does NOT run if connection to the match is lost due to
     /// a radio issue. It will only execute if the field control wire becomes
     /// physically disconnected from the controller (i.e.) from unplugging after
     /// a match ends.
     ///
-    /// </div>
+    /// </section>
     ///
     /// See [`CompetitionBuilder::on_disconnect`] for more information.
     async fn disconnected(&mut self) {}

--- a/packages/vexide-core/src/float/mod.rs
+++ b/packages/vexide-core/src/float/mod.rs
@@ -1,7 +1,7 @@
-//! Floating point numbers.
+//! Floating point arithmetic.
 //!
 //! This module provides implementations of math functions of floating point
-//! primitive types (`f32`, `f64`).
+//! primitive types (`f32`, `f64`) through the [`Float`] trait.
 
 #[cfg(all(target_vendor = "vex", not(feature = "force_rust_libm")))]
 mod newlib;

--- a/packages/vexide-core/src/fs/fs_str.rs
+++ b/packages/vexide-core/src/fs/fs_str.rs
@@ -82,7 +82,7 @@ impl FsStr {
 
     /// Copies this [`FsStr`] into an owned [`FsString`].
     ///
-    /// /// # Examples
+    /// # Examples
     ///
     /// ```
     /// let fs_str = FsStr::new("foo");
@@ -199,6 +199,7 @@ impl FsString {
     }
 
     /// Borrows an [`FsString`] as an [`FsStr`].
+    ///
     /// This is akin to taking a slice of the entire [`FsString`]
     #[must_use]
     #[allow(clippy::missing_const_for_fn)] // false-positive. can't be const dereffed

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -1,8 +1,7 @@
 //! Filesystem manipulation operations.
 //!
 //! This module contains basic methods to manipulate the contents of the brain's
-//! micro SDCard card. All methods in this module represent VEXos filesystem
-//! operations.
+//! micro SDCard. All methods in this module represent VEXos filesystem operations.
 //!
 //! # VEXos Limitations
 //!

--- a/packages/vexide-core/src/os.rs
+++ b/packages/vexide-core/src/os.rs
@@ -7,7 +7,35 @@ use core::fmt;
 
 use vex_sdk::vexSystemVersion;
 
-/// A VEXos version
+/// A VEXos firmware version.
+///
+/// This type represents a version identifier for VEXos firmware. VEXos is
+/// versioned using a slightly modified [semantic versioning] scheme. To
+/// check the version currently running on a brain, use [`system_version`].
+///
+/// [semantic versioning]: https://semver.org/
+///
+/// This type implements `PartialOrd`, meaning it can be compared to other
+/// instances of itself.
+///
+/// # Example
+///
+/// ```
+/// // VEXos 1.1.5b0
+/// const VEXOS_1_1_5_0: Version = Version {
+///     major: 1,
+///     minor: 1,
+///     build: 5,
+///     beta: 0,
+/// };
+///
+/// // Get the currently running VEXos version
+/// let version = system_version();
+///
+/// if version < VEXOS_1_1_5_0 {
+///     panic!("Update your firmware!");
+/// }
+/// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Version {
     /// The major version
@@ -30,7 +58,28 @@ impl fmt::Display for Version {
     }
 }
 
-/// Returns the current VEXos version.
+/// Returns the currently running VEXos [firmware version] on a brain.
+///
+/// [firmware version]: Version
+///
+/// # Example
+///
+/// ```
+/// // VEXos 1.1.5b0
+/// const VEXOS_1_1_5_0: Version = Version {
+///     major: 1,
+///     minor: 1,
+///     build: 5,
+///     beta: 0,
+/// };
+///
+/// // Get the currently running VEXos version
+/// let version = system_version();
+///
+/// if version < VEXOS_1_1_5_0 {
+///     panic!("Update your firmware!");
+/// }
+/// ```
 #[must_use]
 pub fn system_version() -> Version {
     let version_bytes = unsafe { vexSystemVersion() }.to_be_bytes();

--- a/packages/vexide-core/src/path.rs
+++ b/packages/vexide-core/src/path.rs
@@ -71,7 +71,7 @@ impl AsRef<Path> for &str {
     }
 }
 
-/// An owned, mutable path akin to a `String
+/// An owned, mutable path (akin to `String`).
 ///
 /// This type implements `Deref` to [`Path`],
 /// menaing all methods on a [`Path`] can be used on a [`PathBuf`].

--- a/packages/vexide-core/src/program.rs
+++ b/packages/vexide-core/src/program.rs
@@ -1,4 +1,8 @@
 //! User program state.
+//!
+//! This module provides functionality for controlling the state of the currently running
+//! user program on the Brain. At the time, that is essentially just functionality for
+//! exiting the program early using the [`abort`] and [`exit`] functions.
 
 use core::{convert::Infallible, fmt::Debug, time::Duration};
 
@@ -6,9 +10,10 @@ use vex_sdk::{vexSerialWriteFree, vexSystemExitRequest, vexTasksRun};
 
 use crate::{io, time::Instant};
 
-/// A trait that can be implemented for arbitrary return types in the main function.
+/// A trait that can be implemented for arbitrary return types in the `main` function.
 pub trait Termination {
     /// Run specific termination logic.
+    ///
     /// Unlike in the standard library, this function does not return a status code.
     fn report(self);
 }
@@ -32,9 +37,23 @@ impl<T: Termination, E: Debug> Termination for Result<T, E> {
 
 const FLUSH_TIMEOUT: Duration = Duration::from_millis(15);
 
-/// Exits the program using vexSystemExitRequest.
-/// This function will not instantly exit the program,
-/// but will instead wait up to 15mS to force the serial buffer to flush.
+/// Exits the program using `vexSystemExitRequest`.
+///
+/// This function will block up to 15mS to allow the serial buffer to flush, then either exit the program or
+/// block for an indefinite amount of time depending on how long it takes VEXos to kill the program.
+///
+/// Note that because this function never returns, and that it terminates the process, no destructors on
+/// the current stack will be run. If a clean shutdown is needed it is recommended to only call this function
+/// at a known point where there are no more destructors left to run; or, preferably, simply return a type
+/// implementing [`Termination`] (such as `Result`) from the `main` function and avoid this function altogether:
+///
+/// ```
+/// #[vexide::main]
+/// async fn main(peripherals: Peripherals) -> Result<(), MyError> {
+///    // ...
+///    Ok(())
+/// }
+/// ```
 pub fn exit() -> ! {
     let exit_time = Instant::now();
 
@@ -53,6 +72,23 @@ pub fn exit() -> ! {
         vexSystemExitRequest();
 
         // Loop while vexos decides what to do with our exit request.
+        loop {
+            vexTasksRun();
+        }
+    }
+}
+
+/// Exits the program using `vexSystemExitRequest` without flushing the serial buffer.
+///
+/// This function is virtually identical to [`exit`] with the caveat that it will not wait for
+/// stdio buffers to be printed, meaning any writes to `Stdout` *MAY* not be written before the
+/// program is killed by VEXos.
+pub fn abort() -> ! {
+    unsafe {
+        // Request program exit from CPU0.
+        vexSystemExitRequest();
+
+        // Spin while CPU0 decides what to do with our exit request.
         loop {
             vexTasksRun();
         }

--- a/packages/vexide-panic/src/lib.rs
+++ b/packages/vexide-panic/src/lib.rs
@@ -241,8 +241,8 @@ pub fn take_hook() -> Box<dyn Fn(&core::panic::PanicInfo<'_>) + Send> {
     old_hook
 }
 
-#[panic_handler]
 /// The panic handler for vexide.
+#[panic_handler]
 pub fn panic(info: &core::panic::PanicInfo<'_>) -> ! {
     // This can only occur if the panic handler itself has panicked (which can
     // happen in hooks or if println!() fails), resulting in a potential stack

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -3,12 +3,10 @@
 //! Open-source Rust runtime for VEX V5 robots. vexide provides a `no_std` Rust runtime,
 //! async executor, device API, and more for the VEX V5 Brain!
 //!
-//! vexide is the successor to [pros-rs](https://github.com/vexide/pros-rs) which is a set of unmaintained APIs using bindings over [PROS](https://github.com/purduesigbots/pros).
-//!
 //! ## Getting Started
 //!
 //! If you're just getting started, we recommend going through our [docs](https://vexide.dev/docs/), which provide step-by-step instructions for setting up a development environment
-//! with [vexide-template](https://github.com/vexide/vexide-template).
+//! and using vexide's common features.
 //!
 //! # Usage
 //!
@@ -22,7 +20,7 @@
 //! }
 //!```
 //!
-//! Check out our [docs](https://vexide.dev/docs/) for more in-depth usage guides.
+//! Check out our [examples](https://github.com/vexide/vexide/tree/main/examples/) for more examples of different features.
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR also adds `vexide::program::abort` to match `std::process::abort`. Unlike `vexide::program::exit`, `abort` attempts to terminate the program as immediately as possible without doing any cleanup to the serial buffer.
