### PR TITLE
fix: fix vision sensor error checks/docs

### DIFF
--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -115,7 +115,7 @@ impl VisionSensor {
     ///
     /// # Panics
     ///
-    /// - Panics if the given signature ID is not in the interval [0, 7).
+    /// - Panics if the given signature ID is not in the interval [1, 7].
     ///
     /// # Errors
     ///
@@ -143,8 +143,8 @@ impl VisionSensor {
     /// ```
     pub fn set_signature(&mut self, id: u8, signature: VisionSignature) -> Result<(), VisionError> {
         assert!(
-            (1..7).contains(&id),
-            "The given signature ID `{id}` is not in the expected interval [0, 7)."
+            (1..=7).contains(&id),
+            "The given signature ID `{id}` is not in the expected interval [1, 7]."
         );
         self.validate_port()?;
 
@@ -177,8 +177,8 @@ impl VisionSensor {
     /// or `None` if no signature is stored with the given ID.
     fn read_raw_signature(&self, id: u8) -> Result<Option<V5_DeviceVisionSignature>, VisionError> {
         assert!(
-            (1..7).contains(&id),
-            "The given signature ID `{id}` is not in the expected interval [0, 7)."
+            (1..=7).contains(&id),
+            "The given signature ID `{id}` is not in the expected interval [1, 7]."
         );
 
         let mut raw_signature = V5_DeviceVisionSignature::default();
@@ -218,7 +218,7 @@ impl VisionSensor {
     ///
     /// # Panics
     ///
-    /// - Panics if the given signature ID is not in the interval [0, 7).
+    /// - Panics if the given signature ID is not in the interval [1, 7].
     ///
     /// # Errors
     ///
@@ -317,7 +317,7 @@ impl VisionSensor {
     ///
     /// # Panics
     ///
-    /// - Panics if one or more of the given signature IDs are not in the interval [0, 7).
+    /// - Panics if one or more of the given signature IDs are not in the interval [1, 7].
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

I know the AI Vision sensor signature validation code has recently had some problems. I was playing around with the old Vision Sensor recently and found that there were some discrepancies between the documentation and the code regarding the allowed signature ranges. I updated the code and docs where appropriate to indicate that signatures should be in the interval `[1, 7]` (based on PROS).

## Additional Context

- semver: patch