### PR TITLE
feat: implement From<bool> for LogicLevel

### DIFF
--- a/packages/vexide-devices/src/adi/digital.rs
+++ b/packages/vexide-devices/src/adi/digital.rs
@@ -53,11 +53,7 @@ impl LogicLevel {
 
 impl From<bool> for LogicLevel {
     fn from(value: bool) -> Self {
-        if value {
-            Self::High
-        } else {
-            Self::Low
-        }
+        if value { Self::High } else { Self::Low }
     }
 }
 


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Implements `From<bool>` for the digital ADI `LogicLevel`. Assumes `true` corresponds to High and `false` corresponds to Low. QOL addition.

## Additional Context
- These changes update the crate's interface (e.g. functions/modules added or changed).