### PR TITLE
feat: make `talc` an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Before releasing:
 - `vexide::allocator` is no longer cfg-gated to `target_vendor = "vex"`. (#307)
 - Refactored the GPS Sensor API to provide all functionality through a single struct. (#302) (**Breaking Change**)
 - Renamed `LazyLock::get` back to `LazyLock::force`. (#310) (**Breaking Change**)
+- The default `talc` allocator can now be removed by disabling the `allocator` feature, which is enabled by default. (#311) (**Breaking Change**) 
 
 ### Removed
 

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 vex-sdk = { workspace = true }
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 snafu = { workspace = true }
-talc = "4.3.1"
+talc = {  version = "4.3.1", optional = true }
 lock_api = "0.4.11"
 bitflags = "2.4.2"
 futures-core = { version = "0.3.30", default-features = false, features = [
@@ -43,6 +43,7 @@ workspace = true
 default = ["backtraces"]
 force_rust_libm = ["dep:libm"]
 backtraces = ["dep:vex-libunwind"]
+allocator = ["dep:talc"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.

--- a/packages/vexide-core/src/lib.rs
+++ b/packages/vexide-core/src/lib.rs
@@ -14,6 +14,7 @@
 
 extern crate alloc;
 
+#[cfg(feature = "allocator")]
 pub mod allocator;
 pub mod backtrace;
 pub mod competition;

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -24,7 +24,8 @@ compile-time = "0.2.0"
 workspace = true
 
 [features]
-default = []
+default = ["allocator"]
+allocator = ["vexide-core/allocator"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-none-eabi"] # Not actually, but this is at least close.

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -191,6 +191,7 @@ pub unsafe fn startup<const BANNER: bool>(theme: BannerTheme) {
         zero_bss(&raw mut __bss_start, &raw mut __bss_end);
 
         // Initialize the heap allocator using normal bounds
+        #[cfg(feature = "allocator")]
         vexide_core::allocator::claim(&raw mut __heap_start, &raw mut __heap_end);
 
         // If this link address is 0x03800000, this implies we were uploaded using
@@ -200,6 +201,7 @@ pub unsafe fn startup<const BANNER: bool>(theme: BannerTheme) {
         }
 
         // Reclaim 6mb memory region occupied by patches and program copies as heap space.
+        #[cfg(feature = "allocator")]
         vexide_core::allocator::claim(&raw mut __patcher_ram_start, &raw mut __patcher_ram_end);
     }
 

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -37,6 +37,7 @@ default = [
     "startup",
     "macro",
     "backtraces",
+    "allocator",
 ]
 
 macro = ["dep:vexide-macro", "startup", "async", "core", "devices"]

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -44,6 +44,7 @@ macro = ["dep:vexide-macro", "startup", "async", "core", "devices"]
 core = ["dep:vexide-core"]
 backtraces = ["core", "vexide-core/backtraces"]
 force_rust_libm = ["core", "vexide-core/force_rust_libm"]
+allocator = ["core", "vexide-core/allocator", "vexide-startup/allocator"]
 
 startup = ["dep:vexide-startup"]
 

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -64,11 +64,11 @@ pub mod time {
 }
 
 #[doc(inline)]
-#[cfg(feature = "core")]
-pub use vexide_core::{backtrace, competition, float, fs, io, os, path, program, sync};
-#[doc(inline)]
 #[cfg(feature = "allocator")]
 pub use vexide_core::allocator;
+#[doc(inline)]
+#[cfg(feature = "core")]
+pub use vexide_core::{backtrace, competition, float, fs, io, os, path, program, sync};
 #[doc(inline)]
 #[cfg(feature = "devices")]
 pub use vexide_devices as devices;

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -65,7 +65,10 @@ pub mod time {
 
 #[doc(inline)]
 #[cfg(feature = "core")]
-pub use vexide_core::{allocator, backtrace, competition, float, fs, io, os, path, program, sync};
+pub use vexide_core::{backtrace, competition, float, fs, io, os, path, program, sync};
+#[doc(inline)]
+#[cfg(feature = "allocator")]
+pub use vexide_core::allocator;
 #[doc(inline)]
 #[cfg(feature = "devices")]
 pub use vexide_devices as devices;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Adds an `allocator` feature that allows using a custom allocator. This enables interfacing with C code that doesn't use the Rust allocator through `libc_alloc` and also just allows more flexibility.

## Additional Context

- These are breaking changes for `default-features=false` users.
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
