### PR TITLE
feat: make prelude optional

### DIFF
--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -68,6 +68,8 @@ devices = ["dep:vexide-devices"]
 embedded-io = ["vexide-devices/embedded-io"]
 dangerous-motor-tuning = ["vexide-devices/dangerous-motor-tuning"]
 
+no_prelude = []
+
 [package.metadata.docs.rs]
 targets = ["armv7a-vex-v5"]
 cargo-args = [

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -103,6 +103,7 @@ pub use vexide_startup::allocator;
 /// Commonly used features of vexide.
 ///
 /// This module is meant to be glob imported.
+#[cfg(not(feature = "no_prelude"))]
 pub mod prelude {
     #[cfg(feature = "core")]
     pub use crate::competition::{Compete, CompeteExt};


### PR DESCRIPTION
This makes the `prelude` mod optional, as it can now be turned off by enabling the `no_prelude` feature.

- These changes update the crate's interface (e.g. functions/modules added or changed).

