### PR TITLE
refactor: drop libunwind, use frame ptr for backtraces

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,11 @@
 [target.'cfg(target_os = "vexos")']
 runner = "cargo v5 run --file"
-rustflags = ["-Clink-arg=-Tvexide.ld", "-Ctarget-feature=+thumb-mode"]
+rustflags = [
+    "-Clink-arg=-Tvexide.ld",
+    "-Ctarget-feature=+thumb-mode",
+    "-Cforce-unwind-tables=no",
+    "-Cforce-frame-pointers=yes",
+]
 
 [unstable]
 build-std = ["std", "panic_abort"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Before releasing:
 ### Added
 
 - Implemented a conversion between `bool` and `LogicLevel`. (#428)
+- Added support for capturing backtraces without heap allocations via the `BacktraceIter` struct. (#456)
 
 ### Fixed
 
@@ -47,10 +48,13 @@ Before releasing:
 ### Changed
 
 - Corrected some minor doc comments and updated the Nix flake. (#451)
-
 - Programs now execute in Thumb mode instead of ARM mode, reducing code size. (#454)
+- Backtraces are now captured using the frame pointer instead of through unwind tables. (#456) (**Breaking Change**)
 
 ### Removed
+
+- The vexide linker script now removes unwind tables from the executable. (#456) (**Breaking Change**)
+- The `backtrace` Cargo feature has been removed; the `vexide::backtrace` module is now available unconditionally. (#456) (**Breaking Change**)
 
 ### New Contributors
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ vexide-startup = { version = "0.5.0", path = "packages/vexide-startup", default-
 vexide-macro = { version = "0.4.0", path = "packages/vexide-macro", default-features = false }
 vex-sdk = "0.28.0"
 vex-sdk-mock = { version = "0.2.0-rc.1", git = "https://github.com/vexide/vex-sdk", branch = "rc" }
-vex-libunwind = { version = "0.3.0" }
-vex-libunwind-sys = { version = "0.1.1" }
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -31,15 +31,8 @@ vexide = { path = "../vexide", features = [
     "vex-sdk-jumptable",
 ] }
 
-[target.'cfg(target_vendor = "vex")'.dependencies]
-vex-libunwind = { workspace = true, optional = true }
-
 [lints]
 workspace = true
-
-[features]
-default = ["backtrace"]
-backtrace = ["dep:vex-libunwind"]
 
 [package.metadata.docs.rs]
 targets = ["armv7a-vex-v5"]

--- a/packages/vexide-core/src/backtrace.rs
+++ b/packages/vexide-core/src/backtrace.rs
@@ -1,33 +1,84 @@
 //! Support for capturing stack backtraces.
 //!
-//! This module contains the support for capturing a stack backtrace through the [`Backtrace`] type.
-//! Backtraces are helpful to attach to errors, containing information that can be used to get a
-//! chain of where an error was created.
+//! This module contains support for capturing a stack backtrace through the [`Backtrace`] and
+//! [`BacktraceIter`] structs. Obtaining a backtrace gives you a list of every function that was
+//! running at the time of its capture, with more recently called functions being ordered first.
+//! Backtraces can be helpful to attach to errors since they allow you to determine the indirect
+//! causes of a failure.
+//!
+//! # Capturing backtraces
+//!
+//! Calling [`Backtrace::capture`] gives you a list of the addresses of each function currently
+//! running.
+//!
+//! ```
+//! # use vexide::backtrace::Backtrace;
+//! #
+//! let backtrace = Backtrace::capture();
+//! println!("{backtrace}");
+//!
+//! for frame in backtrace.frames() {
+//!     println!("{frame:?}");
+//! }
+//! ```
+//!
+//! You can also use [`BacktraceIter::capture`] to similar effect. This a more lightweight API that
+//! doesn't require memory allocation and allows you to cancel the capture. However, it only allows
+//! you to access the iterator inside a callback:
+//!
+//! ```
+//! # use vexide::backtrace::BacktraceIter;
+//! #
+//! // Only capture up to 5 backtrace frames.
+//! let frames: Vec<_> = BacktraceIter::capture(|backtrace| backtrace.take(5).collect());
+//!
+//! // Print each frame as it's captured.
+//! BacktraceIter::capture(|backtrace| {
+//!     for frame in backtrace {
+//!         println!("- {frame:?}");
+//!     }
+//! });
+//! ```
+//!
+//! # Using the backtrace
+//!
+//! Each frame in backtrace is an address, which isn't particularly meaningful on its own but can be
+//! combined with a built executable to become a file name, line number, and function name. Doing
+//! this shows which functions were being run at the time of the backtrace's capture. Performing the
+//! conversion requires a *symbolizer tool* such as `llvm-symbolizer` or `addr2line`.
+//!
+//! For instance, if you were shown the following backtrace, you could symbolize it as shown.
+//!
+//! ```txt
+//! stack backtrace:
+//!   0: 0x380217b
+//!   1: 0x380209b
+//! note: Use a symbolizer to convert stack frames to human-readable function names.
+//! ```
+//!
+//! ```terminal
+//! $ llvm-symbolizer -p -e ./target/armv7a-vex-v5/debug/program_name 0x380217b 0x380209b
+//! my_function at src/main.rs:30:14
+//!
+//! main at src/main.rs:21:9
+//! ```
+//!
+//! This result would indicate that at the time of the backtrace, the program was running line 30 of
+//! `main.rs` (inside a function named `my_function`), and was running that code because of a
+//! function call on line 21 of `main.rs` (inside `main`).
 //!
 //! # Platform Support
 //!
-//! The [`Backtrace`] API is only functional on the `armv7a-vex-v5` platform target.
-//!
-//! Additionally, backtraces will be unsupported if vexide is compiled without the `backtrace`
-//! feature.
+//! The backtrace API is only functional when compiling for VEXos; using it on another platform will
+//! result in an empty backtrace.
 
-use alloc::vec::Vec;
-use core::fmt::Display;
-
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use vex_libunwind::{UnwindContext, UnwindCursor, UnwindError, registers};
+use alloc::{fmt, vec::Vec};
+use core::{fmt::Display, marker::PhantomData};
 
 /// A captured stack backtrace.
 ///
 /// This type stores the backtrace of a captured stack at a certain point in time. The backtrace is
 /// represented as a list of instruction pointers.
-///
-/// # Platform Support
-///
-/// The [`Backtrace`] API is only functional on the `armv7a-vex-v5` platform target.
-///
-/// Additionally, backtraces will be unsupported if vexide is compiled without the `backtrace`
-/// feature.
 ///
 /// # Example
 ///
@@ -36,19 +87,6 @@ use vex_libunwind::{UnwindContext, UnwindCursor, UnwindError, registers};
 ///
 /// let backtrace = Backtrace::capture();
 /// println!("{backtrace}");
-/// ```
-///
-/// # Symbolication
-///
-/// The number stored in each frame is not particularly meaningful to humans on its own. Using a
-/// tool such as `llvm-symbolizer` or `addr2line`, it can be turned into a function name and line
-/// number to show what functions were being run at the time of the backtrace's capture.
-///
-/// ```terminal
-/// $ llvm-symbolizer -p -e ./target/armv7a-vex-v5/debug/program_name 0x380217b 0x380209b
-/// my_function at /path/to/project/src/main.rs:30:14
-///
-/// main at /path/to/project/src/main.rs:21:9
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Backtrace {
@@ -63,18 +101,19 @@ impl Backtrace {
     ///
     /// # Platform Support
     ///
-    /// Backtraces will be empty on non-vex targets (e.g. WebAssembly) or when the `backtrace`
-    /// feature is disabled.
+    /// Backtraces will be empty when compiling to a non-VEXos platform.
     #[allow(clippy::inline_always)]
     #[inline(always)] // Inlining keeps this function from appearing in backtraces
     #[allow(clippy::missing_const_for_fn)]
-    #[must_use]
+    #[must_use = "this creates a backtrace but doesn't save it or log it anywhere"]
     pub fn capture() -> Self {
-        #[cfg(all(target_os = "vexos", feature = "backtrace"))]
-        return Self::try_capture().unwrap_or(Self { frames: Vec::new() });
-
-        #[cfg(not(all(target_os = "vexos", feature = "backtrace")))]
-        return Self { frames: Vec::new() };
+        BacktraceIter::capture(|bt| {
+            let mut frames = Vec::new();
+            for frame in bt {
+                frames.push(frame);
+            }
+            Self { frames }
+        })
     }
 
     /// Returns a slice of instruction pointers at every captured frame of the backtrace.
@@ -82,56 +121,243 @@ impl Backtrace {
     pub const fn frames(&self) -> &[*const ()] {
         self.frames.as_slice()
     }
-
-    /// Captures a backtrace at the current point of execution, returning an error if the backtrace
-    /// fails to capture.
-    ///
-    /// # Platform Support
-    ///
-    /// See [`Backtrace::capture`].
-    ///
-    /// # Errors
-    ///
-    /// This function errors when the program's unwind info is corrupted.
-    #[inline(never)] // Make sure there's always a frame to remove
-    #[cfg(all(target_os = "vexos", feature = "backtrace"))]
-    fn try_capture() -> Result<Self, UnwindError> {
-        UnwindContext::capture(|context| {
-            let mut cursor = UnwindCursor::new(&context)?;
-            let mut frames = Vec::new();
-
-            // Procedure based on mini_backtrace crate.
-            loop {
-                let mut instruction_pointer = cursor.register(registers::UNW_REG_IP)?;
-
-                // Adjust IP to point inside the function — this improves symbolization quality.
-                if !cursor.is_signal_frame()? {
-                    instruction_pointer -= 1;
-                }
-
-                frames.push(instruction_pointer as *const ());
-
-                // Step to the next frame, break if there is none.
-                if !cursor.step()? {
-                    break;
-                }
-            }
-
-            Ok(Self { frames })
-        })
-    }
 }
 
 impl Display for Backtrace {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        writeln!(f, "stack backtrace:")?;
-        for (i, frame) in self.frames.iter().enumerate() {
-            writeln!(f, "{i:>3}: 0x{:x}", *frame as usize)?;
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        format_backtrace(f, self.frames.iter().copied())
+    }
+}
+
+/// An iterator over the frames of a stack backtrace.
+///
+/// This is a more lightweight alternative to [`Backtrace`]. Rather than allocating a list on the
+/// heap containing every frame, the stack is walked lazily as [`next`](BacktraceIter::next)
+/// is called. This makes it possible to capture frames without allocation or stop walking the stack
+/// early.
+///
+/// Because the iterator inspects the active call stack, it cannot outlive the capture and can
+/// only be used from within the closure passed to [`capture`](BacktraceIter::capture). As with
+/// [`Backtrace`], the frames of the most recently called function are returned first.
+///
+/// # Example
+///
+/// ```
+/// use vexide::backtrace::BacktraceIter;
+///
+/// // Print the five most recent frames.
+/// BacktraceIter::capture(|backtrace| {
+///     for frame in backtrace.take(5) {
+///         println!("- {frame:?}");
+///     }
+/// });
+/// ```
+pub struct BacktraceIter<'a> {
+    // Prevents "Unused lifetime" error on non-vexos targets.
+    lifetime: PhantomData<&'a ()>,
+    #[cfg(all(target_arch = "arm", target_os = "vexos"))]
+    frame: Option<&'a arm::FrameRecord>,
+}
+
+impl Iterator for BacktraceIter<'_> {
+    type Item = *const ();
+
+    fn next(&mut self) -> Option<Self::Item> {
+        #[cfg(target_os = "vexos")]
+        if let Some(frame) = self.frame {
+            let addr = frame.caller_address();
+            self.frame = frame.next();
+            return Some(addr as *const ());
         }
-        write!(
-            f,
-            "note: Use a symbolizer to convert stack frames to human-readable function names."
-        )?;
-        Ok(())
+
+        None
+    }
+}
+
+impl BacktraceIter<'_> {
+    /// Captures a backtrace at the current point of execution, passing an iterator over its frames
+    /// to the given closure.
+    ///
+    /// The iterator borrows from the current call stack and so cannot escape the closure. In
+    /// exchange, capturing this way performs no heap allocation and lets you stop walking the stack
+    /// early by simply not advancing the iterator any further.
+    ///
+    /// # Platform Support
+    ///
+    /// The iterator yields no frames when compiling to a non-VEXos platform.
+    pub fn capture<R>(handler: impl FnOnce(BacktraceIter<'_>) -> R) -> R {
+        cfg_select! {
+            all(
+                target_arch = "arm",
+                target_os = "vexos",
+            ) => {
+                arm::capture_frame(|frame| {
+                    handler(BacktraceIter {
+                        lifetime: PhantomData,
+                        frame: Some(frame),
+                    })
+                })
+            }
+            _ => handler(BacktraceIter {
+                lifetime: PhantomData,
+            })
+        }
+    }
+
+    /// Capture a backtrace by walking the stack, starting at the given [AAPCS32 frame pointer].
+    ///
+    /// This function allows you to capture a backtrace from a different call stack, but does not
+    /// ensure that the specified pointer or lifetime is valid. Generally, a valid frame pointer can
+    /// be obtained by reading either `r7` in thumb mode or `r11` (aka `fp`) in ARM mode.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must either be null or an AAPCS32 frame pointer that's valid for the span of this
+    /// type's lifetime.
+    ///
+    /// [AAPCS32 frame pointer]: https://github.com/ARM-software/abi-aa/blob/main/aapcs32/aapcs32.rst#6214the-frame-pointer
+    #[must_use = "the backtrace isn't captured unless you step the iterator"]
+    #[allow(
+        clippy::missing_const_for_fn,
+        reason = "performs non-const operations on some targets"
+    )]
+    pub unsafe fn from_frame_ptr(ptr: *const ()) -> Self {
+        _ = ptr; // ptr is unused on non-VEXos targets.
+        Self {
+            lifetime: PhantomData,
+            #[cfg(all(target_arch = "arm", target_os = "vexos"))]
+            frame: unsafe { arm::FrameRecord::from_ptr(ptr.cast()) },
+        }
+    }
+
+    /// Consumes the iterator, writing a human-readable representation of the backtrace to `dest`.
+    ///
+    /// This produces the same output as formatting a [`Backtrace`] with [`Display`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underling write operation fails.
+    ///
+    /// [`Display`]: core::fmt::Display
+    pub fn write_to(self, dest: &mut impl fmt::Write) -> fmt::Result {
+        format_backtrace(dest, self)
+    }
+}
+
+/// Writes a human-readable representation of a backtrace to `dest`.
+fn format_backtrace(
+    dest: &mut impl fmt::Write,
+    frames: impl Iterator<Item = *const ()>,
+) -> fmt::Result {
+    writeln!(dest, "stack backtrace:")?;
+    for (i, frame) in frames.enumerate() {
+        writeln!(dest, "{i:>3}: 0x{:x}", frame as usize)?;
+    }
+    write!(
+        dest,
+        "note: Use a symbolizer to convert stack frames to human-readable function names."
+    )
+}
+
+#[cfg(all(target_arch = "arm", target_os = "vexos"))]
+mod arm {
+    use core::{arch::asm, ptr};
+
+    unsafe extern "C" {
+        unsafe static __stack_top: u32;
+        unsafe static __stack_bottom: u32;
+    }
+
+    /// The AAPCS32 frame record.
+    ///
+    /// Stores information about the state of the CPU upon entry to a function.
+    #[repr(C)]
+    pub struct FrameRecord {
+        /// The caller's frame record.
+        caller: *const FrameRecord,
+        /// The value stored in LR upon entry to this function.
+        lr: u32,
+    }
+
+    impl FrameRecord {
+        /// Accesses a frame record using the given frame pointer.
+        ///
+        /// Returns `None` if the given pointer is null or out of range.
+        ///
+        /// # Safety
+        ///
+        /// `ptr` must either be null or a frame pointer that's valid for the span of the specified
+        /// lifetime.
+        #[must_use]
+        pub unsafe fn from_ptr<'a>(ptr: *const Self) -> Option<&'a Self> {
+            // Frame records are only ever stored on the stack.
+            let stack = (&raw const __stack_bottom)..(&raw const __stack_top);
+            if !stack.contains(&ptr.cast()) {
+                return None;
+            }
+
+            // SAFETY: ptr is either a valid frame pointer or null.
+            unsafe { ptr.as_ref() }
+        }
+
+        /// Returns the frame record of this frame's caller, or [`None`] if this is the last frame.
+        #[must_use]
+        pub fn next(&self) -> Option<&Self> {
+            // The caller's stack frame should always be closer to the base of the stack.
+            // (In other words, it should have a higher address.) This check works to prevent
+            // any infinite loops.
+            if self.caller <= ptr::from_ref(self) {
+                return None;
+            }
+
+            // SAFETY: Since the call frame corresponding to this frame record is still active, its
+            // caller must still be active as well, so `caller` is still valid.
+            unsafe { Self::from_ptr(self.caller) }
+        }
+
+        /// Returns the address of the instruction that called into this frame.
+        #[must_use]
+        pub const fn caller_address(&self) -> u32 {
+            const THUMB_BIT: u32 = 0b1;
+            // Some instructions are bigger than this, but a symbolizer can still figure it out
+            // if we give it an address in the middle of an instruction.
+            const INSTR_SIZE: u32 = 2;
+
+            // LR holds the instruction *after* the caller's address since that's where a function
+            // would return to, but we care about which instruction actually called us. Go back 1
+            // instruction to report that instead.
+            (self.lr & !THUMB_BIT) - INSTR_SIZE
+        }
+    }
+
+    /// Reads the active frame record and passes it to `handler`.
+    ///
+    /// The first record passed to `handler` is a synthetic frame record that represents the current
+    /// function and acts as a starting point. Call [`FrameRecord::next`] to advance up the call
+    /// stack.
+    pub fn capture_frame<R>(handler: impl FnOnce(&FrameRecord) -> R) -> R {
+        let caller: *const FrameRecord;
+        let lr: u32;
+
+        // SAFETY: By convention, r7 is the Thumb frame pointer and fp is the ARM frame pointer.
+        // https://github.com/rust-lang/rust/blob/c397dae808f70caebab1fc4e11b3edf7e59f58c7/compiler/rustc_target/src/asm/arm.rs#L70
+        unsafe {
+            cfg_select! {
+                target_feature = "thumb-mode" => asm!(
+                    "mov {caller}, r7",
+                    "mov {lr}, pc",
+                    caller = out(reg) caller,
+                    lr = out(reg) lr,
+                ),
+                _ => asm!(
+                    "mov {caller}, fp",
+                    "mov {lr}, pc",
+                    caller = out(reg) caller,
+                    lr = out(reg) lr,
+                ),
+            };
+        }
+
+        handler(&FrameRecord { caller, lr })
     }
 }

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -30,8 +30,6 @@ vex-sdk-mock = { workspace = true, optional = true }
 [target.'cfg(target_os = "vexos")'.dependencies]
 vex-sdk-jumptable = { version = "0.2.0-rc.1", git = "https://github.com/vexide/vex-sdk", branch = "rc", optional = true }
 vex-sdk-pros = { version = "0.0.1", optional = true }
-vex-libunwind = { workspace = true, optional = true }
-vex-libunwind-sys = { workspace = true, optional = true }
 
 [build-dependencies]
 vex-sdk-vexcode = { version = "0.0.1", optional = true }
@@ -51,7 +49,6 @@ workspace = true
 allocator = ["dep:talc"]
 panic-hook = []
 abort-handler = ["dep:bitbybit", "dep:arbitrary-int"]
-backtrace = ["dep:vex-libunwind", "dep:vex-libunwind-sys"]
 
 vex-sdk-jumptable = ["dep:vex-sdk-jumptable"]
 vex-sdk-vexcode = ["dep:vex-sdk-vexcode"]

--- a/packages/vexide-startup/link/vexide.ld
+++ b/packages/vexide-startup/link/vexide.ld
@@ -35,6 +35,11 @@ OVERWRITE_SECTIONS {
     /DISCARD/ : {
         /* Strip out libstd's _boot routine (replaced with .vexide_boot section). */
         *(.boot)
+        /* Strip unwind info since we use frame pointers for backtraces. */
+        *(.ARM.exidx)
+        *(.ARM.extab*)
+        *(.eh_frame_hdr)
+        *(.eh_frame)
     }
 }
 
@@ -44,7 +49,7 @@ SECTIONS {
     /*
      * Dedicated stack for the CPU fault exception handler.
      *
-     * VEXos provides a 1KiB builtin abort stack, but our stack unwinding code easily overflows it.
+     * VEXos provides a 1KiB builtin abort stack, but our fault reporting easily overflows it.
      */
     .abort_stack (NOLOAD) : ALIGN(8) {
         __abort_stack_bottom = .;

--- a/packages/vexide-startup/src/abort_handler/mod.rs
+++ b/packages/vexide-startup/src/abort_handler/mod.rs
@@ -1,10 +1,6 @@
 use core::fmt::Display;
 
 use arbitrary_int::prelude::*;
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use vex_libunwind::UnwindContext;
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use vex_libunwind_sys::unw_context_t;
 use vex_sdk::{V5_TouchEvent, V5_TouchStatus, vexTasksRun, vexTouchDataGet};
 
 mod report;
@@ -86,42 +82,6 @@ pub struct Fault {
 }
 
 impl Fault {
-    /// Create an unwind context using custom registers instead of ones captured from the current
-    /// processor state.
-    ///
-    /// This is based on the ARM implementation of __unw_getcontext:
-    /// <https://github.com/llvm/llvm-project/blob/6fc3b40b2cfc33550dd489072c01ffab16535840/libunwind/src/UnwindRegistersSave.S#L834>
-    #[cfg(all(target_os = "vexos", feature = "backtrace"))]
-    pub unsafe fn unwind_context(&self) -> UnwindContext<'_> {
-        #[repr(C)]
-        struct RawUnwindContext {
-            // Value of each general-purpose register in the order of r0-r12, sp, lr, pc.
-            r: [u32; 13],
-            sp: u32,
-            lr: u32,
-            pc: u32,
-
-            /// Padding (unused on ARM).
-            data: [u8; const { size_of::<unw_context_t>() - size_of::<u32>() * 16 }],
-        }
-
-        // SAFETY: `context` is a valid `unw_context_t` because it has its general-purpose registers
-        // field set.
-        unsafe {
-            UnwindContext::from_raw(core::mem::transmute::<RawUnwindContext, unw_context_t>(
-                RawUnwindContext {
-                    r: self.registers,
-                    sp: self.stack_pointer,
-                    lr: self.link_register,
-                    pc: self.program_counter,
-                    // This matches the behavior of __unw_getcontext, which leaves
-                    // this data uninitialized.
-                    data: [0; _],
-                },
-            ))
-        }
-    }
-
     /// Read the faulting instruction.
     ///
     /// # Safety

--- a/packages/vexide-startup/src/abort_handler/report.rs
+++ b/packages/vexide-startup/src/abort_handler/report.rs
@@ -1,12 +1,12 @@
-use std::fmt::{self, Write};
+use std::{
+    fmt::{self, Write},
+    iter,
+};
 
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use vex_libunwind::UnwindCursor;
+use vexide_core::backtrace::BacktraceIter;
 
 use super::Fault;
 use crate::error_report::ErrorReport;
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use crate::error_report::backtrace::BacktraceIter;
 
 pub struct SerialWriter(());
 
@@ -85,15 +85,28 @@ pub fn report_fault(fault: &Fault) {
         arr
     });
 
-    #[cfg(all(target_os = "vexos", feature = "backtrace"))]
-    if let Ok(cursor) = UnwindCursor::new(&unsafe { fault.unwind_context() }) {
-        _ = writeln!(dialog, "stack backtrace (check terminal):");
-        dialog.write_backtrace(BacktraceIter::new(cursor.clone()));
-
+    if cfg!(target_os = "vexos") {
+        let mut i = 0;
         _ = writeln!(serial, "stack backtrace:");
-        for (i, frame) in BacktraceIter::new(cursor).enumerate() {
-            _ = writeln!(serial, "{i:>3}: 0x{frame:x}");
+        _ = writeln!(dialog, "stack backtrace (check terminal):");
+
+        let fault_location = fault.program_counter as *const ();
+        let frame_ptr = cfg_select! {
+            target_feature = "thumb-mode" => fault.registers[7],
+            _ => fault.registers[11],
+        } as *const ();
+
+        // SAFETY: By convention, r7 is the Thumb frame pointer and r11 (fp) is the ARM frame
+        // pointer. We're accessing an outer call frame, so the frame record should still be valid.
+        let backtrace = unsafe { BacktraceIter::from_frame_ptr(frame_ptr) };
+
+        for addr in iter::once(fault_location).chain(backtrace) {
+            dialog.write_backtrace(i, addr as u32);
+            _ = writeln!(serial, "{i:>3}: 0x{:x}", addr as u32);
+            i += 1;
         }
+
+        dialog.finish_backtrace(i);
     }
 
     _ = writeln!(

--- a/packages/vexide-startup/src/error_report.rs
+++ b/packages/vexide-startup/src/error_report.rs
@@ -96,37 +96,33 @@ impl ErrorReport {
         self.y_offset += 10;
     }
 
-    #[cfg(all(target_os = "vexos", feature = "backtrace"))]
-    pub fn write_backtrace(&mut self, trace: impl Iterator<Item = u32>) {
+    pub fn write_backtrace(&mut self, i: i32, frame: u32) {
         unsafe {
             vex_sdk::vexDisplayTextSize(1, 5);
         }
-        let mut i = 0;
-        for frame in trace {
-            let format = c"  %d: 0x%08x";
+        let format = c"  %d: 0x%08x";
 
-            unsafe {
-                vex_sdk::vexDisplayPrintf(
-                    50 + (i % 4) * 95,
-                    self.y_offset,
-                    0,
-                    if i < 10 {
-                        format.as_ptr()
-                    } else {
-                        format[1..].as_ptr()
-                    },
-                    i,
-                    frame,
-                );
-            }
-
-            if i % 4 == 3 {
-                self.y_offset += 10;
-            }
-
-            i += 1;
+        unsafe {
+            vex_sdk::vexDisplayPrintf(
+                50 + (i % 4) * 95,
+                self.y_offset,
+                0,
+                if i < 10 {
+                    format.as_ptr()
+                } else {
+                    format[1..].as_ptr()
+                },
+                i,
+                frame,
+            );
         }
 
+        if i % 4 == 3 {
+            self.y_offset += 10;
+        }
+    }
+
+    pub const fn finish_backtrace(&mut self, i: i32) {
         if i % 4 != 0 {
             self.y_offset += 20;
         } else {
@@ -190,42 +186,5 @@ impl Write for ErrorReport {
         }
 
         Ok(())
-    }
-}
-
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-pub mod backtrace {
-    use vex_libunwind::{UnwindCursor, registers};
-
-    /// An iterator that lazily walks up the stack, yielding frames in a backtrace.
-    pub struct BacktraceIter<'a> {
-        pub cursor: Option<UnwindCursor<'a>>,
-    }
-
-    impl<'a> BacktraceIter<'a> {
-        pub const fn new(cursor: UnwindCursor<'a>) -> Self {
-            Self {
-                cursor: Some(cursor),
-            }
-        }
-    }
-
-    impl Iterator for BacktraceIter<'_> {
-        type Item = u32;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            let cursor = self.cursor.as_mut()?;
-
-            let mut instruction_pointer = cursor.register(registers::UNW_REG_IP).ok()?;
-            if !cursor.is_signal_frame().ok()? {
-                instruction_pointer -= 1;
-            }
-
-            if !cursor.step().ok()? {
-                self.cursor = None;
-            }
-
-            Some(instruction_pointer as u32)
-        }
     }
 }

--- a/packages/vexide-startup/src/lib.rs
+++ b/packages/vexide-startup/src/lib.rs
@@ -97,6 +97,9 @@ unsafe extern "C" {
 #[instruction_set(arm::a32)] // VEX program entry begins in ARM mode
 unsafe extern "C" fn _vexide_boot() {
     core::arch::naked_asm!(
+        // Cap off the frame pointer registers so the backtrace routine knows to terminate here.
+        "mov fp, #0",
+        "mov r7, #0",
         // Load the stack pointer to point to our stack section.
         //
         // This technically isn't required, as VEXos already sets up a stack for CPU1, but that

--- a/packages/vexide-startup/src/panic_hook.rs
+++ b/packages/vexide-startup/src/panic_hook.rs
@@ -5,12 +5,9 @@
 
 use std::{fmt::Write, panic::PanicHookInfo};
 
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use vex_libunwind::{UnwindContext, UnwindCursor};
+use vexide_core::backtrace::BacktraceIter;
 
 use crate::error_report::ErrorReport;
-#[cfg(all(target_os = "vexos", feature = "backtrace"))]
-use crate::error_report::backtrace::BacktraceIter;
 
 /// Panic hook for vexide programs.
 ///
@@ -22,26 +19,24 @@ pub(crate) fn hook(info: &PanicHookInfo<'_>) {
     eprintln!("{info}");
     writeln!(dialog, "{info}").unwrap();
 
-    #[cfg(all(target_os = "vexos", feature = "backtrace"))]
-    {
-        _ = UnwindContext::capture(|context| {
-            let cursor = UnwindCursor::new(&context)?;
+    if cfg!(target_os = "vexos") {
+        let mut i = 0;
+        eprintln!("stack backtrace:");
+        _ = writeln!(dialog, "stack backtrace (check terminal):");
 
-            dialog
-                .write_str("stack backtrace (check terminal):\n")
-                .unwrap();
-            dialog.write_backtrace(BacktraceIter::new(cursor.clone()));
-
-            eprintln!("stack backtrace:");
-            for (i, frame) in BacktraceIter::new(cursor).enumerate() {
-                eprintln!("{i:>3}: 0x{frame:x}");
+        BacktraceIter::capture(|backtrace| {
+            for addr in backtrace {
+                dialog.write_backtrace(i, addr as u32);
+                eprintln!("{i:>3}: 0x{:x}", addr as u32);
+                i += 1;
             }
-            eprintln!(
-                "note: Use a symbolizer to convert stack frames to human-readable function names."
-            );
-
-            Ok(())
         });
+
+        dialog.finish_backtrace(i);
+
+        eprintln!(
+            "note: Use a symbolizer to convert stack frames to human-readable function names."
+        );
     }
 
     // Don't exit the program, since we want to be able to see the panic message on the screen.

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -32,7 +32,6 @@ full = [
     "default",
     "macros",
     "startup",
-    "backtrace",
     "allocator",
     "panic-hook",
     "abort-handler",
@@ -48,11 +47,6 @@ async = ["dep:vexide-async"]
 sync = ["dep:vexide-async", "vexide-async/sync"]
 
 core = ["dep:vexide-core"]
-backtrace = [
-    "dep:vexide-core",
-    "vexide-core/backtrace",
-    "vexide-startup/backtrace",
-]
 
 startup = ["dep:vexide-startup"]
 panic-hook = ["vexide-startup/panic-hook"]

--- a/packages/vexide/src/lib.rs
+++ b/packages/vexide/src/lib.rs
@@ -66,11 +66,8 @@ pub mod time {
 }
 
 #[doc(inline)]
-#[cfg(feature = "backtrace")]
-pub use vexide_core::backtrace;
-#[doc(inline)]
 #[cfg(feature = "core")]
-pub use vexide_core::{competition, os, program};
+pub use vexide_core::{backtrace, competition, os, program};
 #[doc(inline)]
 #[cfg(feature = "devices")]
 pub use vexide_devices::{adi, battery, color, controller, display, math, peripherals, smart};


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

This PR removes the libunwind unwind dependency and instead just uses frame pointers for backtraces. There is no change in functionality and backtraces work the same. 15% smaller binaries (clawbot example).

## Additional Context

- These are breaking changes (semver: major).
- These changes update the crate's interface (e.g. functions/modules added or changed).

<!--
Move all applicable items out of the comment:
- I have tested these changes in a simulator.
- I have tested these changes on a VEX V5 Brain.
- These are *only* non-code changes (e.g. documentation, README.md).
-->
