### PR TITLE
refactor: add thumb support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [target.'cfg(target_os = "vexos")']
 runner = "cargo v5 run --file"
-rustflags = ["-Clink-arg=-Tvexide.ld"]
+rustflags = ["-Clink-arg=-Tvexide.ld", "-Ctarget-feature=+thumb-mode"]
 
 [unstable]
 build-std = ["std", "panic_abort"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Before releasing:
 
 - Corrected some minor doc comments and updated the Nix flake. (#451)
 
+- Programs now execute in Thumb mode instead of ARM mode, reducing code size. (#454)
+
 ### Removed
 
 ### New Contributors

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,5 +2,5 @@ use vexide::prelude::*;
 
 #[vexide::main]
 async fn main(_peripherals: Peripherals) {
-    panic!("Hello, world!");
+    println!("Hello, world!");
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,5 +2,5 @@ use vexide::prelude::*;
 
 #[vexide::main]
 async fn main(_peripherals: Peripherals) {
-    println!("Hello, world!");
+    panic!("Hello, world!");
 }

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -118,15 +118,17 @@ unsafe extern "C" fn _vexide_boot() {
         "ldr r0, =__patcher_patch_start",
         "ldr r0, [r0]",
         "ldr r1, ={patch_magic}",
+        // If the patch magic is missing, just skip the patcher code.
         "cmp r0, r1", // r0 == 0xB1DF?
-        // Prepare to memcpy binary to 0x07C00000
+        "bne .Lstart",
+        // Memcpy the unmodified, unpatched binary to 0x07C00000
         "ldr r0, =__patcher_base_start", // memcpy dest -> r0
         "ldr r1, =__user_ram_start", // memcpy src -> r1
         "ldr r2, =__patcher_patch_start+12", // Base binary len is stored as metadata in the patch.
         "ldr r2, [r2]", // memcpy size -> r2
-        // Do the memcpy if patch magic is present (we checked this in our `cmp` instruction).
-        "blxeq __overwriter_aeabi_memcpy",
+        "blx __overwriter_aeabi_memcpy",
         // Jump to the Rust entrypoint.
+        ".Lstart:",
         "blx _start",
         patch_magic = const patcher::PATCH_MAGIC,
     )

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -92,6 +92,7 @@ unsafe extern "C" {
 #[unsafe(no_mangle)]
 #[unsafe(naked)]
 #[cfg(target_os = "vexos")]
+#[instruction_set(arm::a32)] // VEX program entry begins in ARM mode
 unsafe extern "C" fn _vexide_boot() {
     core::arch::naked_asm!(
         // Load the stack pointer to point to our stack section.
@@ -124,9 +125,9 @@ unsafe extern "C" fn _vexide_boot() {
         "ldr r2, =__patcher_patch_start+12", // Base binary len is stored as metadata in the patch.
         "ldr r2, [r2]", // memcpy size -> r2
         // Do the memcpy if patch magic is present (we checked this in our `cmp` instruction).
-        "bleq __overwriter_aeabi_memcpy",
+        "blxeq __overwriter_aeabi_memcpy",
         // Jump to the Rust entrypoint.
-        "b _start",
+        "blx _start",
         patch_magic = const patcher::PATCH_MAGIC,
     )
 }

--- a/packages/vexide-startup/src/patcher/mod.rs
+++ b/packages/vexide-startup/src/patcher/mod.rs
@@ -25,6 +25,9 @@ unsafe extern "C" {
     static mut __patcher_patch_start: u32;
     static mut __patcher_base_start: u32;
     static mut __patcher_new_start: u32;
+
+    #[link_name = "__patcher_overwrite"]
+    unsafe fn patcher_overwrite() -> !;
 }
 
 /// Internal patcher state representing what the patcher is attempting to do.
@@ -163,7 +166,7 @@ pub(crate) unsafe fn patch() {
         bipatch(base, patch, new);
 
         // Jump to the stage 2 overwriter routine to handle the rest.
-        core::arch::asm!("b __patcher_overwrite", options(noreturn));
+        patcher_overwrite();
     }
 }
 

--- a/packages/vexide-startup/src/patcher/overwriter.S
+++ b/packages/vexide-startup/src/patcher/overwriter.S
@@ -1,6 +1,8 @@
 .section .overwriter, "ax"
+.thumb
 
 .global __patcher_overwrite
+.type __patcher_overwrite, %function
 
 __patcher_overwrite:
     cpsid i @ Mask interrupts
@@ -10,7 +12,7 @@ __patcher_overwrite:
     ldr r1, =__patcher_new_start      @ memcpy src -> r1
     ldr r2, =__patcher_patch_start+16 @ New binary len is stored as metadata in the patch
     ldr r2, [r2]                      @ memcpy size -> r2
-    bl __overwriter_aeabi_memcpy
+    blx __overwriter_aeabi_memcpy
 
     @ Clean L1 data cache in the user memory range
     @ NOTE: 0x03800000 is already aligned to cache line size (32), so no work there.
@@ -29,5 +31,5 @@ dcache_clean_range:
 
     cpsie i @ Unmask interrupts
 
-    @ Jump to modified code
-    b _vexide_boot
+    @ Return to modified entrypoint
+    blx _vexide_boot

--- a/packages/vexide-startup/src/patcher/overwriter_aeabi_memcpy.S
+++ b/packages/vexide-startup/src/patcher/overwriter_aeabi_memcpy.S
@@ -27,6 +27,7 @@
  */
 
 .section .overwriter, "ax"
+.thumb
 
 .global __overwriter_aeabi_memcpy
 .type   __overwriter_aeabi_memcpy, %function


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Adds support for compiling to LLVM's thumbv7a arch instead of armv7a, which makes vexide binaries about 20% smaller. The V5 supports both but starts out in ARM mode, so we need to mark the entrypoint as being ARM.

## Additional Context

- These are breaking changes (would bump the MSRV)
- I have tested these changes on a VEX V5 Brain.

<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
