### PR TITLE
Upgrade to SNAFU 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,8 @@ members = ["packages/*"]
 resolver = "2"
 
 [workspace.dependencies]
-snafu = { version = "0.8.0", default-features = false, features = [
-    "rust_1_61",
-    "unstable-core-error",
+snafu = { version = "0.9.0", default-features = false, features = [
+    "rust_1_81",
 ] }
 vexide = { version = "0.8.0", path = "packages/vexide", default-features = false }
 vexide-async = { version = "0.2.0", path = "packages/vexide-async", default-features = false }


### PR DESCRIPTION
Thanks for using SNAFU! I've just released version 0.9 and my tests caught that your crate would be affected by some of the SemVer-incompatible changes in this version. See the [CHANGELOG][] for a full list.

This commit tries to make the minimal amount of changes to get your code compiling again, but it's entirely possible that there are better solutions for your specific case.

This version also updates the minimum supported Rust version to Rust 1.65 and targets Rust 1.81 by default. I didn't check how these changes affect might your crate, so please make sure to use your judgment as well!

Please feel free to take this PR in whatever form is useful to you; I'm not interested in becoming a long-term contributor to your project, so I'd prefer to not learn your project-specific rules or sign anything like a CLA. I don't mind someone with project approval yoinking these changes and committing it themselves and side-stepping all the red tape.

[CHANGELOG]: https://github.com/shepmaster/snafu/blob/main/CHANGELOG.md#090---2026-03-02
