### PR TITLE
docs: bump flake lock and random doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Before releasing:
 
 ### Changed
 
+- Corrected some minor doc comments and updated the Nix flake. (#451)
+
 ### Removed
 
 ### New Contributors
@@ -249,7 +251,7 @@ Before releasing:
 - Fixed an internal issue regarding units with `Motor::set_position`.
 - Fixed `File::seek` seeking to the wrong position when using `SeekFrom::End` with a negative offset. (#267)
 - Fixed a rare issue with IMU calibration timing out at the start of some programs. (#275, #279)
-- Recursive panics (panics that occur *within* `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
+- Recursive panics (panics that occur _within_ `vexide_panic`'s handler) will now immediately abort rather than potentially causing a stack overflow. (#275)
 
 ### Changed
 
@@ -473,8 +475,8 @@ Before releasing:
 ### Added
 
 - The startup banner and code signature may now be configured using parameters passed to `vexide::main`. (#102)
-- Added the ``ProgramOwner``, ``ProgramType``, and ``ProgramFlags`` types for code signature configuration. (#76)
-- Created new ``force_rust_libm`` feature to force the use of a slower, 100% Rust, libm implementation. This is useful for building on WASM. (#106)
+- Added the `ProgramOwner`, `ProgramType`, and `ProgramFlags` types for code signature configuration. (#76)
+- Created new `force_rust_libm` feature to force the use of a slower, 100% Rust, libm implementation. This is useful for building on WASM. (#106)
 - Optimized floating point math operations available through the `Float` extension trait. (#77)
 - Added text metrics getters to the `Text` widget. (#83)
 - Added alignment support for the `Text` widget. (#85)
@@ -489,11 +491,11 @@ Before releasing:
 
 ### Changed
 
-- Updated ``vex-sdk`` to version 0.17.0. (#76)
-- Renamed ``ColdHeader`` to ``CodeSignature``. (#76) (**Breaking Change**)
-- Renamed the entrypoint symbol from ``_entry`` to ``_start``. (#76) (**Breaking Change**)
-- Renamed ``__stack_start`` and ``__stack_end`` symbols to ``__stack_top`` and ``__stack_bottom`` respectively. (#76) (**Breaking Change**)
-- Renamed the ``.cold_magic`` section to ``.code_signature``. (#76) (**Breaking Change**)
+- Updated `vex-sdk` to version 0.17.0. (#76)
+- Renamed `ColdHeader` to `CodeSignature`. (#76) (**Breaking Change**)
+- Renamed the entrypoint symbol from `_entry` to `_start`. (#76) (**Breaking Change**)
+- Renamed `__stack_start` and `__stack_end` symbols to `__stack_top` and `__stack_bottom` respectively. (#76) (**Breaking Change**)
+- Renamed the `.cold_magic` section to `.code_signature`. (#76) (**Breaking Change**)
 - Made fields on screen widgets public. (#81)
 - Renamed `Competition` to `CompetitionRuntime`, `CompetitionRobotExt` to `CompetitionExt`, and `CompetitionRobot` to `Competition`. (#87) (**Breaking Change**)
 - Removed the `Error` associated type from the `Competition` trait and made all methods infallible. (#87) (**Breaking Change**)
@@ -501,7 +503,7 @@ Before releasing:
 ### Removed
 
 - The `no-banner` feature has been removed from `vexide-startup` and must now be toggled through the `vexide:main` attribute. (#102) (**Breaking Change**)
-- Removed the useless ``__rodata_start`` and ``__rodata_end`` symbols.
+- Removed the useless `__rodata_start` and `__rodata_end` symbols.
 - Support for `vexide-math` has been dropped. (#78) (**Breaking Change**)
 - Removed the `vexide-graphics` crate and associated features (containing embedded-graphics and slint drivers) from the main vexide crate due to licensing concerns. These drivers will be available as crates licensed separately from the main `vexide` project. (#297) (**Breaking Change**)
 

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1764466446,
-        "narHash": "sha256-uIJcl1WfL96tvJ5QebbqnsP4nQqW7aCp4XYXgfu7CuY=",
+        "lastModified": 1777338144,
+        "narHash": "sha256-P0VGn7ylF4Obndy+ckrZwf3211boT1Vt/hqQaD0+AXA=",
         "owner": "vexide",
         "repo": "cargo-v5",
-        "rev": "ef20b73886fbc159e49e1ec83bb5ff69d4e72346",
+        "rev": "392c10aa480974201731ca9b771714f4f64d0b0d",
         "type": "github"
       },
       "original": {
@@ -109,11 +109,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1759977445,
-        "narHash": "sha256-LYr4IDfuihCkFAkSYz5//gT2r1ewcWBYgd5AxPzPLIo=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2dad7af78a183b6c486702c18af8a9544f298377",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1760063676,
-        "narHash": "sha256-s5Fjh43skH2L+avOGioLmEHoYZffDbg3abV5h0gjeew=",
+        "lastModified": 1782098508,
+        "narHash": "sha256-YeBVH+avasLg/ZTOyshNI4qfU8p5RbMs9O8944A1QDg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "897deed0923cc5a1d560c5176abe0d172ec9716d",
+        "rev": "67eed429b53d462923d9be580cfc9ed372f7564f",
         "type": "github"
       },
       "original": {

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -286,7 +286,7 @@ impl GpsSensor {
     ///         0.0,
     ///     );
     ///
-    ///     // Get current position and heading
+    ///     // Get current position
     ///     if let Ok(position) = gps.position() {
     ///         println!("Robot is at x={}, y={}", position.x, position.y,);
     ///     }

--- a/packages/vexide-devices/src/smart/gps.rs
+++ b/packages/vexide-devices/src/smart/gps.rs
@@ -99,8 +99,8 @@ impl GpsSensor {
     ///
     /// #[vexide::main]
     /// async fn main(peripherals: Peripherals) {
-    ///     // Create a GPS sensor mounted 2 inches forward and 1 inch right of center
-    ///     // Starting at position (0, 0) with 90 degree heading
+    ///     // Create a GPS sensor mounted 0.225 m west and 0.225 m north of the
+    ///     // tracking origin, starting at position (0, 0) with a 90 degree heading
     ///     let gps = GpsSensor::new(
     ///         // Port 1
     ///         peripherals.port_1,

--- a/packages/vexide-devices/src/smart/motor.rs
+++ b/packages/vexide-devices/src/smart/motor.rs
@@ -100,7 +100,7 @@ pub enum MotorControl {
     /// The motor brakes using a specified [`BrakeMode`].
     Brake(BrakeMode),
 
-    /// The motor outputs a raw voltage (specified in RPM).
+    /// The motor outputs a raw voltage (specified in volts).
     ///
     /// # Fields
     ///


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Bumps the flake lock to get the new (=March) nightly and fixes some various doc typos.

Sorry about doing two things in one PR; I needed to fix my environment first since I'm on NixOS.

## Additional Context

- I ran `cargo test` for fun and nothing broke