### PR TITLE
refactor: consistent derives for error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Before releasing:
 
 ### Added
 
+- Added several missing derived trait implementations for many device error types. (#331)
+
 ### Fixed
 
 - Fixed an issue with `Metadata::len` using the wrong condition. (#314)

--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -193,7 +193,7 @@ impl smart_leds_trait::SmartLedsWrite for AdiAddrLed {
 }
 
 /// Errors that can occur when interacting with an [`AdiAddrLed`] strip.
-#[derive(Debug, Snafu)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum AddrLedError {
     /// The provided index was not in range of the current buffer's length.
     #[snafu(display("Index `{index}` is out of range for buffer of length `{length}`"))]

--- a/packages/vexide-devices/src/adi/gyroscope.rs
+++ b/packages/vexide-devices/src/adi/gyroscope.rs
@@ -213,7 +213,7 @@ impl AdiDevice<1> for AdiGyroscope {
 }
 
 /// Errors that can occur when interacting with an [`AdiGyroscope`].
-#[derive(Debug, Snafu)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum AdiGyroscopeError {
     /// Generic ADI related error.
     #[snafu(transparent)]

--- a/packages/vexide-devices/src/adi/motor.rs
+++ b/packages/vexide-devices/src/adi/motor.rs
@@ -24,7 +24,7 @@
 //!
 //! [Motor Controller 29]: https://www.vexrobotics.com/276-2193.html
 //! [Motor 393]: https://www.vexrobotics.com/393-motors.html
-//! [Smart Motors]: crate::smart::motor
+//! [Smart Motor]: crate::smart::motor
 
 use vex_sdk::{vexDeviceAdiValueGet, vexDeviceAdiValueSet};
 

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -270,7 +270,7 @@ impl Future for ControllerScreenWriteFuture<'_> {
         }
 
         if let ControllerScreenWriteFutureState::Complete { result } = state {
-            Poll::Ready(result.clone())
+            Poll::Ready(*result)
         } else {
             Poll::Pending
         }

--- a/packages/vexide-devices/src/controller.rs
+++ b/packages/vexide-devices/src/controller.rs
@@ -988,7 +988,7 @@ impl Controller {
 }
 
 /// Errors that can occur when interacting with the controller.
-#[derive(Clone, Debug, Snafu)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Snafu)]
 pub enum ControllerError {
     /// The controller is not connected to the Brain.
     Offline,

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -823,7 +823,7 @@ impl Display {
 }
 
 /// An error that occurs when a negative or non-finite font size is attempted to be created.
-#[derive(Debug, Clone, Copy, Snafu)]
+#[derive(Debug, Clone, Copy, PartialEq, Snafu)]
 #[snafu(display("Attempted to create a font size with a negative/non-finite value ({value})."))]
 pub struct InvalidFontSizeError {
     /// The negative value that was attempted to be used as a font size.

--- a/packages/vexide-devices/src/lib.rs
+++ b/packages/vexide-devices/src/lib.rs
@@ -56,8 +56,8 @@ use smart::SmartDeviceType;
 use snafu::Snafu;
 use vexide_core::io;
 
-#[derive(Debug, Snafu)]
 /// Generic errors that can take place when using ports on the V5 Brain.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum PortError {
     /// No device is plugged into the port.
     #[snafu(display("Expected a device to be connected to port {port}"))]

--- a/packages/vexide-devices/src/smart/ai_vision.rs
+++ b/packages/vexide-devices/src/smart/ai_vision.rs
@@ -1012,8 +1012,8 @@ impl From<AiVisionSensor> for SmartPort {
     }
 }
 
-#[derive(Debug, Snafu)]
 /// Errors that can occur when using a vision sensor.
+#[derive(Debug, Clone, Eq, PartialEq, Snafu)]
 pub enum AiVisionError {
     /// An object created by VEXos failed to be converted.
     InvalidObject,

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -235,7 +235,7 @@ pub struct DistanceObject {
 }
 
 /// Errors that can occur when using a distance sensor.
-#[derive(Debug, Snafu)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum DistanceError {
     /// The sensor's status code is 0x00
     /// Need to wait for the sensor to finish initializing

--- a/packages/vexide-devices/src/smart/imu.rs
+++ b/packages/vexide-devices/src/smart/imu.rs
@@ -1048,7 +1048,7 @@ impl core::future::Future for InertialCalibrateFuture<'_> {
 }
 
 /// Errors that can occur when interacting with an Inertial Sensor.
-#[derive(Debug, Snafu)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum InertialError {
     /// The sensor took longer than three seconds to calibrate.
     CalibrationTimedOut,

--- a/packages/vexide-devices/src/smart/link.rs
+++ b/packages/vexide-devices/src/smart/link.rs
@@ -322,7 +322,7 @@ pub enum LinkType {
 }
 
 /// Errors that can occur when interacting with a [`RadioLink`].
-#[derive(Debug, Snafu)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum LinkError {
     /// Not linked with another radio.
     NotLinked,

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -1679,8 +1679,8 @@ impl From<MotorTuningConstants> for V5_DeviceMotorPid {
     }
 }
 
-#[derive(Debug, Snafu)]
 /// Errors that can occur when using a motor.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum MotorError {
     /// Failed to communicate with the motor while attempting to read flags.
     Busy,

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -371,7 +371,7 @@ impl From<SerialPort> for SmartPort {
 }
 
 /// Errors that can occur when interacting with a [`SerialPort`].
-#[derive(Debug, Snafu)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum SerialError {
     /// Internal write error occurred.
     WriteFailed,

--- a/packages/vexide-devices/src/smart/vision.rs
+++ b/packages/vexide-devices/src/smart/vision.rs
@@ -1381,8 +1381,8 @@ impl From<LedMode> for V5VisionLedMode {
     }
 }
 
-#[derive(Debug, Snafu)]
 /// Errors that can occur when using a vision sensor.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]
 pub enum VisionError {
     /// Objects cannot be detected while Wi-Fi mode is enabled.
     WifiMode,


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Derives `#[derive(Debug, Clone, Copy, Eq, PartialEq, Snafu)]` for all error enums where possible. Closes #330