### PR TITLE
fix(devices): validate draw_buffer stride properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,14 @@ Before releasing:
 - `vexide::startup::startup` no longer handles banner printing and no longer takes arguments. If you wish to print a banner without using `#[vexide::main]`, consider using `vexide::startup::banner::print` instead. (#313) (**Breaking Change**)
 - Symbols within the internal implementation of the patcher's `memcpy` will no longer clash with some libc compiler intrinsics. This should only matter if are linking to C libraries. (#314)
 - Fixed a signature validation problem in the original `VisionSensor`. (#319)
-- Fixed a validation issue with `Display::draw_buffer` allowing uninitialized memory to be drawn. (#323)
 
 ### Changed
 
 - Renamed `File::tell` to `File::stream_position`, made Public and Infaliable. (#314)
 
 ### Removed
+
+- Removed `stride` from `Display::draw_buffer`, fixing a buffer size validation error. If you wish to specify the stride, use `vex-sdk` directly instead. (#323) (**Breaking change**)
 
 ### New Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Before releasing:
 - `vexide::startup::startup` no longer handles banner printing and no longer takes arguments. If you wish to print a banner without using `#[vexide::main]`, consider using `vexide::startup::banner::print` instead. (#313) (**Breaking Change**)
 - Symbols within the internal implementation of the patcher's `memcpy` will no longer clash with some libc compiler intrinsics. This should only matter if are linking to C libraries. (#314)
 - Fixed a signature validation problem in the original `VisionSensor`. (#319)
+- Fixed a validation issue with `Display::draw_buffer` allowing uninitialized memory to be drawn. (#323)
 
 ### Changed
 

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -796,7 +796,7 @@ impl Display {
                 i32::from(region.end.x),
                 i32::from(region.end.y + Self::HEADER_HEIGHT),
                 raw_buf.as_mut_ptr(),
-                i32::from(region.end.x - region.start.x),
+                i32::from(region.end.x - region.start.x + 1),
             );
         }
     }

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -775,13 +775,18 @@ impl Display {
         T: IntoIterator<Item = I>,
         I: Into<Rgb<u8>>,
     {
+        // Assert a positive stride value. A negative stride might be supported
+        // as it should be (see https://learn.microsoft.com/en-us/windows/win32/medfound/image-stride)
+        // but it seems like it might not work from some preliminary testing
+        // done by @zabackary.
+        assert!(src_stride > 0, "The stride must be a positive value.");
         let mut raw_buf = buf
             .into_iter()
             .map(|i| i.into().into_raw())
             .collect::<Vec<_>>();
         // Convert the coordinates to u32 to avoid overflows when multiplying.
-        let expected_size = ((region.end.x - region.start.x) as u32
-            * (region.end.y - region.start.y) as u32) as usize;
+        let expected_size =
+            (src_stride.unsigned_abs() * (region.end.y - region.start.y) as u32) as usize;
 
         let buffer_size = raw_buf.len();
         assert_eq!(

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -764,29 +764,23 @@ impl Display {
     /// Draw a buffer of pixels to a specified region of the display.
     ///
     /// This function copies the pixels in the specified buffer to the specified region of the display.
-    /// The stride parameter is defined as the number of pixels per row.
     ///
     /// # Panics
     ///
     /// This function panics if `buf` does not have the correct number of bytes to fill the specified
     /// region.
-    pub fn draw_buffer<T, I>(&mut self, region: Rect, buf: T, src_stride: i32)
+    pub fn draw_buffer<T, I>(&mut self, region: Rect, buf: T)
     where
         T: IntoIterator<Item = I>,
         I: Into<Rgb<u8>>,
     {
-        // Assert a positive stride value. A negative stride might be supported
-        // as it should be (see https://learn.microsoft.com/en-us/windows/win32/medfound/image-stride)
-        // but it seems like it might not work from some preliminary testing
-        // done by @zabackary.
-        assert!(src_stride > 0, "The stride must be a positive value.");
         let mut raw_buf = buf
             .into_iter()
             .map(|i| i.into().into_raw())
             .collect::<Vec<_>>();
         // Convert the coordinates to u32 to avoid overflows when multiplying.
-        let expected_size =
-            (src_stride.unsigned_abs() * (region.end.y - region.start.y) as u32) as usize;
+        let expected_size = ((region.end.y - region.start.y) as u32
+            * (region.end.x - region.start.x) as u32) as usize;
 
         let buffer_size = raw_buf.len();
         assert_eq!(
@@ -802,7 +796,7 @@ impl Display {
                 i32::from(region.end.x),
                 i32::from(region.end.y + Self::HEADER_HEIGHT),
                 raw_buf.as_mut_ptr(),
-                src_stride,
+                i32::from(region.end.x - region.start.x),
             );
         }
     }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

I noticed that passing a stride value that wasn't equal to the rect size to `Display::draw_buffer` (a safe function) was dumping uninitialized memory to the screen -- technically a security bug (do I get a CVE?).

I also updated validation for src_stride to force it to be positive. However, I'm not sure whether this makes sense. It seems like the Display SDK doesn't handle it properly (?) so I just added an assert. See the pictures I sent in Discord.

## Additional Context
- I did some testing on hardware
- This shouldn't be a breaking change
