### PR TITLE
fix(motor): check for driver over current where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Before releasing:
 
 - Fixed an issue where `VisionSensor::signature` would return fields in the incorrect order. (#437)
 - Fixed `Angle::wrapped_half` returning a negated value from what's expected. (#438) (**Breaking Change**)
+- Fixed `Motor::is_driver_over_current` incorrectly checking for the motor's `OVER_CURRENT` fault instead of `DRIVER_OVER_CURRENT`. (#447)
 
 ### Changed
 

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -1465,7 +1465,7 @@ impl Motor {
     /// }
     /// ```
     pub fn is_driver_over_current(&self) -> Result<bool, PortError> {
-        Ok(self.faults()?.contains(MotorFaults::OVER_CURRENT))
+        Ok(self.faults()?.contains(MotorFaults::DRIVER_OVER_CURRENT))
     }
 
     /// Adjusts the internal tuning constants of the motor when using velocity control.


### PR DESCRIPTION
This PR fixes the `Motor::is_driver_over_current` function so that it checks the `DRIVER_OVER_CURRENT` flag rather than the `OVER_CURRENT` flag.