### PR TITLE
docs(changelog): fix SerialPort typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Before releasing:
 - Fixed `Angle::wrapped_half` returning a negated value from what's expected. (#438) (**Breaking Change**)
 - Fixed `Motor::is_driver_over_current` incorrectly checking for the motor's `OVER_CURRENT` fault instead of `DRIVER_OVER_CURRENT`. (#447)
 - Fixed a stack overflow in the abort handler that was causing recursive CPU aborts. (#450)
-- Fixed an issue where the future returned from `SmartPort::open` could be polled after completion, effectively duplicating SmartPorts. (#452)
+- Fixed an issue where the future returned from `SerialPort::open` could be polled after completion, effectively duplicating SmartPorts. (#452)
 
 ### Changed
 


### PR DESCRIPTION
Fixes a typo in the changelog.