### PR TITLE
fix(boot): replace patch magic with named constant

### DIFF
--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -67,6 +67,7 @@ mod patcher;
 use core::arch::naked_asm;
 
 pub use code_signature::{CodeSignature, ProgramFlags, ProgramOwner, ProgramType};
+use patcher::PATCH_MAGIC;
 
 /// Load address of user programs in memory.
 const USER_MEMORY_START: u32 = 0x0380_0000;
@@ -124,7 +125,7 @@ unsafe extern "C" fn _boot() {
         // header value of 0xB1DF.
         "ldr r0, =__patcher_patch_start",
         "ldr r0, [r0]",
-        "ldr r1, =0x1BDF",
+        "ldr r1, ={patch_magic}",
         "cmp r0, r1", // r0 == 0xB1DF?
         // Prepare to memcpy binary to 0x07C00000
         "ldr r0, =__patcher_base_start",     // memcpy dest -> r0
@@ -135,6 +136,7 @@ unsafe extern "C" fn _boot() {
         "bleq __overwriter_aeabi_memcpy",
         // Jump to the Rust entrypoint.
         "b _start",
+        patch_magic = const PATCH_MAGIC,
     )
 }
 

--- a/packages/vexide-startup/src/patcher/mod.rs
+++ b/packages/vexide-startup/src/patcher/mod.rs
@@ -3,6 +3,9 @@ use vexide_core::io::{Cursor, Read, Seek, SeekFrom};
 
 mod varint_decode;
 
+/// First four bytes of a patch file.
+pub const PATCH_MAGIC: u32 = 0xB1DF;
+
 // Assembly implementation of the patch overwriter (`__patcher_overwrite`).
 //
 // The overwriter is responsible for self-modifying the currently running code
@@ -102,10 +105,8 @@ enum PatcherState {
 /// The caller must ensure that the patch loaded at 0x07A00000 has been built using the currently running
 /// binary as the basis for the patch.
 pub(crate) unsafe fn patch() {
-    // First four bytes of the patch file MUST be 0xB1DF for the patch to be applied.
-    const PATCH_MAGIC: u32 = 0xB1DF;
-
-    // Next four bytes of the patch have to match this version identifier for the patch to be applied.
+    // The first four bytes after the patch magic have to match this version identifier for the
+    // patch to be applied.
     const PATCH_VERSION: u32 = 0x1000;
 
     /// Load address of patch files.


### PR DESCRIPTION
Fixes the patch magic check in `vexide_startup::_boot` from 0x1BDF to its correct value, 0xB1DF, using a named constant within the inline assembly.