### PR TITLE
chore: add default workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ vexide = { path = "packages/vexide" }
 
 [workspace]
 members = ["packages/*"]
+default-members = ["packages/*"]
 resolver = "2"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Adds the `default-members` field to the workspace so that `cargo build` has the behavior of `cargo build -p vexide`.