### PR TITLE
fix: remove unused argument from `Display::erase`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Before releasing:
 - Symbols within the internal implementation of the patcher's `memcpy` will no longer clash with some libc compiler intrinsics. This should only matter if are linking to C libraries. (#314)
 - Fixed a signature validation problem in the original `VisionSensor`. (#319)
 - Fixed `AdiDigital*::is_low` improperly returning `is_high` (#324)
+- `Display::erase` now functions as expected instead of using the program flags' background color. (#350)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Before releasing:
 - Symbols within the internal implementation of the patcher's `memcpy` will no longer clash with some libc compiler intrinsics. This should only matter if are linking to C libraries. (#314)
 - Fixed a signature validation problem in the original `VisionSensor`. (#319)
 - Fixed `AdiDigital*::is_low` improperly returning `is_high` (#324)
+- `Display::erase` now functions as expected instead of using the program flags' background color. (#350)
 
 ### Changed
 
@@ -145,7 +146,7 @@ Before releasing:
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
 - Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275, #279)
-- Recursive panics (panics that occur *within* `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
+- Recursive panics (panics that occur _within_ `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
 
 ### Changed
 
@@ -367,8 +368,8 @@ Before releasing:
 ### Added
 
 - The startup banner and code signature may now be configured using parameters passed to `vexide::main`. (#102)
-- Added the ``ProgramOwner``, ``ProgramType``, and ``ProgramFlags`` types for code signature configuration. (#76)
-- Created new ``force_rust_libm`` feature to force the use of a slower, 100% Rust, libm implementation. This is useful for building on WASM. (#106)
+- Added the `ProgramOwner`, `ProgramType`, and `ProgramFlags` types for code signature configuration. (#76)
+- Created new `force_rust_libm` feature to force the use of a slower, 100% Rust, libm implementation. This is useful for building on WASM. (#106)
 - Optimized floating point math operations available through the `Float` extension trait. (#77)
 - Added text metrics getters to the `Text` widget. (#83)
 - Added alignment support for the `Text` widget. (#85)
@@ -383,11 +384,11 @@ Before releasing:
 
 ### Changed
 
-- Updated ``vex-sdk`` to version 0.17.0. (#76)
-- Renamed ``ColdHeader`` to ``CodeSignature``. (#76) (**Breaking Change**)
-- Renamed the entrypoint symbol from ``_entry`` to ``_start``. (#76) (**Breaking Change**)
-- Renamed ``__stack_start`` and ``__stack_end`` symbols to ``__stack_top`` and ``__stack_bottom`` respectively. (#76) (**Breaking Change**)
-- Renamed the ``.cold_magic`` section to ``.code_signature``. (#76) (**Breaking Change**)
+- Updated `vex-sdk` to version 0.17.0. (#76)
+- Renamed `ColdHeader` to `CodeSignature`. (#76) (**Breaking Change**)
+- Renamed the entrypoint symbol from `_entry` to `_start`. (#76) (**Breaking Change**)
+- Renamed `__stack_start` and `__stack_end` symbols to `__stack_top` and `__stack_bottom` respectively. (#76) (**Breaking Change**)
+- Renamed the `.cold_magic` section to `.code_signature`. (#76) (**Breaking Change**)
 - Made fields on screen widgets public. (#81)
 - Renamed `Competition` to `CompetitionRuntime`, `CompetitionRobotExt` to `CompetitionExt`, and `CompetitionRobot` to `Competition`. (#87) (**Breaking Change**)
 - Removed the `Error` associated type from the `Competition` trait and made all methods infallible. (#87) (**Breaking Change**)
@@ -395,7 +396,7 @@ Before releasing:
 ### Removed
 
 - The `no-banner` feature has been removed from `vexide-startup` and must now be toggled through the `vexide:main` attribute. (#102) (**Breaking Change**)
-- Removed the useless ``__rodata_start`` and ``__rodata_end`` symbols.
+- Removed the useless `__rodata_start` and `__rodata_end` symbols.
 - Support for `vexide-math` has been dropped. (#78) (**Breaking Change**)
 - Removed the `vexide-graphics` crate and associated features (containing embedded-graphics and slint drivers) from the main vexide crate due to licensing concerns. These drivers will be available as crates licensed separately from the main `vexide` project. (#297) (**Breaking Change**)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@ Before releasing:
 - Symbols within the internal implementation of the patcher's `memcpy` will no longer clash with some libc compiler intrinsics. This should only matter if are linking to C libraries. (#314)
 - Fixed a signature validation problem in the original `VisionSensor`. (#319)
 - Fixed `AdiDigital*::is_low` improperly returning `is_high` (#324)
-- `Display::erase` now functions as expected instead of using the program flags' background color. (#350)
 
 ### Changed
 
@@ -146,7 +145,7 @@ Before releasing:
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
 - Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275, #279)
-- Recursive panics (panics that occur _within_ `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
+- Recursive panics (panics that occur *within* `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
 
 ### Changed
 
@@ -368,8 +367,8 @@ Before releasing:
 ### Added
 
 - The startup banner and code signature may now be configured using parameters passed to `vexide::main`. (#102)
-- Added the `ProgramOwner`, `ProgramType`, and `ProgramFlags` types for code signature configuration. (#76)
-- Created new `force_rust_libm` feature to force the use of a slower, 100% Rust, libm implementation. This is useful for building on WASM. (#106)
+- Added the ``ProgramOwner``, ``ProgramType``, and ``ProgramFlags`` types for code signature configuration. (#76)
+- Created new ``force_rust_libm`` feature to force the use of a slower, 100% Rust, libm implementation. This is useful for building on WASM. (#106)
 - Optimized floating point math operations available through the `Float` extension trait. (#77)
 - Added text metrics getters to the `Text` widget. (#83)
 - Added alignment support for the `Text` widget. (#85)
@@ -384,11 +383,11 @@ Before releasing:
 
 ### Changed
 
-- Updated `vex-sdk` to version 0.17.0. (#76)
-- Renamed `ColdHeader` to `CodeSignature`. (#76) (**Breaking Change**)
-- Renamed the entrypoint symbol from `_entry` to `_start`. (#76) (**Breaking Change**)
-- Renamed `__stack_start` and `__stack_end` symbols to `__stack_top` and `__stack_bottom` respectively. (#76) (**Breaking Change**)
-- Renamed the `.cold_magic` section to `.code_signature`. (#76) (**Breaking Change**)
+- Updated ``vex-sdk`` to version 0.17.0. (#76)
+- Renamed ``ColdHeader`` to ``CodeSignature``. (#76) (**Breaking Change**)
+- Renamed the entrypoint symbol from ``_entry`` to ``_start``. (#76) (**Breaking Change**)
+- Renamed ``__stack_start`` and ``__stack_end`` symbols to ``__stack_top`` and ``__stack_bottom`` respectively. (#76) (**Breaking Change**)
+- Renamed the ``.cold_magic`` section to ``.code_signature``. (#76) (**Breaking Change**)
 - Made fields on screen widgets public. (#81)
 - Renamed `Competition` to `CompetitionRuntime`, `CompetitionRobotExt` to `CompetitionExt`, and `CompetitionRobot` to `Competition`. (#87) (**Breaking Change**)
 - Removed the `Error` associated type from the `Competition` trait and made all methods infallible. (#87) (**Breaking Change**)
@@ -396,7 +395,7 @@ Before releasing:
 ### Removed
 
 - The `no-banner` feature has been removed from `vexide-startup` and must now be toggled through the `vexide:main` attribute. (#102) (**Breaking Change**)
-- Removed the useless `__rodata_start` and `__rodata_end` symbols.
+- Removed the useless ``__rodata_start`` and ``__rodata_end`` symbols.
 - Support for `vexide-math` has been dropped. (#78) (**Breaking Change**)
 - Removed the `vexide-graphics` crate and associated features (containing embedded-graphics and slint drivers) from the main vexide crate due to licensing concerns. These drivers will be available as crates licensed separately from the main `vexide` project. (#297) (**Breaking Change**)
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR ~~removes the unused color argument from `Display::erase` and documents the fact that the SDK uses the default background color instead.~~ fixes `Display::erase` to work as expected. It now fills a rectangle normally instead of using `vexDisplayErase` which does not take a background color.

## Additional Context
- Not tested on a brain. _(edit: still not tested; I don't have hardware access until late October)_
- semver: ~~major~~ [patch](https://xkcd.com/1172/)
- ~~function argument removed~~

Fixes #349.