### PR TITLE
fix(svc): save spsr, use ldrhne

### DIFF
--- a/packages/vexide-startup/src/abort_handler/mod.rs
+++ b/packages/vexide-startup/src/abort_handler/mod.rs
@@ -74,15 +74,22 @@ pub fn install_vector_table() {
 
 #[unsafe(naked)]
 #[unsafe(no_mangle)]
+#[instruction_set(arm::a32)]
 pub extern "aapcs" fn svc() -> ! {
     core::arch::naked_asm!(
         "
-        @ Save state and SPSR so we can restore it later
+        @ Save state and SPSR so we can restore it later. Saving SPSR matches
+        @ the behavior of the ARM sample SVC handler:
+        @ https://developer.arm.com/documentation/dui0203/j/handling-processor-exceptions/armv6-and-earlier--armv7-a-and-armv7-r-profiles/svc-handlers?lang=en
+        @ This is intended to prevent modification inside vexSystemSWInterrupt from
+        @ corrupting the register.
+
         push {{r0-r3,r12,lr}}
         mrs r0, spsr
         push {{r0,r3}} @ r3 is a random register to maintain alignment
 
         @ Extract the SVC immediate number from the instruction and place it into r0.
+        @ This is intended to match the behavior of Xilinx's embeddedsw SVC handler.
         @
         @ The way we do this depends on whether or not user code was running in ARM
         @ or Thumb mode at the time of this exception, so we check the T-bit in SPSR
@@ -99,16 +106,15 @@ pub extern "aapcs" fn svc() -> ! {
         ldreq r0, [lr,#-4]
         biceq r0, r0, #0xff000000
 
-        @ Call VEXos interrupt handler, fn() -> ()
+        @ Call VEXos interrupt handler as fn(svc_comment) -> ()
         bl vexSystemSWInterrupt
 
-        @ Restore spsr, other registers
+        @ Restore spsr, other registers. Then return.
         pop {{r0,r3}}
             @ Only the cxsf groups are restored because writing to the entire thing could cause issues.
             @ These bits restore things like interrupt state, condition flags, etc.
         msr spsr_cxsf, r0
-        pop {{r0-r3,r12,lr}}
-        movs pc, lr
+        ldmia sp!, {{r0-r3,r12,pc}}^
         ",
     )
 }


### PR DESCRIPTION
Switched to using the standard form for `ldrhne` and added logic for saving and restoring spsr.
