### PR TITLE
fix: adjust `workspace.default-members` to allow building examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ vexide = { path = "packages/vexide" }
 
 [workspace]
 members = ["packages/*"]
-default-members = ["packages/*"]
+default-members = [".", "packages/*"]
 resolver = "2"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
