### PR TITLE
fix: fix CI and new install dependency resolution failures

### DIFF
--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -31,7 +31,7 @@ replace_with = { version = "0.1.7", default-features = false }
 libm = { version = "0.2.8", optional = true }
 
 [target.'cfg(target_vendor = "vex")'.dependencies]
-vex-libunwind = { version = "0.1.0", git = "https://github.com/vexide/vex-libunwind.git", optional = true }
+vex-libunwind = { version = "0.1.0", git = "https://github.com/vexide/vex-libunwind.git", tag = "v0.1.0", optional = true }
 
 [target.'cfg(not(target_vendor = "vex"))'.dependencies]
 libm = "0.2.8"

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -20,7 +20,7 @@ authors = [
 vex-sdk = { workspace = true }
 no_std_io = { version = "0.6.0", features = ["alloc"] }
 snafu = { workspace = true }
-talc = {  version = "4.3.1", optional = true }
+talc = { version = "4.3.1", optional = true }
 lock_api = "0.4.11"
 bitflags = "2.4.2"
 futures-core = { version = "0.3.30", default-features = false, features = [


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

I tried to fix CI and new (uncached) installs by pinning vex-libunwind to a specific tag since v0.1.0 does not exist in the main branch anymore since [`4739942`](https://github.com/vexide/vex-libunwind/commit/4739942191b481231fb0dd4b78a939e00b8e0e08).

Long-term, it seemed like vex-libunwind was going to be maintained on crates.io, so this is a stopgap fix.

## Additional Context
_Not really?_
