### PR TITLE
fix: remove `workspace.default-members` for now

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ vexide = { path = "packages/vexide" }
 
 [workspace]
 members = ["packages/*"]
-default-members = [".", "packages/*"]
 resolver = "2"
 
 [workspace.dependencies]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Reverts #322 which broke examples and #326 which broke rust-analyzer.