### PR TITLE
refactor: add dedicated abort stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Before releasing:
 
 - Fixed an issue where `VisionSensor::signature` would return fields in the incorrect order. (#437)
 - Fixed `Angle::wrapped_half` returning a negated value from what's expected. (#438) (**Breaking Change**)
+- Fixed a stack overflow in the abort handler that was causing recursive CPU aborts. (#450)
 
 ### Changed
 

--- a/packages/vexide-startup/link/vexide.ld
+++ b/packages/vexide-startup/link/vexide.ld
@@ -38,6 +38,21 @@ OVERWRITE_SECTIONS {
     }
 }
 
+__abort_stack_length = 16K;
+
+SECTIONS {
+    /*
+     * Dedicated stack for the CPU fault exception handler.
+     *
+     * VEXos provides a 1KiB builtin abort stack, but our stack unwinding code easily overflows it.
+     */
+    .abort_stack (NOLOAD) : ALIGN(8) {
+        __abort_stack_bottom = .;
+        . += __abort_stack_length;
+        __abort_stack_top = .;
+    } > USER_RAM
+} INSERT AFTER .bss;
+
 SECTIONS {
     /* Patcher Memory */
     .patcher_patch (NOLOAD) : {

--- a/packages/vexide-startup/src/abort_handler/mod.rs
+++ b/packages/vexide-startup/src/abort_handler/mod.rs
@@ -151,6 +151,11 @@ pub extern "aapcs" fn irq() -> ! {
     )
 }
 
+unsafe extern "C" {
+    /// Base of the dedicated CPU fault stack, defined in `vexide.ld`.
+    unsafe static __abort_stack_top: u8;
+}
+
 macro_rules! fault_exception_vector {
     (
         $name:ident:
@@ -167,6 +172,11 @@ macro_rules! fault_exception_vector {
 
                 sub lr, lr, #{lr_offset}    @ Apply an offset to link register so that it points at address
                                             @ of return instruction (see Abort::program_counter docs).
+
+                @ Reset stack to the base of our custom abort stack (this is valid because we never
+                @ return from this function or access stack data from a previous abort handler).
+                movw sp, #:lower16:{abort_stack_top}
+                movt sp, #:upper16:{abort_stack_top}
 
                 sub sp, sp, #4 @ Ensure stack is aligned to 8 after we're done here.
 
@@ -188,6 +198,7 @@ macro_rules! fault_exception_vector {
                 blx {exception_handler}        @ Actually call the function now
                 ",
                 exception_handler = sym fault_exception_handler,
+                abort_stack_top = sym __abort_stack_top,
                 lr_offset = const $lr_offset,
                 exception = const $exception as u32,
             );


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Fixes #450 by adding a 16KiB dedicated abort stack which pulls from what is today heap memory.

## Additional Context
- I have tested these changes on a VEX V5 Brain.
<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
