### PR TITLE
fix: correctly implement Sleeper::eq

### DIFF
--- a/packages/vexide-async/src/reactor.rs
+++ b/packages/vexide-async/src/reactor.rs
@@ -11,7 +11,7 @@ pub(crate) struct Sleeper {
 
 impl PartialEq for Sleeper {
     fn eq(&self, other: &Self) -> bool {
-        other.deadline.eq(&other.deadline)
+        self.deadline.eq(&other.deadline)
     }
 }
 impl PartialOrd for Sleeper {


### PR DESCRIPTION
See title.

As far as I can tell, there is no actual code that uses the PartialEq or Eq impl for Sleeper (since it is pub(crate)) so this should not break anything relying on the broken behavior.

## Describe the changes this PR makes. Why should it be merged?

Fixes #449

## Additional Context

- I have tested these changes on a VEX V5 Brain.