### PR TITLE
fix(devices): `AdiDigital*::is_low` shouldn't return `is_high`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Before releasing:
 - `vexide::startup::startup` no longer handles banner printing and no longer takes arguments. If you wish to print a banner without using `#[vexide::main]`, consider using `vexide::startup::banner::print` instead. (#313) (**Breaking Change**)
 - Symbols within the internal implementation of the patcher's `memcpy` will no longer clash with some libc compiler intrinsics. This should only matter if are linking to C libraries. (#314)
 - Fixed a signature validation problem in the original `VisionSensor`. (#319)
+- Fixed `AdiDigital*::is_low` improperly returning `is_high` (#324)
 
 ### Changed
 

--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -118,7 +118,7 @@ impl AdiDigitalIn {
     /// - A [`PortError::IncorrectDevice`] error is returned if an ADI expander device was required but
     ///   something else was connected.
     pub fn is_low(&self) -> Result<bool, PortError> {
-        Ok(self.level()?.is_high())
+        Ok(self.level()?.is_low())
     }
 }
 
@@ -292,7 +292,7 @@ impl AdiDigitalOut {
     /// - A [`PortError::IncorrectDevice`] error is returned if an ADI expander device was required but
     ///   something else was connected.
     pub fn is_low(&self) -> Result<bool, PortError> {
-        Ok(self.level()?.is_high())
+        Ok(self.level()?.is_low())
     }
 
     /// Set the digital logic level to [`LogicLevel::High`]. Analogous to


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This one tripped me up today. `AdiDigitalOut` and `AdiDigitalIn` both have an incorrect `is_low` implementation.

## Additional Context
- I did not test this
- Technically semver major if [xkcd 1172](https://xkcd.com/1172/) is to be believed