### PR TITLE
refactor: remove `Task` and `CompetitionRuntime` from prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Before releasing:
 - Removed `vexide_startup`'s copy of libm it previously linked to. Its functionality is now available from `std`. (#361)
 - Removed `InertialSensor::MAX_HEADING` and `GpsSensor::MAX_HEADING`. Prefer `Angle::FULL_TURN` instead.
 - Removed `DeviceTimestamp` in favor of `LowResolutionTime`. (#386) (**Breaking change**)
+- Removed `Task` and `CompetitionRuntime` from `vexide::prelude`. (#393) (**Breaking Change**)
 
 ### Miscellaneous
 

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -101,7 +101,7 @@ pub use vexide_startup::allocator;
 /// This module is meant to be glob imported.
 pub mod prelude {
     #[cfg(feature = "core")]
-    pub use crate::competition::{Compete, CompeteExt, CompetitionRuntime};
+    pub use crate::competition::{Compete, CompeteExt};
     #[cfg(feature = "devices")]
     pub use crate::{
         adi::{
@@ -143,7 +143,7 @@ pub mod prelude {
     #[cfg(feature = "async")]
     pub use crate::{
         runtime::block_on,
-        task::{Task, spawn, task_local},
+        task::{spawn, task_local},
         time::{sleep, sleep_until},
     };
 }


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
`CompetitionRuntime` is barely ever used by anyone and `Task` rarely needs to be implicitly named.