### PR TITLE
fix: use Option for soundness of SerialPort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Before releasing:
 - Fixed an issue where `VisionSensor::signature` would return fields in the incorrect order. (#437)
 - Fixed `Angle::wrapped_half` returning a negated value from what's expected. (#438) (**Breaking Change**)
 - Fixed a stack overflow in the abort handler that was causing recursive CPU aborts. (#450)
+- Fixed an issue where the future returned from `SmartPort::open` could be polled after completion, effectively duplicating SmartPorts. (#452)
 
 ### Changed
 

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -77,7 +77,7 @@ impl SerialPort {
     pub fn open(port: SmartPort, baud_rate: u32) -> SerialPortOpenFuture {
         SerialPortOpenFuture {
             state: SerialPortOpenState::Configure { baud_rate },
-            serial: ManuallyDrop::new(Self {
+            serial: Some(Self {
                 device: unsafe { port.device_handle() },
                 port,
             }),
@@ -385,7 +385,7 @@ enum SerialPortOpenState {
 #[derive(Debug)]
 pub struct SerialPortOpenFuture {
     state: SerialPortOpenState,
-    serial: ManuallyDrop<SerialPort>,
+    serial: Option<SerialPort>,
 }
 
 impl core::future::Future for SerialPortOpenFuture {
@@ -393,19 +393,22 @@ impl core::future::Future for SerialPortOpenFuture {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
+        // According to the `Future` docs, "Once a future has finished, clients
+        // should not poll it again."
+        // Therefore, it is okay to panic here since it is not our problem.
+        let serial = this.serial.as_ref().unwrap();
 
         if let SerialPortOpenState::Configure { baud_rate } = this.state {
             unsafe {
-                vexDeviceGenericSerialEnable(this.serial.device, 0);
-                vexDeviceGenericSerialBaudrate(this.serial.device, baud_rate as i32);
+                vexDeviceGenericSerialEnable(serial.device, 0);
+                vexDeviceGenericSerialBaudrate(serial.device, baud_rate as i32);
             }
 
             this.state = SerialPortOpenState::Waiting;
         }
 
-        if this.serial.validate_port().is_ok() {
-            // SAFETY: Device is not accessed from self.serial after `Poll::Ready` return.
-            Poll::Ready(unsafe { ManuallyDrop::take(&mut this.serial) })
+        if serial.validate_port().is_ok() {
+            Poll::Ready(this.serial.take().unwrap())
         } else {
             cx.waker().wake_by_ref();
             Poll::Pending

--- a/packages/vexide-devices/src/smart/serial.rs
+++ b/packages/vexide-devices/src/smart/serial.rs
@@ -14,7 +14,6 @@
 //! automatically flushed by VEXos as fast as possible (down to ~10µs or so).
 
 use core::{
-    mem::ManuallyDrop,
     pin::Pin,
     task::{Context, Poll},
 };


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Currently, creating a serial port uses `ManuallyDrop::take`, which, when called multiple times, returns copies of the inner value as per its safety contract. However, using an `Option` instead ensures that polling the future after the port has been taken panics.

There is no difference in `Drop` behavior when a future is dropped before it is resolved because `SerialPort` does not have a `Drop` impl.

## Additional Context
- I don't have the hardware to test this, so not hardware tested.

Fixes #448