### PR TITLE
fix: flip more assertion logics in ai vision and remove more typos

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "hotspot",
         "leds",
         "loopspeed",
+        "microcontroller",
         "opcontrol",
         "parametricity",
         "photoresistor",

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -11,7 +11,7 @@
 //! cortex-era [Motor 393] and Motor 269 units from VEX. These are fairly
 //! standard DC motors that can be driven using standard voltage control or PWM,
 //! with an integrated PTC breaker designed to prevent damage to the motors in
-//! the event that they are overucurrent or stalled.
+//! the event that they are overcurrent or stalled.
 //!
 //! While this module provides an API similar to that of a [Smart Motor], it is
 //! in reality simply outputting an 8-bit PWM signal, which will be processed by

--- a/packages/vexide-devices/src/adi/servo.rs
+++ b/packages/vexide-devices/src/adi/servo.rs
@@ -5,7 +5,7 @@
 //! # Hardware Overview
 //!
 //! Servos are similar in both appearance and function to [`AdiMotor`](super::motor::AdiMotor)s, with the
-//! caveat that they are designed to hold a specific *angle* rather than a continious
+//! caveat that they are designed to hold a specific *angle* rather than a continuous
 //! *speed*. In other words:
 //!
 //! - Motors are designed for continuous rotation, providing variable speed and
@@ -14,7 +14,7 @@
 //!   holding a specific angle within a limited range of motion.
 //!
 //! Servos, similar to motors, are PWM controlled. They use a standard
-//! [servo control](https://en.wikipedia.org/wiki/Servo_control) singal. A PWM input of
+//! [servo control](https://en.wikipedia.org/wiki/Servo_control) signal. A PWM input of
 //! 1ms - 2ms will give full reverse to full forward, while 1.5ms is neutral.
 //!
 //! # Operating Range

--- a/packages/vexide-devices/src/peripherals.rs
+++ b/packages/vexide-devices/src/peripherals.rs
@@ -106,7 +106,7 @@ static PERIPHERALS_TAKEN: AtomicBool = AtomicBool::new(false);
 /// it has been used to create a device.
 ///
 /// If you need to store a peripherals struct for use in multiple functions, use [`DynamicPeripherals`] instead.
