### PR TITLE
feat(patcher): allow patcher code to be compiled out when using monolith uploads

### DIFF
--- a/packages/vexide-startup/build.rs
+++ b/packages/vexide-startup/build.rs
@@ -1,6 +1,15 @@
 #![allow(missing_docs)]
 
+use std::env;
+
 fn main() {
+    println!(r#"cargo::rustc-check-cfg=cfg(vexide_upload_strategy, values("monolith", "differential"))"#);
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let upload_strategy = env::var("CARGO_CFG_VEXIDE_UPLOAD_STRATEGY").unwrap_or("differential".into());
+    match upload_strategy.as_str() {
+        "differential" => {}, // Link script needs no overriding for differential uploads
+        "monolith" => println!("cargo:rustc-link-arg=--defsym=__patcher_section_length=0"),
+        value => panic!(r#"Unknown value "{value}" for vexide_upload_strategy! Valid values are "differential" and "monolith""#)
+    };
     println!("cargo:rustc-link-search=native={manifest_dir}/link");
 }

--- a/packages/vexide-startup/link/vexide.ld
+++ b/packages/vexide-startup/link/vexide.ld
@@ -1,6 +1,6 @@
 /* This file contains vexide-specific memory layout options */
 
-__patcher_section_length = 2M;
+PROVIDE(__patcher_section_length = 2M);
 /* 6MiB total, 2MiB for each subsection. (start = 0x07a00000) */
 __linked_file_start = __linked_file_end - (__patcher_section_length * 3);
 

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -69,6 +69,7 @@ use core::arch::naked_asm;
 pub use code_signature::{CodeSignature, ProgramFlags, ProgramOwner, ProgramType};
 use patcher::PATCH_MAGIC;
 
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 /// Load address of user programs in memory.
 const USER_MEMORY_START: u32 = 0x0380_0000;
 
@@ -176,6 +177,7 @@ pub unsafe fn startup() {
 
         // If this link address is 0x03800000, this implies we were uploaded using
         // differential uploads by cargo-v5 and may have a patch to apply.
+        #[cfg(not(vexide_upload_strategy = "monolith"))]
         if vex_sdk::vexSystemLinkAddrGet() == USER_MEMORY_START {
             patcher::patch();
         }

--- a/packages/vexide-startup/src/patcher/mod.rs
+++ b/packages/vexide-startup/src/patcher/mod.rs
@@ -1,6 +1,9 @@
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 use varint_decode::VarIntReader;
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 use vexide_core::io::{Cursor, Read, Seek, SeekFrom};
 
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 mod varint_decode;
 
 /// First four bytes of a patch file.
@@ -12,7 +15,9 @@ pub const PATCH_MAGIC: u32 = 0xB1DF;
 // in memory with the new version built at 0x07E00000 by the first patcher stage.
 //
 // In other words, this code is responsible for actually "applying" the patch.
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 core::arch::global_asm!(include_str!("./overwriter_aeabi_memcpy.S"));
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 core::arch::global_asm!(include_str!("./overwriter.S"));
 
 // Linkerscript Symbols
@@ -24,14 +29,6 @@ unsafe extern "C" {
     static mut __patcher_patch_start: u32;
     static mut __patcher_base_start: u32;
     static mut __patcher_new_start: u32;
-}
-
-/// Internal patcher state representing what the patcher is attempting to do.
-#[derive(Debug)]
-enum PatcherState {
-    Initial,
-    Add(usize),
-    Copy(usize),
 }
 
 /// Differential Upload Patcher
@@ -104,6 +101,7 @@ enum PatcherState {
 ///
 /// The caller must ensure that the patch loaded at 0x07A00000 has been built using the currently running
 /// binary as the basis for the patch.
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 pub(crate) unsafe fn patch() {
     // The first four bytes after the patch magic have to match this version identifier for the
     // patch to be applied.
@@ -168,7 +166,16 @@ pub(crate) unsafe fn patch() {
 ///
 /// This is essentially a port of <https://github.com/divvun/bidiff/blob/main/crates/bipatch/src/lib.rs>
 // NOTE: LLVM should always inline this function since it's only called once.
+#[cfg(not(vexide_upload_strategy = "monolith"))]
 fn bipatch<B: Read + Seek, P: Read>(mut old: B, mut patch: P, mut new: &mut [u8]) {
+    /// Internal patcher state representing what the patcher is attempting to do.
+    #[derive(Debug)]
+    enum PatcherState {
+        Initial,
+        Add(usize),
+        Copy(usize),
+    }
+    
     let mut buf = [0u8; 4096];
     let mut state = PatcherState::Initial;
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Allows the patcher code to be removed from the final binary when using monolith uploads to reduce binary size. The upload strategy should be specified using `cargo build --config 'build.rustflags=["--cfg", "vexide_upload_strategy=\"<monolith|differential>\""]'`. If no upload strategy is specified the upload strategy defaults to differential.
## Additional Context
Closes #289
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 Brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
