### PR TITLE
chore: update flake to use `fromRustupToolchainFile`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
             cargo-v5'
             pkgs.llvmPackages.bintools
             pkgs.cargo-binutils
-            (rustToolchain.default.override {
+            (rustToolchain.override {
               extensions = [ "rust-analyzer" "rust-src" "clippy" ];
             })
           ];


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
Means we can avoid hardcoding versions in the flake, and just keep it up to date with `rust-toolchain.toml`. Need a Nix user to actually test this first, and ideally someone to update flake.lock as well.

~~We should also do this for vexide-template, but I'll get to that later.~~ (edit: done, https://github.com/vexide/vexide-template/commit/1b2b2a088cab1ddf437d827b74896c0ae1a6f248)