### PR TITLE
fix: use correct no-std APIs

### DIFF
--- a/packages/vexide-devices/src/adi/addrled.rs
+++ b/packages/vexide-devices/src/adi/addrled.rs
@@ -200,7 +200,7 @@ impl<const N: usize> AdiAddrLed<N> {
     pub fn set_buffer(&mut self, buf: &[Color]) -> Result<usize, PortError> {
         self.port.validate_expander()?;
 
-        self.update(bytemuck::cast_slice(buf), 0);
+        self.update(bytemuck::must_cast_slice(buf), 0);
 
         Ok(buf.len().min(N))
     }

--- a/packages/vexide-devices/src/color.rs
+++ b/packages/vexide-devices/src/color.rs
@@ -84,13 +84,13 @@ impl Color {
     /// Creates a new RGB color from a raw 0RGB representation.
     #[must_use]
     pub const fn from_raw(raw: u32) -> Self {
-        unsafe { std::mem::transmute(raw.to_le()) }
+        bytemuck::must_cast(raw.to_le())
     }
 
     /// Converts this color to a raw 0RGB representation.
     #[must_use]
     pub const fn into_raw(self) -> u32 {
-        unsafe { std::mem::transmute::<Self, u32>(self).to_le() }
+        bytemuck::must_cast::<Self, u32>(self).to_le()
     }
 }
 

--- a/packages/vexide-devices/src/display.rs
+++ b/packages/vexide-devices/src/display.rs
@@ -5,7 +5,7 @@
 //! The [`Fill`] trait can be used to draw filled in shapes to the display and the [`Stroke`] trait
 //! can be used to draw the outlines of shapes.
 
-use alloc::{borrow::Cow, ffi::CString};
+use alloc::{borrow::Cow, ffi::CString, string::String};
 use core::{
     ffi::{CStr, c_char},
     time::Duration,


### PR DESCRIPTION
Makes compiling vexide-devices on `no-std` work again