### PR TITLE
Updated the Rust nightly override command to specify a rustc version date for vexide version 7.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ All of these crates are re-exported from the [`vexide`](https://github.com/vexid
 
 vexide relies on some features that are only available in Rust’s nightly release channel, so you’ll need to switch to using nightly to build it. We also use the `rust-src` component due to our target not shipping pre-built versions of the standard library in `rustup`.
 
-The override command needs to be ran in the project directory. Change date in override command to your vexide version's release date. The folling works for vexide 7.0.
+The override command needs to be ran in the project directory. Change date in override command to your vexide version's release date. The following works for vexide 7.0.
 ```sh
 rustup override set nightly-2025-03-06
+```
+```
 rustup component add rust-src
 ```
 


### PR DESCRIPTION
Updated the Rust nightly override command to specify a date for vexide version 7.0.

## Describe the changes this PR makes. Why should it be merged?
README updated to specify version of rustc nightly to use, the one at vexide 7.0 release for compatibility.
This makes vexide usable for new users who would install a newer, incompatible version of rustc.
See #415.

## Additional Context
- I have tested these changes on a VEX V5 Brain: No.
- I have tested these changes in a simulator: Yes, tested for compilation.
- These are *only* non-code changes (e.g. documentation, README.md).