### PR TITLE
refactor(patcher): split out into separate linker script

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [build]
 target = "./armv7a-vex-v5.json"
+rustflags = ["-Clink-arg=-Tv5_diff.ld"]
 
 [target."cfg(target_vendor = \"vex\")"]
 runner = "cargo v5 run --file"

--- a/packages/vexide-macro/src/lib.rs
+++ b/packages/vexide-macro/src/lib.rs
@@ -182,11 +182,11 @@ pub fn main(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let opts = MacroOpts::from(parse_macro_input!(attrs as Attrs));
 
     let entrypoint = make_entrypoint(&item, opts.clone());
-    let code_signature = make_code_sig(opts);
+    // let code_signature = make_code_sig(opts);
 
     quote! {
         const _: () = {
-            #code_signature
+            // #code_signature
 
             #entrypoint
         };

--- a/packages/vexide-startup/link/v5.ld
+++ b/packages/vexide-startup/link/v5.ld
@@ -1,98 +1,79 @@
 OUTPUT_FORMAT("elf32-littlearm")
-
-/*
- * _boot is an assembly routine defined in src/lib.rs that sets
- * up the stack pointer before jumping to _start (Rust entrypoint).
- */
 ENTRY(_boot)
 
-__program_ram_start = 0x03800000;
-__program_ram_length = 0x04200000; /* This is actually 0x04800000, but we don't want the stack colliding with the patch. */
-__program_ram_end = __program_ram_start + __program_ram_length;
+/*
+ * PROVIDE() is used here so that users can override default values.
+ * This is intended to give developers the option to use this Rust
+ * target even if the default values in this linker script aren't
+ * suitable for their needs.
+ *
+ * For example: `-C link-arg=--defsym=__stack_length=8M` could
+ * be used to increase the stack size above the value set in this
+ * file.
+ */
 
-__patcher_ram_start = 0x07A00000;
-__patcher_ram_length = 0x600000; /* 6mb total, 2mb for each subsection. */
-__patcher_ram_end = __patcher_ram_start + __patcher_ram_length; /* End of CPU1 RWX memory block. */
-__patcher_section_length = 0x200000;
+PROVIDE(__vcodesig_magic = 0x35585658);     /* XVX5                 */
+PROVIDE(__vcodesig_type = 0);               /* V5_SIG_TYPE_USER     */
+PROVIDE(__vcodesig_owner = 2);              /* V5_SIG_OWNER_PARTNER */
+PROVIDE(__vcodesig_options = 0);            /* none (0)             */
 
-__code_signature_length = 0x20;
+__user_ram_start = 0x03800000;
+__user_ram_end   = 0x08000000;
+/* (0x48 =) 72 MiB length */
+__user_ram_length = __user_ram_start - __user_ram_end;
 
-__stack_length = 0x400000;
-__heap_end = __program_ram_end - __stack_length;
-__program_length = __heap_start - __program_ram_start;
+/*
+ * VEXos provides a method for pre-loading a "linked file" at a specified
+ * address in User RAM, conventionally near the end, after the primary
+ * program binary. We need to be sure not to place any data in that location,
+ * so we allow the user of this linker script to inform the start address of
+ * this blob.
+ */
+PROVIDE(__linked_file_start = __user_ram_end);
+PROVIDE(__linked_file_end = __user_ram_end);
 
-/* see https://github.com/llvm/llvm-project/blob/main/libunwind/src/AddressSpace.hpp#L78 */
-__eh_frame_hdr_start = SIZEOF(.eh_frame_hdr) > 0 ? ADDR(.eh_frame_hdr) : 0;
-__eh_frame_hdr_end = SIZEOF(.eh_frame_hdr) > 0 ? . : 0;
+PROVIDE(__stack_length = 4M);
+PROVIDE(__stack_top = __linked_file_start);
+PROVIDE(__stack_bottom = __linked_file_start - __stack_length);
 
 MEMORY {
-    /*
-     * Memory available for (initial) use by the user program.
-     *
-     * This is technically all the way from 0x03800000-0x8000000, but we reserve
-     * the last 6mb for the patcher, which is later reclaimed as heap space.
-     */
-    PROGRAM_RAM (RWX) : ORIGIN = __program_ram_start, LENGTH = __program_ram_length
-
-    /*
-     * Memory reserved for the patcher.
-     *
-     * We reserve last 6mb of the CPU1 RWX region for storing data relating to patch
-     * uploading. This region is further split into three 2mb "subsections":
-     *
-     * - The first 2mb are where the actual patch itself is loaded to.
-     * - The next 2mb is a buffer where the running user program is copied to, which
-     *   will serve as a reference for building the patched binary. We can't use active
-     *   memory to do this, since statics and unwind tables will be written to at runtime,
-     *   messing with the patch.
-     * - The final 2mb is where the new patched binary will be constructed and eventually
-     *   memcpy'd back to __program_ram_start.
-     *
-     * Following the patch process (or if we don't need to patch), this entire region is
-     * claimed as heap space.
-     */
-    PATCHER_RAM (RWX) : ORIGIN = __patcher_ram_start, LENGTH = __patcher_ram_length
+    USER_RAM (RWX) : ORIGIN = __user_ram_start, LENGTH = __user_ram_length
 }
 
 SECTIONS {
     /*
-     * VEXos expects program binaries to have a 32-byte header called a "code signature",
-     * at their start, which tells the OS that we are a valid program and configures some
+     * VEXos expects program binaries to have a 32-byte header called a "code signature"
+     * at their start which tells the OS that we are a valid program and configures some
      * miscellaneous startup behavior.
      */
     .code_signature : {
-        KEEP(*(.code_signature))
-        . = __program_ram_start + __code_signature_length;
-    } > PROGRAM_RAM
+        LONG(__vcodesig_magic)
+        LONG(__vcodesig_type)
+        LONG(__vcodesig_owner)
+        LONG(__vcodesig_options)
+
+        FILL(0)
+        . = __user_ram_start + 0x20;
+    } > USER_RAM
 
     /*
      * Executable program instructions.
      */
     .text : {
-        /* _boot routine (always runs first, must be at 0x03800020) */
+        /* _boot routine (entry point from VEXos, must be at 0x03800020) */
         *(.boot)
-        /* Stage 2 patcher. */
-        *(.overwriter)
-        /* Rest of the program. */
+
+        /* The rest of the program. */
         *(.text .text.*)
-    } > PROGRAM_RAM
+    } > USER_RAM
 
     /*
      * Global/uninitialized/static/constant data sections.
      */
     .rodata : {
-        *(.rodata .rodata.*)
-    } > PROGRAM_RAM
-
-    .data : {
-        *(.data .data.*)
-    } > PROGRAM_RAM
-
-    .bss : {
-        __bss_start = .;
-        *(.bss .bss.*)
-        __bss_end = .;
-    } > PROGRAM_RAM
+        *(.rodata .rodata1 .rodata.*)
+        *(.srodata .srodata.*)
+    } > USER_RAM
 
     /*
      * Task-local data
@@ -101,7 +82,7 @@ SECTIONS {
         __vexide_tdata_start = .;
         *(.vexide_tdata .vexide_tdata.*)
         __vexide_tdata_end = .;
-    } > PROGRAM_RAM
+    } > USER_RAM
 
     /*
      * ARM Stack Unwinding Sections
@@ -109,64 +90,68 @@ SECTIONS {
      * These sections are added by the compiler in some cases to facilitate stack unwinding.
      * __eh_frame_start and similar symbols are used by libunwind.
      */
