### PR TITLE
refactor: rename `RotationSensor::set_computation_interval` -> `RotationSensor::set_data_interval`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Before releasing:
 ### Changed
 
 - Renamed `File::tell` to `File::stream_position`, made Public and Infaliable. (#314)
+- Renamed `RotationSensor::set_computation_interval` to `RotationSensor::set_data_interval`. (#329) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/position.rs
+++ b/packages/vexide-devices/src/position.rs
@@ -7,7 +7,7 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
 
-/// A opaque fixed-point raw angular position reading from a sensor.
+/// A opaque, fixed-point raw angular position reading from a sensor.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Position(i64);
 

--- a/packages/vexide-devices/src/smart/rotation.rs
+++ b/packages/vexide-devices/src/smart/rotation.rs
@@ -255,7 +255,7 @@ impl RotationSensor {
     ///     _ = sensor.set_data_interval(RotationSensor::MIN_DATA_INTERVAL);
     /// }
     /// ```
-    pub fn set_computation_interval(&mut self, interval: Duration) -> Result<(), PortError> {
+    pub fn set_data_interval(&mut self, interval: Duration) -> Result<(), PortError> {
         self.validate_port()?;
 
         let mut time_ms = interval


### PR DESCRIPTION
Matches the method name of other sensors.

## Describe the changes this PR makes. Why should it be merged?

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
