### PR TITLE
docs: update link for vex::sizeType

### DIFF
--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -233,7 +233,7 @@ pub struct DistanceObject {
     /// unknown what the sensor is *actually* measuring here either, so use this data with a grain
     /// of salt.
     ///
-    /// [`vex::sizeType`]: https://api.vexcode.cloud/v5/search/sizeType/sizeType/enum
+    /// [`vex::sizeType`]: https://api.vex.com/v5/home/python/Enums.html#object-size-types
     pub relative_size: u32,
 
     /// Observed velocity of the object in m/s.


### PR DESCRIPTION
The new docs website for VEXcode doesn't document this enum anymore, so I've updated it to use the Python docs (the second best option).