+
+    .except_ordered : {
+        PROVIDE(__extab_start = .);
+        *(.gcc_except_table *.gcc_except_table.*)
+        *(.ARM.extab*)
+        PROVIDE(__extab_end = .);
+    } > USER_RAM
+
     .eh_frame_hdr : {
+        /* see https://github.com/llvm/llvm-project/blob/main/libunwind/src/AddressSpace.hpp#L78 */
+        PROVIDE(__eh_frame_hdr_start = .);
         KEEP(*(.eh_frame_hdr))
-    } > PROGRAM_RAM
+        PROVIDE(__eh_frame_hdr_end = .);
+    } > USER_RAM
 
     .eh_frame : {
-        __eh_frame_start = .;
-       KEEP(*(.eh_frame))
-        __eh_frame_end = .;
-    } > PROGRAM_RAM
+        PROVIDE(__eh_frame_start = .);
+        KEEP(*(.eh_frame))
+        PROVIDE(__eh_frame_end = .);
+    } > USER_RAM
 
-    .ARM.exidx : {
-        __exidx_start = .;
+    .except_unordered : {
+        PROVIDE(__exidx_start = .);
         *(.ARM.exidx*)
-        __exidx_end = .;
-    } > PROGRAM_RAM
+        PROVIDE(__exidx_end = .);
+    } > USER_RAM
 
