### PR TITLE
fix: make `DistanceObject::relative_size` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,7 @@ Before releasing:
 - `RadioLink::new` can now only fail on `NulError` and will not bail if a radio is disconnected. (#240) (**Breaking Change**)
 - `RadioLink::unread_bytes` can now return a `LinkError::ReadError`. (#243)
 - `RadioLink::is_linked` is now infallible. (#243) (**Breaking Change**)
+- `DistanceObject::relative_size` is now optional. (#402) (**Breaking Change**)
 
 ### Removed
 

--- a/packages/vexide-devices/src/smart/distance.rs
+++ b/packages/vexide-devices/src/smart/distance.rs
@@ -134,7 +134,7 @@ impl DistanceSensor {
                 distance: distance_raw,
                 relative_size: match unsafe { vexDeviceDistanceObjectSizeGet(self.device) } {
                     -1 => None,
-                    size => Some(size as u32)
+                    size => Some(size as u32),
                 },
                 velocity: unsafe { vexDeviceDistanceObjectVelocityGet(self.device) },
                 // TODO: determine if confidence reading is separate from whether or not an object


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
If VEXos is unable to calculate object size, it'll return `-1`. This often happens even when the object is in range, leading to a `u32::MAX` return in some cases. This PR makes `relative_size` into an `Option<u32>` that returns `None` when `vexDeviceDistanceObjectSizeGet(dev) == -1`.