-/// This struct is always preferrable to [`DynamicPeripherals`] when possible.
+/// This struct is always preferable to [`DynamicPeripherals`] when possible.
 #[derive(Debug)]
 pub struct Peripherals {
     /// Brain display

--- a/packages/vexide-devices/src/smart/ai_vision.rs
+++ b/packages/vexide-devices/src/smart/ai_vision.rs
@@ -203,7 +203,7 @@ pub struct AiVisionColor {
 /// A color code used by an AI Vision Sensor to detect groups of color blobs.
 ///
 /// The color code can have up to 7 color signatures.
-/// When the colors in a color code are detected next to eachother, the sensor will detect the color code.
+/// When the colors in a color code are detected next to each other, the sensor will detect the color code.
 pub struct AiVisionColorCode([Option<u8>; 7]);
 impl AiVisionColorCode {
     /// Creates a new color code with the given color signature ids.
@@ -435,7 +435,7 @@ impl AiVisionSensor {
     /// ```
     pub fn set_color_code(&mut self, id: u8, code: &AiVisionColorCode) -> Result<()> {
         assert!(
-            !(1..=8).contains(&id),
+            (1..=8).contains(&id),
             "The given ID ({id}) is out of the interval [1, 8]."
         );
         self.validate_port()?;
@@ -507,7 +507,7 @@ impl AiVisionSensor {
     /// ```
     pub fn color_code(&self, id: u8) -> Result<Option<AiVisionColorCode>> {
         assert!(
-            !(1..=8).contains(&id),
+            (1..=8).contains(&id),
             "The given ID ({id}) is out of the interval [1, 8]."
         );
         self.validate_port()?;

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -85,8 +85,8 @@ impl GpsSensor {
     ///
     /// `initial_heading` is a value between 0 and 360 degrees that informs the GPS of its heading at the start of the
     /// match. Similar to `initial_position`, this is useful for improving accuracy when the sensor is in close proximity
-    /// to a field wall, as the sensor's rotation values are continiously checked against the GPS field strips to prevent
-    /// drift over time. If the sensor starts too close to a field wall, providing an `initial_haeding` can help prevent
+    /// to a field wall, as the sensor's rotation values are continuously checked against the GPS field strips to prevent
+    /// drift over time. If the sensor starts too close to a field wall, providing an `initial_heading` can help prevent
     /// this drift at the start of the match.
     ///
     /// # Examples

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -142,7 +142,7 @@ impl InertialSensor {
         Ok(())
     }
 
-    /// Returns the internal status code of the intertial sensor.
+    /// Returns the internal status code of the inertial sensor.
     ///
     /// # Errors
     ///

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -5,7 +5,7 @@
 //!
 //! # Hardware Overview
 //!
-//! There are two types of radios in a VEXnink connection: "manager" and "worker". A "manager" radio can transmit data at up to 1040 bytes/s
+//! There are two types of radios in a VEXlink connection: "manager" and "worker". A "manager" radio can transmit data at up to 1040 bytes/s
 //! while a "worker" radio can transmit data at up to 520 bytes/s.
 //! A connection should only ever have both types of radios.
 //!

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -649,7 +649,7 @@ impl Motor {
     ///
     /// # Accuracy
     ///
-    /// In some cases, this reported value may be noisy or innaccurate, especially for systems where accurate
+    /// In some cases, this reported value may be noisy or inaccurate, especially for systems where accurate
     /// velocity control at high speeds is required (such as flywheels). If the accuracy of this value proves
     /// inadequate, you may opt to perform your own velocity calculations by differentiating [`Motor::position`]
     /// over the reported internal timestamp of the motor using [`Motor::timestamp`].
@@ -958,7 +958,7 @@ impl Motor {
     /// }
     /// ```
     ///
-    /// Reset the position of the motor to 0 degrees (analaogous to [`reset_position`](Motor::reset_position)):
+    /// Reset the position of the motor to 0 degrees (analogous to [`reset_position`](Motor::reset_position)):
     /// ```
     /// use vexide::prelude::*;
     ///

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -9,7 +9,7 @@
 //! The sensor provides absolute rotational position tracking from 0° to 360° with 0.088° accuracy. The
 //! sensor is compromised of two magnets which utilize the [Hall Effect] to indicate angular position. A
 //! chip inside the rotation sensor (a Cortex M0+) then keeps track of the total rotations of the sensor
-//! to determine total position travelled.
+//! to determine total position traveled.
 //!
 //! Position is reported by VEXos in centidegrees before being converted to an instance of [`Position`].
 //!

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -343,7 +343,7 @@ impl VisionSensor {
     ///     _ = sensor.set_signature(1, sig_1);
     ///     _ = sensor.set_signature(2, sig_2);
     ///
-    ///     // Create a code assocating signatures 1 and 2 together.
+    ///     // Create a code associating signatures 1 and 2 together.
     ///     let code = VisionCode::from((1, 2));
     ///
     ///     // Register our code on the sensor. When we call [`VisionSensor::objects`], the associated
@@ -801,7 +801,7 @@ impl VisionSensor {
     ///     let mut sensor = VisionSensor::new(peripherals.port_1);
     ///
     ///     // Place the sensor into "Wi-Fi mode", allowing you to connect to it via a hotspot
-    ///     // and recieve a video stream of its camera froma nother device.
+    ///     // and receive a video stream of its camera from another device.
     ///     _ = sensor.set_mode(VisionMode::WiFi);
     /// }
     /// ```
@@ -850,7 +850,7 @@ impl VisionSensor {
     ///     let mut sensor = VisionSensor::new(peripherals.port_1);
     ///
     ///     // Place the sensor into "Wi-Fi mode", allowing you to connect to it via a hotspot
-    ///     // and recieve a video stream of its camera froma nother device.
+    ///     // and receive a video stream of its camera from another device.
     ///     _ = sensor.set_mode(VisionMode::WiFi);
     ///
     ///     sleep(VisionSensor::UPDATE_INTERVAL).await;


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Fixes more of the assert!s for the AI Vision for the `set_color_code` and `color_code` methods. Also checks for more typos.

## Additional Context
N/A
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