-    .ARM.extab : {
-        __extab_start = .;
-        *(.ARM.extab*)
-        __extab_end = .;
-    } > PROGRAM_RAM
+    /* -- Data intended to be mutable at runtime begins here. -- */
 
-    /* -- End of loadable sections - anything beyond this point shouldn't go in the BIN. -- */
+    .data : {
+        *(.data .data1 .data.*)
+        *(.sdata .sdata.* .sdata2.*)
+    } > USER_RAM
+
+    /* -- End of loadable sections - anything beyond this point shouldn't go in the binary uploaded to the device. -- */
+
+    .bss (NOLOAD) : {
+        __bss_start = .;
+        *(.sbss*)
+        *(.bss .bss.*)
+
+        /* Align the heap */
+        . = ALIGN(8);
+        __bss_end = .;
+    } > USER_RAM
 
     /*
      * Active memory sections for the stack/heap.
      *
      * Because these are (NOLOAD), they will not influence the final size of the binary.
      */
-    .heap (NOLOAD) : ALIGN(4) {
+    .heap (NOLOAD) : {
         __heap_start = .;
-        . = __heap_end;
-    } > PROGRAM_RAM
+        . = __stack_bottom;
+        __heap_end = .;
+    } > USER_RAM
 
     .stack (NOLOAD) : ALIGN(8) {
         __stack_bottom = .;
         . += __stack_length;
         __stack_top = .;
-    } > PROGRAM_RAM
-
-    /* Patcher Memory */
-    .patcher_patch (NOLOAD) : {
-        __patcher_patch_start = .;
-        . += __patcher_section_length;
-        __patcher_patch_end = .;
-    } > PATCHER_RAM
-
-    .patcher_base_copy (NOLOAD) : {
-        __patcher_base_start = .;
-        . += __patcher_section_length;
-        __patcher_base_end = .;
-    } > PATCHER_RAM
-
-    .patcher_new (NOLOAD) : {
-        __patcher_new_start = .;
-        . += __patcher_section_length;
-        __patcher_new_end = .;
-    } > PATCHER_RAM
+    } > USER_RAM
 
     /*
      * `.ARM.attributes` contains arch metadata for compatibility purposes, but we

--- a/packages/vexide-startup/link/v5_diff.ld
+++ b/packages/vexide-startup/link/v5_diff.ld
@@ -1,0 +1,26 @@
+/* Applying this linker script will reserve space at the end of user memory for differential uploading. */
+
+__patcher_section_length = 2M;
+/* 6MiB total, 2MiB for each subsection. (start = 0x07a00000) */
+__linked_file_start = __linked_file_end - (__patcher_section_length * 3);
+
+SECTIONS {
+    /* Patcher Memory */
+    .patcher_patch (NOLOAD) : {
+        __patcher_patch_start = .;
+        . += __patcher_section_length;
+        __patcher_patch_end = .;
+    } > USER_RAM
+
+    .patcher_base_copy (NOLOAD) : {
+        __patcher_base_start = .;
+        . += __patcher_section_length;
+        __patcher_base_end = .;
+    } > USER_RAM
+
+    .patcher_new (NOLOAD) : {
+        __patcher_new_start = .;
+        . += __patcher_section_length;
+        __patcher_new_end = .;
+    } > USER_RAM
+} INSERT AFTER .stack;

