### PR TITLE
chore: update deps & changelog, bump tracking version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Before releasing:
 ### Changed
 
 - Corrected some minor doc comments and updated the Nix flake. (#451)
+- Upgraded to SNAFU 0.9. (#442)
+- Updated to `vex-sdk` 0.29.0-rc.1.
 - Programs now execute in Thumb mode instead of ARM mode, reducing code size. (#454)
 - Backtraces are now captured using the frame pointer instead of through unwind tables. (#456) (**Breaking Change**)
 
@@ -61,6 +63,7 @@ Before releasing:
 
 - @elijah629 made their first contribution in #428!
 - @speedskater1610 made their first contribution in #429!
+- @shepmaster made their first contribution in #442!
 
 ## [0.8.0]
 
@@ -551,7 +554,7 @@ Before releasing:
 
 ### New Contributors
 
-[unreleased]: https://github.com/vexide/vexide/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/vexide/vexide/compare/v0.8.0...HEAD
 [0.2.0]: https://github.com/vexide/vexide/compare/v0.1.0...v0.2.0
 [0.2.1]: https://github.com/vexide/vexide/compare/v0.2.0...v0.2.1
 [0.3.0]: https://github.com/vexide/vexide/compare/v0.2.1...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ icon = "cool-x"
 compress = true
 
 [dev-dependencies]
-vex-sdk = "0.28.0"
+vex-sdk = "0.29.0-rc.1"
 vexide = { path = "packages/vexide", features = [ "full", "default-sdk" ] }
 
 [workspace]
@@ -26,14 +26,14 @@ resolver = "2"
 snafu = { version = "0.9.0", default-features = false, features = [
     "rust_1_81",
 ] }
-vexide = { version = "0.8.0", path = "packages/vexide", default-features = false }
-vexide-async = { version = "0.2.0", path = "packages/vexide-async", default-features = false }
-vexide-core = { version = "0.8.0", path = "packages/vexide-core", default-features = false }
-vexide-devices = { version = "0.8.0", path = "packages/vexide-devices", default-features = false }
-vexide-startup = { version = "0.5.0", path = "packages/vexide-startup", default-features = false }
+vexide = { version = "0.9.0", path = "packages/vexide", default-features = false }
+vexide-async = { version = "0.2.1", path = "packages/vexide-async", default-features = false }
+vexide-core = { version = "0.9.0", path = "packages/vexide-core", default-features = false }
+vexide-devices = { version = "0.9.0", path = "packages/vexide-devices", default-features = false }
+vexide-startup = { version = "0.6.0", path = "packages/vexide-startup", default-features = false }
 vexide-macro = { version = "0.4.0", path = "packages/vexide-macro", default-features = false }
-vex-sdk = "0.28.0"
-vex-sdk-mock = { version = "0.2.0-rc.1", git = "https://github.com/vexide/vex-sdk", branch = "rc" }
+vex-sdk = "0.29.0-rc.1"
+vex-sdk-mock = "0.2.0-rc.1"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/packages/vexide-async/Cargo.toml
+++ b/packages/vexide-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-async"
-version = "0.2.0"
+version = "0.2.1"
 edition =  "2024"
 license = "MIT"
 description = "Tiny async executor for vexide."

--- a/packages/vexide-core/Cargo.toml
+++ b/packages/vexide-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-core"
-version = "0.8.0"
+version = "0.9.0"
 edition =  "2024"
 license = "MIT"
 description = "Low-level core functionality for vexide."

--- a/packages/vexide-devices/Cargo.toml
+++ b/packages/vexide-devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-devices"
-version = "0.8.0"
+version = "0.9.0"
 edition =  "2024"
 license = "MIT"
 description = "VEX hardware abstractions and peripheral access."

--- a/packages/vexide-startup/Cargo.toml
+++ b/packages/vexide-startup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide-startup"
-version = "0.5.0"
+version = "0.6.0"
 edition =  "2024"
 license = "MIT"
 description = "User program startup and runtime support for vexide."
@@ -28,8 +28,8 @@ vex-sdk = { workspace = true }
 vex-sdk-mock = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "vexos")'.dependencies]
-vex-sdk-jumptable = { version = "0.2.0-rc.1", git = "https://github.com/vexide/vex-sdk", branch = "rc", optional = true }
-vex-sdk-pros = { version = "0.0.1", optional = true }
+vex-sdk-jumptable = { version = "0.2.0-rc.1", optional = true }
+vex-sdk-pros = { version = "0.1.0-rc.1", optional = true }
 
 [build-dependencies]
 vex-sdk-vexcode = { version = "0.0.1", optional = true }

--- a/packages/vexide-startup/src/banner/mod.rs
+++ b/packages/vexide-startup/src/banner/mod.rs
@@ -17,7 +17,7 @@ use vexide_core::{competition, os, time};
 /// This function is called by the `#[vexide::main]` macro if the startup banner is enabled.
 #[inline]
 pub fn print(theme: BannerTheme) {
-    const VEXIDE_VERSION: &str = "0.8.0";
+    const VEXIDE_VERSION: &str = "0.9.0";
 
     println!(
         "

--- a/packages/vexide/Cargo.toml
+++ b/packages/vexide/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vexide"
-version = "0.8.0"
+version = "0.9.0"
 edition =  "2024"
 description = "Open-source Rust runtime for VEX robots."
 keywords = ["Robotics", "bindings", "vex", "v5"]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Updates to the latest VEX SDK, bumps vexide versions to their upcoming values, and updates the changelog.
