### PR TITLE
fix: use correct assertion logic in AI vision id methods

### DIFF
--- a/packages/vexide-core/src/competition.rs
+++ b/packages/vexide-core/src/competition.rs
@@ -49,7 +49,7 @@
 //! # Reading Competition State
 //!
 //! In addition to providing hooks into different competition modes, this module also provides
-//! functions for reading information about the competition enviornment, such as the current match
+//! functions for reading information about the competition environment, such as the current match
 //! mode, match control hardware, and whether the robot is enabled or disabled. This is provided
 //! by the [`is_connected`], [`system`], [`mode`], and [`status`] functions.
 

--- a/packages/vexide-core/src/float/newlib.rs
+++ b/packages/vexide-core/src/float/newlib.rs
@@ -26,7 +26,7 @@ static mut errno: c_int = 0;
 /// # Safety
 ///
 /// This function returns a raw pointer to a mutable static. It is intended for
-/// interoptability with libm.
+/// compatibility with libm.
 #[unsafe(no_mangle)] // SAFETY: libm requires this symbol to exist, and this is the only place it is defined
 unsafe extern "C" fn __errno() -> *mut c_int {
     &raw mut errno

--- a/packages/vexide-core/src/fs/fs_str.rs
+++ b/packages/vexide-core/src/fs/fs_str.rs
@@ -308,7 +308,7 @@ impl FsString {
     /// This function will error under the following conditions:
     ///
     /// - The capacity of the [`FsString`] has surpasses [`isize::MAX`] bytes
-    /// - An allocation error occured while reserving space.
+    /// - An allocation error occurred while reserving space.
     pub fn try_reserve(
         &mut self,
         additional: usize,
@@ -320,7 +320,7 @@ impl FsString {
     ///
     /// # Note
     ///
-    /// Reserving an exact amount of times can often negatively impact performace.
+    /// Reserving an exact amount of times can often negatively impact performance.
     /// you most likely want to use [`FsString::reserve`]
     pub fn reserve_exact(&mut self, additional: usize) {
         self.inner.reserve_exact(additional);
@@ -330,14 +330,14 @@ impl FsString {
     ///
     /// # Note
     ///
-    /// Reserving an exact amount of times can often negatively impact performace.
+    /// Reserving an exact amount of times can often negatively impact performance.
     /// you most likely want to use [`FsString::reserve`]
     ///
     /// # Errors
     /// This function will error under the following conditions:
     ///
     /// - The capacity of the [`FsString`] has surpasses [`isize::MAX`] bytes
-    /// - An allocation error occured while reserving space.
+    /// - An allocation error occurred while reserving space.
     pub fn try_reserve_exact(
         &mut self,
         additional: usize,

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # VEXos Limitations
 //!
-//! While this module largely mimicks Rust's `std::fs` API, there are several major
+//! While this module largely mimics Rust's `std::fs` API, there are several major
 //! limitations in the VEXos filesystem. This module only provides a small subset of
 //! what would normally be expected in a typical Rust environment. Notably:
 //!
@@ -46,7 +46,7 @@ pub use fs_str::{Display, FsStr, FsString};
 /// - Files MUST be opened in either `read` XOR `write` mode.
 /// - VEXos does not allow you to open a file configured as `read` and `write`
 ///   at the same time. Doing so will return an error with `File::open`. This is
-///   a fundamental limtiation of the OS.
+///   a fundamental limitation of the OS.
 ///
 /// # Examples
 ///
@@ -843,7 +843,7 @@ pub struct DirEntry {
 impl DirEntry {
     /// Returns the full path to the directory item.
     ///
-    /// This path is creeated by joining the path of the call to [`read_dir`] to the name of the file.
+    /// This path is created by joining the path of the call to [`read_dir`] to the name of the file.
     ///
     /// # Examples
     ///

--- a/packages/vexide-core/src/fs/mod.rs
+++ b/packages/vexide-core/src/fs/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! While this module largely mimicks Rust's `std::fs` API, there are several major
 //! limitations in the VEXos filesystem. This module only provides a small subset of
-//! what would normally be expected in a typical Rust enviornment. Notably:
+//! what would normally be expected in a typical Rust environment. Notably:
 //!
 //! - Files cannot be opened as read and write at the same time (only one). To read a
 //!   file that you’ve written to, you’ll need to drop your written file descriptor and

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -20,7 +20,7 @@
 //!
 //! Because these motors are no longer V5RC legal, they are not affected by
 //! competition control restrictions, nor do they have any software-imposed
-//! current limitations beyond the aformentioned PTC circuit.
+//! current limitations beyond the aforementioned PTC circuit.
 //!
 //! [Motor Controller 29]: https://www.vexrobotics.com/276-2193.html
 //! [Motor 393]: https://www.vexrobotics.com/393-motors.html

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -527,7 +527,7 @@ impl ControllerScreen {
     /// async fn main(peripherals: Peripherals) {
     ///     let mut controller = peripherals.primary_controller;
     ///
-    ///     _ = controller.try_set_text("Hello, world!", 0, 0);
+    ///     _ = controller.try_set_text("Hello, world!", 1, 1);
     /// }
     /// ```
     pub fn try_set_text(
@@ -540,12 +540,12 @@ impl ControllerScreen {
 
         assert!(
             column <= Self::MAX_COLUMNS as u8 && column != 0,
-            "Invalid column number ({column}) is greater than the maximum number of columns ({})",
+            "{column} is not a valid controller column number. Must be in the range [1, {}]",
             ControllerScreen::MAX_COLUMNS
         );
         assert!(
             line <= Self::MAX_LINES as u8 && line != 0,
-            "Invalid line number ({line}) is greater than the maximum number of line ({})",
+            "{line} is not a valid controller line number. Must be in the range [1, {}]",
             ControllerScreen::MAX_LINES
         );
 

--- a/packages/vexide-devices/src/peripherals.rs
+++ b/packages/vexide-devices/src/peripherals.rs
@@ -25,7 +25,7 @@
 //!
 //! By extension of this, only one mutable reference to a piece of hardware may exist. This
 //! pattern of treating peripherals as a singleton is fairly common in the Rust embedded scene,
-//! and is extensively coevered in [The Embedded Rust Book](https://docs.rust-embedded.org/book/peripherals/singletons.html).
+//! and is extensively covered in [The Embedded Rust Book](https://docs.rust-embedded.org/book/peripherals/singletons.html).
 //!
 //! # Usage
 //!

--- a/packages/vexide-devices/src/smart/ai_vision.rs
+++ b/packages/vexide-devices/src/smart/ai_vision.rs
@@ -596,7 +596,7 @@ impl AiVisionSensor {
     /// ```
     pub fn set_color(&mut self, id: u8, color: AiVisionColor) -> Result<()> {
         assert!(
-            !(1..=7).contains(&id),
+            (1..=7).contains(&id),
             "The given ID ({id}) is out of the interval [1, 7]."
         );
         self.validate_port()?;
@@ -650,7 +650,7 @@ impl AiVisionSensor {
     /// ```
     pub fn color(&self, id: u8) -> Result<Option<AiVisionColor>> {
         assert!(
-            !(1..=7).contains(&id),
+            (1..=7).contains(&id),
             "The given ID ({id}) is out of the interval [1, 7]."
         );
         self.validate_port()?;

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -563,7 +563,7 @@ impl GpsSensor {
     ///         0.0,
     ///     );
     ///
-    ///     // Read out accleration values every 10mS
+    ///     // Read out acceleration values every 10mS
     ///     loop {
     ///         if let Ok(acceleration) = gps.acceleration() {
     ///             println!(

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -296,7 +296,7 @@ impl InertialSensor {
     /// }
     /// ```
     ///
-    /// Calibrating in a competition enviornment:
+    /// Calibrating in a competition environment:
     ///
     /// ```
     /// use vexide::prelude::*;

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -49,7 +49,7 @@
 //!
 //! If the IMU loses power due to a disconnect — even momentarily, all calibration data will be lost
 //! and VEXos will re-initiate calibration automatically. The robot cannot be moving when this occurs
-//! due to the aformentioned unpredictable behavior. As such, it is vital that the IMU maintain a stable
+//! due to the aforementioned unpredictable behavior. As such, it is vital that the IMU maintain a stable
 //! connection to the Brain and voltage supply during operation.
 
 use core::{
@@ -594,7 +594,7 @@ impl InertialSensor {
     ///     // Calibrate sensor, panic if calibration fails.
     ///     sensor.calibrate().await.unwrap();
     ///
-    ///     // Read out accleration values every 10mS
+    ///     // Read out acceleration values every 10mS
     ///     loop {
     ///         if let Ok(acceleration) = sensor.acceleration() {
     ///             println!(

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -28,7 +28,7 @@
 //!   can disrupt operation. By restricting the stall current to 2.5A, the motor effectively avoids
 //!   undesirable performance dips and ensures that users do not inadvertently cause stall situations.
 //!
-//! - **Motor Count**: Robots that use 8 or fewer 11W motors will have the aformentioned current limit
+//! - **Motor Count**: Robots that use 8 or fewer 11W motors will have the aforementioned current limit
 //!   of 2.5A set for each motor. Robots using more than 8 motors, will have a lower default current limit
 //!   per-motor than 2.5A. This limit is determined in VEXos by a calculation accounting for the number of
 //!   motors plugged in, and the user's manually set current limits using [`Motor::set_current_limit`]. For

--- a/packages/vexide-startup/src/patcher/mod.rs
+++ b/packages/vexide-startup/src/patcher/mod.rs
@@ -25,7 +25,7 @@ enum PatcherState {
 /// This function builds a modified version of the user program in memory with a binary patch (generated
 /// by `bidiff` in cargo-v5) applied to it, then overwrites (self-modifies) the current program with the
 /// newer version. This allows us to only upload a binary diff of what has changed from the original (the
-/// "base") file, which is significanly smaller than reuploading the entire binary every time.
+/// "base") file, which is significantly smaller than reuploading the entire binary every time.
 ///
 /// # Overview
 ///
@@ -91,7 +91,7 @@ enum PatcherState {
 /// The caller must ensure that the patch loaded at 0x07A00000 has been built using the currently running
 /// binary as the basis for the patch.
 pub(crate) unsafe fn patch() {
-    // First four byets of the patch file MUST be 0xB1DF for the patch to be applied.
+    // First four bytes of the patch file MUST be 0xB1DF for the patch to be applied.
     const PATCH_MAGIC: u32 = 0xB1DF;
 
     // Next four bytes of the patch have to match this version identifier for the patch to be applied.
@@ -112,7 +112,7 @@ pub(crate) unsafe fn patch() {
     unsafe {
         // First few bytes contain some important metadata we'll need to setup the patch.
         let patch_magic = PATCH_MEMORY.read(); // Should be 0xB1DF if the patch needs to be applied.
-        let patch_version = PATCH_MEMORY.offset(1).read(); // Shoud be 0x1000
+        let patch_version = PATCH_MEMORY.offset(1).read(); // Should be 0x1000
         let patch_len = PATCH_MEMORY.offset(2).read(); // length of the patch buffer
         let base_binary_len = PATCH_MEMORY.offset(3).read(); // length of the currently running binary
         let new_binary_len = PATCH_MEMORY.offset(4).read(); // length of the new binary after the patch


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Another flipped assertion logic error.