--- a/packages/vexide-startup/link/v5_diff.ld
+++ b/packages/vexide-startup/link/v5_diff.ld
@@ -4,6 +4,21 @@ __patcher_section_length = 2M;
 /* 6MiB total, 2MiB for each subsection. (start = 0x07a00000) */
 __linked_file_start = __linked_file_end - (__patcher_section_length * 3);
 
+OVERWRITE_SECTIONS {
+    /* Ensure .overwriter is placed after .boot but before .text */
+
+    .text : {
+        /* _boot routine (entry point from VEXos, must be at 0x03800020) */
+        *(.boot)
+
+        /* Stage 2 patcher. */
+        *(.overwriter)
+
+        /* The rest of the program. */
+        *(.text .text.*)
+    } > USER_RAM
+}
+
 SECTIONS {
     /* Patcher Memory */
     .patcher_patch (NOLOAD) : {

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -81,8 +81,8 @@ unsafe extern "C" {
     static mut __heap_start: u8;
     static mut __heap_end: u8;
 
-    static mut __patcher_ram_start: u8;
-    static mut __patcher_ram_end: u8;
+    static mut __linked_file_start: u8;
+    static mut __linked_file_end: u8;
 
     static mut __bss_start: u32;
     static mut __bss_end: u32;
@@ -129,7 +129,7 @@ unsafe extern "C" fn _boot() {
         "cmp r0, r1", // r0 == 0xB1DF?
         // Prepare to memcpy binary to 0x07C00000
         "ldr r0, =__patcher_base_start",     // memcpy dest -> r0
-        "ldr r1, =__program_ram_start",      // memcpy src -> r1
+        "ldr r1, =__user_ram_start",         // memcpy src -> r1
         "ldr r2, =__patcher_patch_start+12", // Base binary len is stored as metadata in the patch
         "ldr r2, [r2]",                      // memcpy size -> r2
         // Do the memcpy if patch magic is present (we checked this in our `cmp` instruction).
@@ -182,6 +182,6 @@ pub unsafe fn startup() {
 
         // Reclaim 6mb memory region occupied by patches and program copies as heap space.
         #[cfg(feature = "allocator")]
-        vexide_core::allocator::claim(&raw mut __patcher_ram_start, &raw mut __patcher_ram_end);
+        vexide_core::allocator::claim(&raw mut __linked_file_start, &raw mut __linked_file_end);
     }
 }

--- a/packages/vexide-startup/src/patcher/overwriter.S
+++ b/packages/vexide-startup/src/patcher/overwriter.S
@@ -6,7 +6,7 @@ __patcher_overwrite:
     cpsid i @ Mask interrupts
 
     @ Execute memcpy to copy our patched program at 0x07E00000 onto active memory.
-    ldr r0, =__program_ram_start      @ memcpy dest -> r0
+    ldr r0, =__user_ram_start         @ memcpy dest -> r0
     ldr r1, =__patcher_new_start      @ memcpy src -> r1
     ldr r2, =__patcher_patch_start+16 @ New binary len is stored as metadata in the patch
     ldr r2, [r2]                      @ memcpy size -> r2
@@ -14,7 +14,7 @@ __patcher_overwrite:
 
     @ Clean L1 data cache in the user memory range
     @ NOTE: 0x03800000 is already aligned to cache line size (32), so no work there.
-    ldr r1, =__patcher_ram_end @ End address of RWX user memory
+    ldr r1, =__user_ram_end @ End address of RWX user memory
 dcache_clean_range:
     mcr p15, 0, r0, c7, c11, 1 @ Clean and invalidate D-cache line by MVA (DCCMVAU)
     add r0, #32                @ Move to the next cache line


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR splits out the patcher sections into a separate linker script so that there are less vexide-specific in the primary v5.ld script. This is part of an effort to gain compatibility with Rust's builtin armv7a-vex-v5 target.

These are breaking changes because switching to a modified version of the builtin Rust linker script has removed the capability to configure the code signature directly from source code.

Resolves #353 

## Additional Context

- I have tested these changes on a VEX V5 Brain.
- These are breaking changes (semver: major).
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
