### PR TITLE
test: make startup example check-only

### DIFF
--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -24,7 +24,7 @@
 //! This is an example of a minimal user program that boots without using the main vexide runtime or
 //! the `#[vexide::main]` macro.
 //!
-//! ```
+//! ```no_run
 //! use vexide_core::program::{CodeSignature, ProgramOptions, ProgramOwner, ProgramType};
 //!
 //! // SAFETY: This symbol is unique and is being used to start the runtime.


### PR DESCRIPTION
This example doesn't compile on macos because of the link section which is making `cargo test --all` fail for me, so it should be `check`-only